### PR TITLE
Update gradle-publish.yml

### DIFF
--- a/.github/workflows/gradle-publish.yml
+++ b/.github/workflows/gradle-publish.yml
@@ -8,8 +8,11 @@
 name: Gradle Package
 
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        default: ""
 
 jobs:
   build:


### PR DESCRIPTION
Allow gradle-publish to be manually triggered to create releases