### PR TITLE
docs: add product docs and contribution guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!-- For JIRA-linked work, the PR title must begin with the ticket key (see AGENTS.md). -->
+
+## Why this matters
+
+<!-- Business value / product reason — keep it tight and specific. -->
+
+- …
+
+## Proposed Implementation
+
+<!-- Brief summary: behavior, key files/areas, tests or manual checks. -->
+
+- …
+
+## Problems Encountered / Decisions Made
+
+<!-- Deviations from the plan, issues discovered during implementation, tradeoffs. Use “None” if nothing applies. -->
+
+- …

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# AGENTS.md
+
+## Project Snapshot
+- Project type: Minecraft Fabric mod (`fabric-loom`) using Gradle.
+- Language/runtime baseline: Java 21.
+- Current target stack is defined in `gradle.properties` and `build.gradle` (Minecraft, Yarn mappings, Fabric Loader, Fabric API).
+- Objective: maximize safe, repeatable AI-agent-driven development with strong automated verification.
+
+## Codebase Structure
+- `src/main/java`: Common logic that must remain safe on both logical client and logical server.
+- `src/client/java`: Client-only logic (rendering, client integration, client UI/state).
+- `src/test/java`: Automated tests (JUnit and related support code).
+- `src/main/resources`: Common resources (`fabric.mod.json`, data, tags, recipes, structures, lang, worldgen).
+- `src/client/resources`: Client assets (models, blockstates, textures, sounds, item models).
+
+## Agent-First Engineering Principles
+- Prefer small, focused, reviewable diffs over broad rewrites.
+- Keep behavior deterministic where practical (avoid hidden side effects and implicit global coupling).
+- Design for testability first: clear boundaries, injectable collaborators, and pure logic extraction.
+- Keep names and package placement consistent with existing project conventions.
+- Use non-interactive, scriptable workflows and commands suitable for CI and autonomous agents.
+- Do not make speculative refactors outside the requested scope.
+
+## Working Rules For Agents
+- Before coding, identify whether change is common, client-only, data-driven, or test-only.
+- Preserve `main`/`client` source-set separation.
+- Avoid touching large generated/resource surfaces unless the task requires it.
+- When fixing bugs, prefer the smallest change that addresses root cause and add regression coverage.
+- If a requested behavior cannot be fully automated/tested, document the limitation and propose follow-up automation.
+
+## Fabric-Specific Development Rules
+- Keep Java 21 compatibility.
+- Favor Fabric API events/hooks/utilities before introducing Mixins.
+- Use Mixins only when needed; keep them minimal and as targeted as possible.
+- Maintain compatibility-minded behavior (avoid fragile assumptions about execution order or side effects).
+
+## Networking & Side Safety
+- Treat server as authoritative for gameplay/world state changes.
+- Keep client-only classes out of common/server paths.
+- Use side checks where required to prevent desync/crashes.
+- For custom networking payloads:
+  - Define payload ID/type/codec clearly.
+  - Register payload types before handler registration/sending.
+  - Validate all C2S payload inputs server-side before applying state changes.
+
+## Data Generation Rules
+- Use datagen for data-driven resources when appropriate.
+- When changing data-generated content, run `./gradlew runDatagen` and include required generated outputs.
+- Avoid committing unrelated generated churn.
+- Keep datagen providers deterministic (same inputs should produce same outputs).
+
+## Testability-First Design Rules
+- New behavior should include automated tests by default.
+- Bug fixes should include a regression test whenever feasible.
+- Prefer unit tests for logic-heavy code and decision branches.
+- Add integration/gameplay-focused tests when unit tests cannot prove behavior.
+- If no automated test is added, explicitly state why and what test should be added later.
+
+## Testing Expectations
+- Unit tests: use JUnit 5 (`fabric-loader-junit` already configured) for core logic and utility behavior.
+- Integration-style tests: use for cross-component behavior where pure unit tests are insufficient.
+- GameTests: use for world/gameplay interactions that require real game context.
+- Keep test runs reproducible and suitable for unattended agent execution.
+
+## Automation Pipeline For Agents
+- During development:
+  - Run targeted tests for changed scope when available.
+- Before handoff/PR:
+  - Run `./gradlew test`.
+  - Run `./gradlew build` for full compile/package confidence on larger changes.
+  - Run `./gradlew runDatagen` when data-driven content changed.
+- Prefer fast feedback loops, but do not skip required quality gates.
+
+## Build/Test/Validation
+- Main automated commands:
+  - `./gradlew test`
+  - `./gradlew build`
+  - `./gradlew runDatagen` (only when data-driven assets/providers are touched)
+- If a command fails, surface the failure clearly and fix root causes before handoff where possible.
+
+## Change Scope & Safety
+- Keep unrelated files untouched.
+- Do not change dependency versions/tooling unless the task requires it.
+- Preserve backward compatibility assumptions unless the task explicitly allows breaking changes.
+- Minimize risk in networking, persistence, and registry code by adding/adjusting tests first.
+
+## Delivery Checklist
+- Change is scoped and minimal.
+- Source-set sidedness (`main` vs `client`) is preserved.
+- Automated tests were added/updated when behavior changed.
+- Required automation commands were run (or explicitly reported as not run).
+- Datagen was run when relevant.
+- Handoff notes include what changed, what was validated, and any follow-up automation tasks.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,3 +91,30 @@
 - Required automation commands were run (or explicitly reported as not run).
 - Datagen was run when relevant.
 - Handoff notes include what changed, what was validated, and any follow-up automation tasks.
