### PR TITLE
Use-Tardis-Data-Model

### DIFF
--- a/src/client/java/com/adamkali/dwm/ClientTardis.java
+++ b/src/client/java/com/adamkali/dwm/ClientTardis.java
@@ -1,28 +1,26 @@
 package com.adamkali.dwm;
 
-import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.network.UpdateTardisChameleonC2SPayload;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.minecraft.util.math.GlobalPos;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Objects;
+import java.util.UUID;
 
 public class ClientTardis {
-    private final TardisBlockEntity tardisBlockEntity;
+    private final UUID tardisId;
 
-    public ClientTardis(TardisBlockEntity tardisBlockEntity) {
-        this.tardisBlockEntity = tardisBlockEntity;
+    public ClientTardis(UUID tardisId) {
+        this.tardisId = tardisId;
     }
 
-    public TardisBlockEntity getTardisBlockEntity() {
-        return tardisBlockEntity;
+    public UUID getTardisId() {
+        return tardisId;
     }
 
     public void updateChameleonVariant(@NotNull TardisChameleonVariant variant) {
-        this.tardisBlockEntity.setVariant(variant);
-        ClientPlayNetworking.send(new UpdateTardisChameleonC2SPayload(variant.getId(), new GlobalPos(Objects.requireNonNull(this.tardisBlockEntity.getWorld()).getRegistryKey(), this.tardisBlockEntity.getPos())));
-        this.tardisBlockEntity.markDirty();
+        TardisLogic.setVariant(this.tardisId, variant);
+        ClientPlayNetworking.send(new UpdateTardisChameleonC2SPayload(variant.getId(), this.tardisId));
     }
 }

--- a/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
+++ b/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
@@ -1,11 +1,9 @@
 package com.adamkali.dwm.network;
 
 import com.adamkali.dwm.ClientTardis;
-import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.gui.TardisChameleonGui;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.minecraft.block.entity.BlockEntity;
 import org.slf4j.Logger;
 
 public class ClientPayloadTypeRegistry {
@@ -21,13 +19,8 @@ public class ClientPayloadTypeRegistry {
                 LOGGER.warn("Received OpenTardisChameleonScreen payload but client or world is null");
                 return;
             }
-            BlockEntity blockEntity = context.client().world.getBlockEntity(payload.tardisPosition().pos());
-            if (blockEntity instanceof TardisBlockEntity tardis) {
-                ClientTardis clientTardis = new ClientTardis(tardis);
-                context.client().setScreen(new TardisChameleonGui(clientTardis));
-            } else {
-                LOGGER.warn("Received OpenTardisChameleonScreen payload but block entity is not a TardisBlockEntity");
-            }
+            ClientTardis clientTardis = new ClientTardis(payload.tardisId());
+            context.client().setScreen(new TardisChameleonGui(clientTardis));
         });
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
@@ -5,6 +5,8 @@ import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.model.tileentity.*;
 import com.adamkali.dwm.render.state.TardisRenderState;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisDoorState;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.VertexConsumer;
@@ -17,6 +19,7 @@ import net.minecraft.util.math.RotationAxis;
 import net.minecraft.util.math.RotationPropertyHelper;
 
 import java.util.HashMap;
+import java.util.Objects;
 
 public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBlockEntity> {
     private final HashMap<TardisChameleonVariant, TardisModel> modelCache = new HashMap<>();
@@ -43,8 +46,10 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         BlockState state = entity.getCachedState();
         int rotation = state.get(TardisBlock.FACING_ROTATION, 0);
 
-        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(textureCache.get(entity.getVariant())));
-        this.render(matrices, vertexConsumer, modelCache.get(entity.getVariant()), entity.getDoorState().getDoorSwing(), RotationPropertyHelper.toDegrees(rotation), light, overlay);
+        TardisChameleonVariant variant = Objects.requireNonNullElse(TardisLogic.getVariant(entity.getTardisId()), TardisChameleonVariant.TT_CAPSULE);
+        TardisDoorState doorState = Objects.requireNonNullElse(TardisLogic.getDoorState(entity.getTardisId()), new TardisDoorState());
+        VertexConsumer vertexConsumer = vertexConsumers.getBuffer(RenderLayer.getEntityCutout(textureCache.get(variant)));
+        this.render(matrices, vertexConsumer, modelCache.get(variant), doorState.doorSwing, RotationPropertyHelper.toDegrees(rotation), light, overlay);
     }
 
     private void render(MatrixStack matrices, VertexConsumer vertices, TardisModel model, float doorProgress, float rotation, int light, int overlay) {

--- a/src/main/java/com/adamkali/dwm/block/TardisBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/TardisBlock.java
@@ -24,7 +24,6 @@ import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.GlobalPos;
 import net.minecraft.util.math.RotationPropertyHelper;
 import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
@@ -88,7 +87,7 @@ public class TardisBlock extends BlockWithEntity {
             }
         } else {
             if (player.isSneaking() && DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)) {
-                ServerPlayNetworking.send((ServerPlayerEntity) player, new OpenTardisChameleonScreen(GlobalPos.create(world.getRegistryKey(), pos)));
+                ServerPlayNetworking.send((ServerPlayerEntity) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
             }
         }
 