+
+## Git Conventions
+
+### Commits
+
+Conventional Commits: `<type>(<scope>): <description>`
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
+
+Commits must be atomic - one change per commit.
+
+### Pull requests
+
+The default pull request description structure is defined in `.github/pull_request_template.md`. When creating or updating a pull request, write the **body** using that template: keep the three sections below in this order, replace placeholder bullets with concrete content, and do not leave a section empty — if nothing applies, use a single line `None`.
+
+- **Why this matters** — business value / product reason, tightened for clarity
+- **Proposed Implementation** — brief summary of what changed
+- **Problems Encountered / Decisions Made** — deviations from the plan or issues that surfaced during implementation
+
+### Pull request labels
+
+After creating or updating a pull request, apply the appropriate label(s) using the `EditPullRequestLabels` tool:
+
+- **`documentation`** — the PR contains changes to documentation only (e.g. `AGENTS.md`, `README.md`, inline code comments, or other docs)
+- **`enhancement`** — the PR introduces a change in intended behaviour, an improvement to an existing feature, or a new feature
+- **`bug`** — the PR fixes a defect / unintended behaviour
+
+A single PR may carry more than one label if it touches multiple categories.

--- a/docs/branding-guidelines.md
+++ b/docs/branding-guidelines.md
@@ -1,0 +1,44 @@
+# DWM Branding Guidelines
+
+See also: [Docs Index](./index.md), [Differentiation Strategy](./differentiation-strategy.md)
+
+## Brand Core
+- **Canonical Name:** The Doctor Who Mod
+- **Short Name:** DWM
+- **Mod ID:** `dwm`
+
+Use "The Doctor Who Mod" in player-facing launches and major announcements. Use "DWM" for technical/internal shorthand and repeated mentions.
+
+## Brand Thesis
+DWM should feel like a polished, playable Doctor Who toolkit for builders and tinkerers, not a broad franchise content dump. Every feature should support one of two player promises:
+- Utility-rich Time Lord interactions.
+- Cohesive, high-identity worldbuilding pieces.
+
+## Product Personality
+- **Clear:** Features are understandable on first use.
+- **Tactile:** Interactions have immediate feedback (audio/state/animation).
+- **Curated:** Additions feel deliberate, not sprawling.
+- **Immersive:** Doctor Who atmosphere is strong without overwhelming Minecraft readability.
+
+## Naming Standards
+- Keep registry IDs and resource paths `snake_case`.
+- Keep player-facing labels title-cased and franchise-familiar (`Sonic Screwdriver`, `TARDIS Wall`).
+- Prefer family naming for build content (for example, `Roundel A/B`, `Big Roundel A/B`).
+- Reserve "experimental" wording for features that are config-gated or not default-ready.
+
+## Voice and Tone
+- Use concise, confident language in docs and release notes.
+- Emphasize what players can do now over future promises.
+- Avoid overclaiming cinematic scope where systems are decorative/utility-focused.
+- Describe feature status explicitly: Stable, Experimental, Planned.
+
+## Visual and Experience Direction
+- Prioritize readable silhouettes and recognizable Doctor Who motifs.
+- Keep block families modular so players can compose many layouts from a small set.
+- Favor interaction polish (button states, door motion, sonic feedback) over one-off novelty.
+
+## Content Acceptance Filters
+Before adding new content, validate:
+1. Does this improve utility interactions or themed building cohesion?
+2. Is the player value obvious without external explanation?
+3. Does it strengthen DWM's identity rather than imitate a generic Doctor Who mod checklist?

--- a/docs/differentiation-strategy.md
+++ b/docs/differentiation-strategy.md
@@ -1,0 +1,52 @@
+# DWM Differentiation Strategy
+
+See also: [Docs Index](./index.md), [Branding Guidelines](./branding-guidelines.md)
+
+## Positioning Statement
+The Doctor Who Mod (DWM) delivers a focused Doctor Who Minecraft experience centered on polished utility interactions and cohesive builder-first content, with clear status transparency between stable and experimental systems.
+
+## How DWM Should Be Different
+- **Focused over sprawling:** ship fewer systems with better usability and feedback.
+- **Builder-first identity:** make themed construction practical, modular, and survival-friendly.
+- **Readable interactions:** sonic and TARDIS interactions should feel clear in one or two attempts.
+- **Status transparency:** clearly label stable vs experimental features to build player trust.
+
+## Strategic Pillars
+### 1) Signature Interaction Polish
+Differentiate through feel:
+- High-quality state transitions (door/button/variant changes).
+- Distinct and reliable sonic outcomes by context.
+- Immediate feedback loops (audio + visual state change).
+
+### 2) Cohesive Themed Building Platform
+Differentiate through composition:
+- Expand content in families, not one-off blocks.
+- Preserve naming/material consistency across families.
+- Encourage remixability across TARDIS interiors/exteriors.
+
+### 3) Trustworthy Product Communication
+Differentiate through clarity:
+- Publish docs that map directly to shipped behavior.
+- Mark experimental systems in docs and configs.
+- Avoid roadmap ambiguity in player-facing text.
+
+## Near-Term Opportunities (Low Risk, High Signal)
+- Add simple in-doc usage recipes for each feature family.
+- Publish "starter build kits" using existing block families.
+- Improve first-use guidance for experimental chameleon flow.
+- Keep release notes tightly tied to implemented behavior.
+
+## Mid-Term Opportunities
+- Introduce progression loops that connect sonic utility and TARDIS expression.
+- Add compact tutorials/advancements that teach interactions naturally.
+- Establish a recognizable "DWM quality bar" checklist for every new feature.
+
+## Anti-Goals
+- Do not compete on sheer feature count alone.
+- Do not add disconnected fan-service content without clear gameplay value.
+- Do not ship unclear systems that require external guides to understand basic use.
+
+## Success Indicators
+- Players can name DWM's identity in one sentence.
+- First-session players successfully use at least one sonic interaction and one TARDIS interaction.
+- Community feedback highlights polish and cohesion more than quantity.