--- a/src/main/java/com/adamkali/dwm/network/DWMPacketCodecs.java
+++ b/src/main/java/com/adamkali/dwm/network/DWMPacketCodecs.java
@@ -1,0 +1,13 @@
+package com.adamkali.dwm.network;
+
+import io.netty.buffer.ByteBuf;
+import net.minecraft.network.codec.PacketCodec;
+
+import java.util.UUID;
+
+public class DWMPacketCodecs {
+    public static final PacketCodec<ByteBuf, UUID> UUID_PACKET_CODEC = PacketCodec.of((uuid, buf) -> {
+        buf.writeLong(uuid.getMostSignificantBits());
+        buf.writeLong(uuid.getLeastSignificantBits());
+    }, buf -> new UUID(buf.readLong(), buf.readLong()));
+}

--- a/src/main/java/com/adamkali/dwm/network/OpenTardisChameleonScreen.java
+++ b/src/main/java/com/adamkali/dwm/network/OpenTardisChameleonScreen.java
@@ -3,11 +3,12 @@ package com.adamkali.dwm.network;
 import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.packet.CustomPayload;
-import net.minecraft.util.math.GlobalPos;
 
-public record OpenTardisChameleonScreen(GlobalPos tardisPosition) implements CustomPayload {
+import java.util.UUID;
+
+public record OpenTardisChameleonScreen(UUID tardisId) implements CustomPayload {
     public static final CustomPayload.Id<OpenTardisChameleonScreen> ID = new CustomPayload.Id<>(DWMPacketIds.OPEN_TARDIS_CHAMELEON_SCREEN_ID);
-    public static final PacketCodec<RegistryByteBuf, OpenTardisChameleonScreen> CODEC = PacketCodec.tuple(GlobalPos.PACKET_CODEC, OpenTardisChameleonScreen::tardisPosition, OpenTardisChameleonScreen::new);
+    public static final PacketCodec<RegistryByteBuf, OpenTardisChameleonScreen> CODEC = PacketCodec.tuple(DWMPacketCodecs.UUID_PACKET_CODEC, OpenTardisChameleonScreen::tardisId, OpenTardisChameleonScreen::new);
 
     @Override
     public Id<? extends CustomPayload> getId() {

--- a/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
+++ b/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
@@ -1,14 +1,10 @@
 package com.adamkali.dwm.network;
 
-import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
-import net.minecraft.block.entity.BlockEntity;
-import net.minecraft.util.Identifier;
-import net.minecraft.util.math.GlobalPos;
-import net.minecraft.world.World;
 import org.slf4j.Logger;
 
 public class ServerPayloadTypeRegistry {
@@ -20,22 +16,7 @@ public class ServerPayloadTypeRegistry {
         PayloadTypeRegistry.playC2S().register(UpdateTardisChameleonC2SPayload.ID, UpdateTardisChameleonC2SPayload.CODEC);
 
         ServerPlayNetworking.registerGlobalReceiver(UpdateTardisChameleonC2SPayload.ID, (payload, context) -> {
-            Identifier variantId = payload.variantId();
-            GlobalPos pos = payload.tardisPos();
-            World world = context.server().getWorld(pos.dimension());
-            if (world == null) {
-                LOGGER.warn("Received UpdateTardisChameleonC2SPayload for invalid world: {}", pos.dimension());
-                return;
-            }
-
-            BlockEntity blockEntity = world.getBlockEntity(pos.pos());
-
-            if (!(blockEntity instanceof TardisBlockEntity tardis)) {
-                LOGGER.warn("Received UpdateTardisChameleonC2SPayload for non-Tardis block entity: {}", blockEntity);
-                return;
-            }
-            tardis.setVariant(TardisChameleonVariant.fromId(variantId));
-            tardis.markDirty();
+            TardisLogic.setVariant(payload.tardisId(), TardisChameleonVariant.fromId(payload.variantId()));
         });
     }
 }

--- a/src/main/java/com/adamkali/dwm/network/UpdateTardisChameleonC2SPayload.java
+++ b/src/main/java/com/adamkali/dwm/network/UpdateTardisChameleonC2SPayload.java
@@ -4,13 +4,14 @@ import net.minecraft.network.RegistryByteBuf;
 import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.util.Identifier;
-import net.minecraft.util.math.GlobalPos;
 
-public record UpdateTardisChameleonC2SPayload(Identifier variantId, GlobalPos tardisPos) implements CustomPayload {
+import java.util.UUID;
+
+public record UpdateTardisChameleonC2SPayload(Identifier variantId, UUID tardisId) implements CustomPayload {
     public static final CustomPayload.Id<UpdateTardisChameleonC2SPayload> ID = new CustomPayload.Id<>(DWMPacketIds.UPDATE_TARDIS_CHAMELEON_PACKET_ID);
     public static final PacketCodec<RegistryByteBuf, UpdateTardisChameleonC2SPayload> CODEC = PacketCodec.tuple(
             Identifier.PACKET_CODEC, UpdateTardisChameleonC2SPayload::variantId,
-            GlobalPos.PACKET_CODEC, UpdateTardisChameleonC2SPayload::tardisPos,
+            DWMPacketCodecs.UUID_PACKET_CODEC, UpdateTardisChameleonC2SPayload::tardisId,
             UpdateTardisChameleonC2SPayload::new);
 
     @Override

--- a/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
+++ b/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.tardis.data;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
@@ -30,12 +31,16 @@ public class TardisDataLoader {
         return directory;
     }
 
-    private static File getTardisDataFile(UUID uuid, boolean createDirectoryIfMissing) {
+    private static File getTardisDataFile(@NotNull UUID uuid, boolean createDirectoryIfMissing) {
         File directory = getTardisDataDirectory(createDirectoryIfMissing);
-        return new File(directory, uuid.toString() + ".json");
+        return new File(directory, uuid + ".json");
     }
 
-    private static TardisDataModel load(UUID uuid) {
+    private static TardisDataModel load(@Nullable UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+
         File file = TardisDataLoader.getTardisDataFile(uuid, false);
         if (!file.exists()) {
             return null;
@@ -53,7 +58,18 @@ public class TardisDataLoader {
         }
     }
 
-    public static @Nullable TardisDataModel get(UUID uuid) {
+    /**
+     * Returns the TardisDataModel from cache, or loads it from file if not already loaded.
+     * Returns null if the UUID is null, or if the TardisDataModel doesn't exist.
+     *
+     * @param uuid
+     * @return The TardisDataModel, or null.
+     */
+    public static @Nullable TardisDataModel get(@Nullable UUID uuid) {
+        if (uuid == null) {
+            return null;
+        }
+
         if (tardisData.containsKey(uuid)) {
             return tardisData.get(uuid);
         }

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
@@ -4,18 +4,25 @@ import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
+import net.minecraft.util.ActionResult;
 
 import java.util.UUID;
 
 public class TardisLogic {
-    public static void toggleDoor(UUID tardisId) {
+    public static ActionResult toggleDoor(UUID tardisId) {
         TardisDataModel tardis = TardisDataLoader.get(tardisId);
         if (tardis == null) {
-            return;
+            return ActionResult.FAIL;
+        }
+
+        float doorSwing = tardis.doorState.doorSwing;
+        if (doorSwing > 0.0f && doorSwing < 1.0f) {
+            return ActionResult.PASS;
         }
 
         tardis.doorState.isOpen = !tardis.doorState.isOpen;
         tardis.markDirty();
+        return ActionResult.SUCCESS;
     }
 
     public static TardisDoorState getDoorState(UUID tardisId) {

--- a/src/test/java/com/adamkali/dwm/network/DWMPacketCodecsTest.java
+++ b/src/test/java/com/adamkali/dwm/network/DWMPacketCodecsTest.java
@@ -1,0 +1,32 @@
+package com.adamkali.dwm.network;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DWMPacketCodecsTest {
+
+    @Test
+    void testUUIDCodecRoundTrip() {
+        UUID originalUUID = UUID.randomUUID();
+
+        ByteBuf buffer = Unpooled.buffer();
+
+        try {
+            DWMPacketCodecs.UUID_PACKET_CODEC.encode(buffer, originalUUID);
+
+            // Verify buffer size is 16 bytes (UUID is 16 bytes)
+            assertEquals(16, buffer.readableBytes(), "Buffer should contain exactly 16 bytes");
+
+            UUID decodedUUID = DWMPacketCodecs.UUID_PACKET_CODEC.decode(buffer);
+
+            assertEquals(originalUUID, decodedUUID, "Decoded UUID should match original UUID");
+        } finally {
+            buffer.release();
+        }
+    }
+}


### PR DESCRIPTION
Connect the TARDIS block entity to the externally managed TARDIS logic
Update the packet management to send by TARDIS ID instead of TARDIS block entity location
Update the TARDIS Chameleon GUI to reflect these changes.
Remove the render of the TARDIS in the TARDIS Chameleon GUI as this broke with this change, and is not needed.