--- a/docs/feature-building-content.md
+++ b/docs/feature-building-content.md
@@ -1,0 +1,33 @@
+# Feature: Building Content System
+
+See also: [Docs Index](./index.md)
+
+## Product Intent
+Enable players to quickly build coherent Doctor Who-inspired interiors and exteriors using a curated, modular block library.
+
+## Player Outcomes
+- Build themed spaces without heavy custom texturing workflows.
+- Mix-and-match block families while preserving visual consistency.
+- Use recipes that support survival-friendly progression.
+
+## Implemented Now
+- Themed block families including:
+  - Roundel A / Roundel B
+  - Big Roundel A / Big Roundel B
+  - TARDIS Wall
+  - Chronoplasm Powder variants (multiple colors)
+- Localization and item/block presentation for these families.
+- Recipe coverage for obtaining and combining core decorative materials.
+
+## How It Works In-Game
+1. Gather base resources.
+2. Craft themed block components from provided recipes.
+3. Combine families to create room panels, corridors, and console-like spaces.
+
+## Known Constraints
+- Current focus is on strong decorative breadth and consistency.
+- Some visual polish relies on the completeness of bundled texture assets.
+
+## Future Opportunities
+- Add builder starter kits and pattern guides.
+- Expand family variants while maintaining naming/material consistency.

--- a/docs/feature-chameleon-system.md
+++ b/docs/feature-chameleon-system.md
@@ -1,0 +1,31 @@
+# Feature: TARDIS Chameleon System (Experimental)
+
+See also: [Docs Index](./index.md), [TARDIS Exterior Block](./feature-tardis-block.md)
+
+## Product Intent
+Allow players to personalize TARDIS exterior identity through selectable visual variants while keeping the interaction flow simple.
+
+## Player Outcomes
+- Select a preferred TARDIS exterior style.
+- Keep visual expression aligned with roleplay/build themes.
+- Understand that this is an optional experimental path.
+
+## Implemented Now
+- Multiple chameleon variants mapped to different TARDIS exterior styles.
+- Client GUI for selecting variants.
+- Networking payloads to update variant state server-side.
+- Config gate for enabling/disabling chameleon GUI.
+
+## How It Works In-Game
+1. Enable the experimental chameleon setting in config.
+2. Sneak-use the TARDIS interaction path that opens the variant selector.
+3. Pick a variant; client sends update payload; server applies new variant data.
+
+## Known Constraints
+- This feature is experimental and disabled by default.
+- Stability and UX polish are still evolving.
+- Multiplayer behavior depends on correct payload registration and synced state.
+
+## Future Opportunities
+- Promote from experimental to stable after UX hardening.
+- Add better in-game onboarding for first-time variant selection.

--- a/docs/feature-sonic-screwdrivers.md
+++ b/docs/feature-sonic-screwdrivers.md
@@ -1,0 +1,37 @@
+# Feature: Sonic Screwdrivers
+
+See also: [Docs Index](./index.md)
+
+## Product Intent
+Give players a recognizable Doctor Who utility tool that feels versatile, tactile, and immediately useful in normal survival play.
+
+## Player Outcomes
+- Solve small interaction problems quickly (doors, trapdoors, TNT prep).
+- Gain a themed utility option for mobs and utility interactions.
+- Progress toward Doctor-themed loadouts through craftable variants.
+
+## Implemented Now
+- Craftable sonic variants: Second, Third, Fourth, and Fifth Doctor.
+- Shared sonic interaction logic with context-sensitive outcomes.
+- Custom sonic use sounds and usage stat tracking.
+
+## How It Works In-Game
+1. Craft a sonic screwdriver variant.
+2. Use it on supported blocks/entities.
+3. The action is resolved based on target context.
+
+Current interactions include:
+- Toggle iron doors and iron trapdoors.
+- Prime TNT safely.
+- Break glass/stained glass without drops.
+- Damage slimes.
+- Shear sheep.
+
+## Known Constraints
+- Interactions are intentionally scoped to a curated set of targets.
+- Not every Doctor variant in TARDIS visuals exists as a sonic item yet.
+- Behavior is utility-first, not combat-focused.
+
+## Future Opportunities
+- Add stronger player feedback for each sonic action type.
+- Expand supported interactions while preserving clarity and balance.

--- a/docs/feature-tardis-block.md
+++ b/docs/feature-tardis-block.md
@@ -1,0 +1,30 @@
+# Feature: TARDIS Exterior Block
+
+See also: [Docs Index](./index.md), [TARDIS Chameleon System](./feature-chameleon-system.md)
+
+## Product Intent
+Make the TARDIS a tangible world object that is expressive, interactive, and persistent per placement.
+
+## Player Outcomes
+- Place and keep a recognizable TARDIS identity in a world.
+- Interact with the exterior to trigger visible door-state behavior.
+- Use the TARDIS as a themed anchor for builds and roleplay spaces.
+
+## Implemented Now
+- Placeable `tardis_block` with block entity backing data.
+- Persistent per-instance identity data (including UUID and variant metadata).
+- Interactive door state transitions with sound feedback.
+- Custom client rendering for TARDIS model presentation.
+
+## How It Works In-Game
+1. Place the TARDIS block.
+2. Interact with the block to toggle door-state behavior.
+3. Door swing/state persists through block entity data and render updates.
+
+## Known Constraints
+- This is currently an exterior interaction feature, not full interior travel gameplay.
+- Visual fidelity depends on available client-side model/texture assets.
+
+## Future Opportunities
+- Add clearer in-game affordances for TARDIS state.
+- Extend interactions into deeper progression systems around ownership and travel.

--- a/docs/feature-tardis-door-button.md
+++ b/docs/feature-tardis-door-button.md
@@ -1,0 +1,30 @@
+# Feature: TARDIS Door Button
+
+See also: [Docs Index](./index.md), [TARDIS Exterior Block](./feature-tardis-block.md)
+
+## Product Intent
+Provide a compact, thematic interaction block that feels mechanically readable and architecturally useful near TARDIS builds.
+
+## Player Outcomes
+- Add a recognizable control element to TARDIS-themed doors/walls.
+- Trigger short-lived state changes with immediate audio feedback.
+- Integrate button behavior into decorative or redstone-adjacent builds.
+
+## Implemented Now
+- Custom `tardis_door_button` block with directional placement behavior.
+- Pressed/unpressed state handling with timed reset.
+- Click/interaction audio cues.
+- Dedicated blockstate/model assets for active and inactive visuals.
+
+## How It Works In-Game
+1. Place the button on a supported face.
+2. Interact to press it.
+3. Button enters active state briefly, then returns to default state.
+
+## Known Constraints
+- Purpose is focused on concise interaction feedback, not complex control logic.
+- Shape and orientation follow defined facing-based rules.
+
+## Future Opportunities
+- Add explicit links to nearby TARDIS state interactions.
+- Expand redstone utility while keeping clear visual language.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,23 @@
+# DWM Product Documentation
+
+This folder documents implemented player-facing features for The Doctor Who Mod (`dwm`) with a product-first lens.
+
+## Feature Map
+
+### Stable Features
+- [Sonic Screwdrivers](./feature-sonic-screwdrivers.md)
+- [TARDIS Exterior Block](./feature-tardis-block.md)
+- [TARDIS Door Button](./feature-tardis-door-button.md)
+- [Building Content System](./feature-building-content.md)
+
+### Experimental Features
+- [TARDIS Chameleon System](./feature-chameleon-system.md) (config-gated and disabled by default)
+
+## Brand and Differentiation
+- [Branding Guidelines](./branding-guidelines.md)
+- [Differentiation Strategy](./differentiation-strategy.md)
+
+## Scope Notes
+- These docs describe behavior currently implemented in this repository.
+- Experimental and partially implemented surfaces are explicitly labeled.
+- Future ideas are listed as opportunities, not current capabilities.


### PR DESCRIPTION
## Why this matters

- Establishes a clear, player-facing product narrative for what DWM currently ships and what is experimental.
- Improves contributor consistency by defining agent workflow standards and a reusable pull request description template.

## Proposed Implementation

- Added `docs/index.md` plus feature and strategy documentation pages covering sonic tools, TARDIS systems, building content, branding, and differentiation.
- Added `AGENTS.md` with project conventions, testing/automation expectations, and PR/commit guidance.
- Added `.github/pull_request_template.md` to standardize PR context and decision logging.

## Problems Encountered / Decisions Made

- None.


Made with [Cursor](https://cursor.com)