### PR TITLE
Enhance TARDIS test coverage and reliability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       gradle_command:
         type: string
         default: ""
+      store_test_results:
+        type: boolean
+        default: false
     docker:
       - image: cimg/openjdk:21.0
     environment:
@@ -27,6 +30,11 @@ jobs:
           command: |
             chmod +x ./gradlew
             ./gradlew << parameters.gradle_command >>
+      - when:
+          condition: << parameters.store_test_results >>
+          steps:
+            - store_test_results:
+                path: build/test-results/test
 
   update-version:
     machine:
@@ -83,6 +91,7 @@ workflows:
       - run-gradle:
           name: Test
           gradle_command: "test"
+          store_test_results: true
       - update-version:
           <<: *main_branch_only
           requires:

--- a/src/client/java/com/adamkali/dwm/ClientTardis.java
+++ b/src/client/java/com/adamkali/dwm/ClientTardis.java
@@ -2,7 +2,6 @@ package com.adamkali.dwm;
 
 import com.adamkali.dwm.network.UpdateTardisChameleonC2SPayload;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
-import com.adamkali.dwm.tardis.logic.TardisLogic;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import org.jetbrains.annotations.NotNull;
 
@@ -20,7 +19,6 @@ public class ClientTardis {
     }
 
     public void updateChameleonVariant(@NotNull TardisChameleonVariant variant) {
-        TardisLogic.setVariant(this.tardisId, variant);
         ClientPlayNetworking.send(new UpdateTardisChameleonC2SPayload(variant.getId(), this.tardisId));
     }
 }

--- a/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
+++ b/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
@@ -1,6 +1,8 @@
 package com.adamkali.dwm.network;
 
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
@@ -16,7 +18,24 @@ public class ServerPayloadTypeRegistry {
         PayloadTypeRegistry.playC2S().register(UpdateTardisChameleonC2SPayload.ID, UpdateTardisChameleonC2SPayload.CODEC);
 
         ServerPlayNetworking.registerGlobalReceiver(UpdateTardisChameleonC2SPayload.ID, (payload, context) -> {
-            TardisLogic.setVariant(payload.tardisId(), TardisChameleonVariant.fromId(payload.variantId()));
+            safelyHandleChameleonUpdate(payload, context.player().getName().getString());
         });
+    }
+
+    static boolean safelyHandleChameleonUpdate(UpdateTardisChameleonC2SPayload payload, String playerName) {
+        try {
+            TardisDataModel tardis = TardisDataLoader.get(payload.tardisId());
+            if (tardis == null) {
+                LOGGER.warn("Rejected chameleon update for unknown tardisId {} from {}", payload.tardisId(), playerName);
+                return false;
+            }
+
+            TardisChameleonVariant variant = TardisChameleonVariant.fromId(payload.variantId());
+            TardisLogic.setVariant(payload.tardisId(), variant);
+            return true;
+        } catch (IllegalArgumentException e) {
+            LOGGER.warn("Rejected chameleon update with invalid variant {} from {}", payload.variantId(), playerName);
+            return false;
+        }
     }
 }

--- a/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
+++ b/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
@@ -53,7 +53,7 @@ public class TardisDataLoader {
             }
             tardisData.put(uuid, model);
             return model;
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
             return null;
         }
     }

--- a/src/test/java/com/adamkali/dwm/ClientTardisTest.java
+++ b/src/test/java/com/adamkali/dwm/ClientTardisTest.java
@@ -1,0 +1,30 @@
+package com.adamkali.dwm;
+
+import com.adamkali.dwm.network.UpdateTardisChameleonC2SPayload;
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+class ClientTardisTest {
+    @Test
+    void updateChameleonVariant_sendsPayloadToServer() {
+        UUID tardisId = UUID.randomUUID();
+        ClientTardis clientTardis = new ClientTardis(tardisId);
+        TardisChameleonVariant variant = TardisChameleonVariant.FOURTH_DOCTOR_BOX;
+
+        try (MockedStatic<ClientPlayNetworking> networking = Mockito.mockStatic(ClientPlayNetworking.class);
+             MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            clientTardis.updateChameleonVariant(variant);
+
+            networking.verify(() -> ClientPlayNetworking.send(
+                    new UpdateTardisChameleonC2SPayload(variant.getId(), tardisId)
+            ));
+            logic.verifyNoInteractions();
+        }
+    }
+}

--- a/src/test/java/com/adamkali/dwm/config/DWMConfigTest.java
+++ b/src/test/java/com/adamkali/dwm/config/DWMConfigTest.java
@@ -1,0 +1,69 @@
+package com.adamkali.dwm.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DWMConfigTest {
+    @BeforeEach
+    void resetConfigStatics() throws Exception {
+        Field initializedField = DWMConfig.class.getDeclaredField("initialized");
+        initializedField.setAccessible(true);
+        initializedField.set(null, false);
+
+        Field configField = DWMConfig.class.getDeclaredField("config");
+        configField.setAccessible(true);
+        configField.set(null, new HashMap<String, Object>());
+    }
+
+    @Test
+    void init_whenConfigIsEmpty_marksFirstStartTrueAndKeepsChameleonDisabledByDefault() {
+        try (MockedStatic<DWMConfigManager> configManager = Mockito.mockStatic(DWMConfigManager.class)) {
+            configManager.when(DWMConfigManager::load).thenReturn(new HashMap<>());
+
+            DWMConfig.init();
+
+            assertTrue(DWMConfig.getBoolean(DWMConfig.IS_FIRST_START));
+            assertFalse(DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI));
+        }
+    }
+
+    @Test
+    void init_whenConfigExists_marksFirstStartFalse() {
+        HashMap<String, Object> loaded = new HashMap<>();
+        loaded.put(DWMConfig.IS_FIRST_START.getKey(), true);
+        loaded.put(DWMConfig.ENABLE_CHAMELEON_GUI.getKey(), true);
+
+        try (MockedStatic<DWMConfigManager> configManager = Mockito.mockStatic(DWMConfigManager.class)) {
+            configManager.when(DWMConfigManager::load).thenReturn(loaded);
+
+            DWMConfig.init();
+
+            assertFalse(DWMConfig.getBoolean(DWMConfig.IS_FIRST_START));
+            assertTrue(DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI));
+        }
+    }
+
+    @Test
+    void setBooleanAndSave_persistsUpdatedConfig() {
+        try (MockedStatic<DWMConfigManager> configManager = Mockito.mockStatic(DWMConfigManager.class)) {
+            configManager.when(DWMConfigManager::load).thenReturn(new HashMap<>());
+            DWMConfig.init();
+
+            DWMConfig.setBoolean(DWMConfig.ENABLE_CHAMELEON_GUI, true);
+            DWMConfig.save();
+
+            configManager.verify(() -> DWMConfigManager.save(Mockito.argThat(map ->
+                    map.containsKey(DWMConfig.ENABLE_CHAMELEON_GUI.getKey())
+                            && Boolean.TRUE.equals(map.get(DWMConfig.ENABLE_CHAMELEON_GUI.getKey()))
+            )));
+        }
+    }
+}

--- a/src/test/java/com/adamkali/dwm/gametest/SonicInteractionGameTests.java
+++ b/src/test/java/com/adamkali/dwm/gametest/SonicInteractionGameTests.java
@@ -1,0 +1,52 @@
+package com.adamkali.dwm.gametest;
+
+import com.adamkali.dwm.item.DWMItems;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.TrapdoorBlock;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.passive.SheepEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsageContext;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.util.math.Vec3d;
+import net.minecraft.world.GameMode;
+
+public class SonicInteractionGameTests implements FabricGameTest {
+    @GameTest(templateName = EMPTY_STRUCTURE)
+    public void sonicFirstSessionSmokeFlow(TestContext context) {
+        if (DWMItems.SONIC_SECOND_DOCTOR == null) {
+            throw new AssertionError("Expected sonic item to be registered");
+        }
+
+        PlayerEntity player = context.createMockPlayer(GameMode.SURVIVAL);
+        ItemStack sonicStack = new ItemStack(DWMItems.SONIC_SECOND_DOCTOR);
+        player.setStackInHand(Hand.MAIN_HAND, sonicStack);
+
+        BlockPos trapdoorPos = new BlockPos(1, 2, 1);
+        context.setBlockState(1, 2, 1, Blocks.IRON_TRAPDOOR);
+        context.expectBlock(Blocks.IRON_TRAPDOOR, 1, 2, 1);
+        BlockHitResult hitResult = new BlockHitResult(Vec3d.ofCenter(trapdoorPos), Direction.UP, trapdoorPos, false);
+        ItemUsageContext itemUsageContext = new ItemUsageContext(player, Hand.MAIN_HAND, hitResult);
+        DWMItems.SONIC_SECOND_DOCTOR.useOnBlock(itemUsageContext);
+
+        if (!context.getWorld().getBlockState(trapdoorPos).get(TrapdoorBlock.OPEN)) {
+            throw new AssertionError("Expected sonic interaction to open iron trapdoor");
+        }
+
+        SheepEntity sheep = (SheepEntity) context.spawnEntity(EntityType.SHEEP, 2, 2, 1);
+        context.expectEntities(EntityType.SHEEP, 1);
+        DWMItems.SONIC_SECOND_DOCTOR.useOnEntity(sonicStack, player, sheep, Hand.MAIN_HAND);
+        if (!sheep.isSheared()) {
+            throw new AssertionError("Expected sonic interaction to shear sheep");
+        }
+
+        context.complete();
+    }
+}

--- a/src/test/java/com/adamkali/dwm/gametest/TardisDoorGameTests.java
+++ b/src/test/java/com/adamkali/dwm/gametest/TardisDoorGameTests.java
@@ -1,0 +1,28 @@
+package com.adamkali.dwm.gametest;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.WorldSavePath;
+
+public class TardisDoorGameTests implements FabricGameTest {
+    @GameTest(templateName = EMPTY_STRUCTURE)
+    public void tardisDoorStateSmokeFlow(TestContext context) {
+        context.setBlockState(1, 2, 1, DWMBlocks.TARDIS_BLOCK);
+        context.expectBlock(DWMBlocks.TARDIS_BLOCK, 1, 2, 1);
+        TardisDataLoader.tardisSaveDirectory = context.getWorld().getServer().getSavePath(WorldSavePath.ROOT).resolve("gametest_tardis_data");
+        TardisDataModel model = TardisDataLoader.create();
+        ActionResult toggleResult = TardisLogic.toggleDoor(model.uuid);
+        if (toggleResult != ActionResult.SUCCESS) {
+            throw new AssertionError("Expected successful door toggle in smoke flow");
+        }
+        TardisLogic.updateDoorState(model.uuid);
+
+        context.complete();
+    }
+}

--- a/src/test/java/com/adamkali/dwm/network/ChameleonGameTests.java
+++ b/src/test/java/com/adamkali/dwm/network/ChameleonGameTests.java
@@ -1,0 +1,36 @@
+package com.adamkali.dwm.network;
+
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import net.fabricmc.fabric.api.gametest.v1.FabricGameTest;
+import net.minecraft.test.GameTest;
+import net.minecraft.test.TestContext;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.WorldSavePath;
+
+public class ChameleonGameTests implements FabricGameTest {
+    @GameTest(templateName = EMPTY_STRUCTURE)
+    public void chameleonValidPayloadSmokeFlow(TestContext context) {
+        TardisDataLoader.tardisSaveDirectory = context.getWorld().getServer().getSavePath(WorldSavePath.ROOT).resolve("gametest_tardis_data");
+        TardisDataModel model = TardisDataLoader.create();
+
+        boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(
+                new UpdateTardisChameleonC2SPayload(TardisChameleonVariant.FIFTH_DOCTOR_BOX.getId(), model.uuid),
+                "gametest"
+        );
+        if (!accepted) {
+            throw new AssertionError("Expected valid payload to be accepted");
+        }
+
+        boolean rejected = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(
+                new UpdateTardisChameleonC2SPayload(Identifier.of("dwm", "invalid_variant"), model.uuid),
+                "gametest"
+        );
+        if (rejected) {
+            throw new AssertionError("Expected invalid payload to be rejected");
+        }
+
+        context.complete();
+    }
+}

--- a/src/test/java/com/adamkali/dwm/network/ServerPayloadTypeRegistryTest.java
+++ b/src/test/java/com/adamkali/dwm/network/ServerPayloadTypeRegistryTest.java
@@ -1,0 +1,113 @@
+package com.adamkali.dwm.network;
+
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
+import net.minecraft.util.Identifier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServerPayloadTypeRegistryTest {
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        TardisDataLoader.tardisSaveDirectory = tempDir;
+        Field field = TardisDataLoader.class.getDeclaredField("tardisData");
+        field.setAccessible(true);
+        HashMap<?, ?> cache = (HashMap<?, ?>) field.get(null);
+        cache.clear();
+    }
+
+    @Test
+    void safelyHandleChameleonUpdate_rejectsUnknownTardisId() {
+        UUID unknownId = UUID.randomUUID();
+        UpdateTardisChameleonC2SPayload payload = new UpdateTardisChameleonC2SPayload(
+                TardisChameleonVariant.FIRST_DOCTOR_BOX.getId(),
+                unknownId
+        );
+
+        try (MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+             MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            loader.when(() -> TardisDataLoader.get(unknownId)).thenReturn(null);
+
+            boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+
+            assertFalse(accepted);
+            logic.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void safelyHandleChameleonUpdate_rejectsInvalidVariantId() {
+        UUID tardisId = UUID.randomUUID();
+        UpdateTardisChameleonC2SPayload payload = new UpdateTardisChameleonC2SPayload(
+                Identifier.of("dwm", "not_a_variant"),
+                tardisId
+        );
+
+        try (MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+             MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            loader.when(() -> TardisDataLoader.get(tardisId)).thenReturn(new TardisDataModel());
+
+            boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+
+            assertFalse(accepted);
+            logic.verifyNoInteractions();
+        }
+    }
+
+    @Test
+    void safelyHandleChameleonUpdate_appliesValidPayload() {
+        UUID tardisId = UUID.randomUUID();
+        TardisChameleonVariant variant = TardisChameleonVariant.SEVENTH_DOCTOR_BOX;
+        UpdateTardisChameleonC2SPayload payload = new UpdateTardisChameleonC2SPayload(variant.getId(), tardisId);
+
+        try (MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+             MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            loader.when(() -> TardisDataLoader.get(tardisId)).thenReturn(new TardisDataModel());
+
+            boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+
+            assertTrue(accepted);
+            logic.verify(() -> TardisLogic.setVariant(tardisId, variant));
+        }
+    }
+
+    @Test
+    void safelyHandleChameleonUpdate_persistsUpdatedVariantThroughSaveAndLoad() throws Exception {
+        TardisDataModel model = TardisDataLoader.create();
+        UUID tardisId = model.uuid;
+        UpdateTardisChameleonC2SPayload payload = new UpdateTardisChameleonC2SPayload(
+                TardisChameleonVariant.SIXTH_DOCTOR_BOX.getId(),
+                tardisId
+        );
+
+        boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+        TardisDataLoader.save();
+
+        Field field = TardisDataLoader.class.getDeclaredField("tardisData");
+        field.setAccessible(true);
+        HashMap<?, ?> cache = (HashMap<?, ?>) field.get(null);
+        cache.clear();
+
+        TardisDataModel loaded = TardisDataLoader.get(tardisId);
+
+        assertTrue(accepted);
+        assertTrue(loaded != null);
+        assertTrue(loaded.variant == TardisChameleonVariant.SIXTH_DOCTOR_BOX);
+    }
+}

--- a/src/test/java/com/adamkali/dwm/tardis/data/TardisDataLoaderTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/data/TardisDataLoaderTest.java
@@ -9,8 +9,11 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -21,8 +24,12 @@ public class TardisDataLoaderTest {
     Path tempDir;
 
     @BeforeEach
-    void setUp() {
+    void setUp() throws Exception {
         TardisDataLoader.tardisSaveDirectory = tempDir;
+        Field field = TardisDataLoader.class.getDeclaredField("tardisData");
+        field.setAccessible(true);
+        HashMap<?, ?> cache = (HashMap<?, ?>) field.get(null);
+        cache.clear();
     }
 
     @AfterEach
@@ -117,6 +124,37 @@ public class TardisDataLoaderTest {
         // Assert
         assertNotNull(loadedModel, "Loaded model should not be null");
         assertEquals(originalModel.uuid, loadedModel.uuid, "UUIDs should match");
+    }
+
+    @Test
+    void save_OnlyPersistsDirtyModels() {
+        TardisDataModel dirtyModel = TardisDataLoader.create();
+        dirtyModel.markDirty();
+        UUID dirtyId = dirtyModel.uuid;
+
+        TardisDataModel cleanModel = TardisDataLoader.create();
+        UUID cleanId = cleanModel.uuid;
+
+        TardisDataLoader.save();
+
+        File dirtyFile = new File(tempDir.toFile(), dirtyId + ".json");
+        File cleanFile = new File(tempDir.toFile(), cleanId + ".json");
+
+        assertTrue(dirtyFile.exists(), "Dirty model should be saved");
+        assertFalse(cleanFile.exists(), "Clean model should not be saved");
+    }
+
+    @Test
+    void get_WithCorruptedJson_ShouldFailSafe() throws IOException {
+        UUID testUuid = UUID.randomUUID();
+        File corruptedFile = new File(tempDir.toFile(), testUuid + ".json");
+        try (FileWriter writer = new FileWriter(corruptedFile)) {
+            writer.write("{invalid json");
+        }
+
+        TardisDataModel loadedModel = TardisDataLoader.get(testUuid);
+
+        assertNull(loadedModel, "Corrupted json should be treated as missing model");
     }
 
 

--- a/src/test/java/com/adamkali/dwm/tardis/logic/TardisLogicTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/logic/TardisLogicTest.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
+import net.minecraft.util.ActionResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -34,12 +35,29 @@ class TardisLogicTest {
 
             // Test opening the door
             assertFalse(testTardis.doorState.isOpen);
-            TardisLogic.toggleDoor(testTardisId);
+            ActionResult firstResult = TardisLogic.toggleDoor(testTardisId);
+            assertEquals(ActionResult.SUCCESS, firstResult);
             assertTrue(testTardis.doorState.isOpen);
 
             // Test closing the door
-            TardisLogic.toggleDoor(testTardisId);
+            ActionResult secondResult = TardisLogic.toggleDoor(testTardisId);
+            assertEquals(ActionResult.SUCCESS, secondResult);
             assertFalse(testTardis.doorState.isOpen);
+        }
+    }
+
+    @Test
+    void toggleDoor_WhenDoorSwingInTransition_ShouldReturnPassWithoutStateMutation() {
+        try (MockedStatic<TardisDataLoader> mockedStatic = Mockito.mockStatic(TardisDataLoader.class)) {
+            mockedStatic.when(() -> TardisDataLoader.get(testTardisId)).thenReturn(testTardis);
+            testTardis.doorState.isOpen = false;
+            testTardis.doorState.doorSwing = 0.4f;
+
+            ActionResult result = TardisLogic.toggleDoor(testTardisId);
+
+            assertEquals(ActionResult.PASS, result);
+            assertFalse(testTardis.doorState.isOpen);
+            assertEquals(0.4f, testTardis.doorState.doorSwing, 0.001f);
         }
     }
 
@@ -47,8 +65,8 @@ class TardisLogicTest {
     void toggleDoor_WithNullTardis_ShouldDoNothing() {
         try (MockedStatic<TardisDataLoader> mockedStatic = Mockito.mockStatic(TardisDataLoader.class)) {
             mockedStatic.when(() -> TardisDataLoader.get(testTardisId)).thenReturn(null);
-            TardisLogic.toggleDoor(testTardisId);
-            // Test passes if no exception is thrown
+            ActionResult result = TardisLogic.toggleDoor(testTardisId);
+            assertEquals(ActionResult.FAIL, result);
         }
     }
 
@@ -88,6 +106,20 @@ class TardisLogicTest {
     }
 
     @Test
+    void updateDoorState_WhenDoorOpening_ShouldClampToOne() {
+        try (MockedStatic<TardisDataLoader> mockedStatic = Mockito.mockStatic(TardisDataLoader.class)) {
+            mockedStatic.when(() -> TardisDataLoader.get(testTardisId)).thenReturn(testTardis);
+
+            testTardis.doorState.isOpen = true;
+            testTardis.doorState.doorSwing = 0.99f;
+
+            TardisLogic.updateDoorState(testTardisId);
+
+            assertEquals(1.0f, testTardis.doorState.doorSwing, 0.001f);
+        }
+    }
+
+    @Test
     void updateDoorState_WhenDoorClosing_ShouldDecreaseDoorSwing() {
         try (MockedStatic<TardisDataLoader> mockedStatic = Mockito.mockStatic(TardisDataLoader.class)) {
             mockedStatic.when(() -> TardisDataLoader.get(testTardisId)).thenReturn(testTardis);
@@ -98,6 +130,20 @@ class TardisLogicTest {
             TardisLogic.updateDoorState(testTardisId);
 
             assertEquals(0.45f, testTardis.doorState.doorSwing, 0.001f);
+        }
+    }
+
+    @Test
+    void updateDoorState_WhenDoorClosing_ShouldClampToZero() {
+        try (MockedStatic<TardisDataLoader> mockedStatic = Mockito.mockStatic(TardisDataLoader.class)) {
+            mockedStatic.when(() -> TardisDataLoader.get(testTardisId)).thenReturn(testTardis);
+
+            testTardis.doorState.isOpen = false;
+            testTardis.doorState.doorSwing = 0.01f;
+
+            TardisLogic.updateDoorState(testTardisId);
+
+            assertEquals(0.0f, testTardis.doorState.doorSwing, 0.001f);
         }
     }
 


### PR DESCRIPTION
## Why this matters
Improves confidence in core TARDIS and sonic screwdriver gameplay flows by adding broader automated coverage, reducing the risk of regressions as gameplay logic evolves.

## Proposed Implementation
Adds new GameTests for sonic interaction, TARDIS door behavior, and chameleon updates; expands unit coverage across config, data loading, logic, and server payload registration; and includes related reliability/documentation updates already in this branch.

## Problems Encountered / Decisions Made
Kept validation split between GameTests and unit tests so world-interaction behavior is tested in-game while deterministic logic stays in fast JUnit tests.

Made with [Cursor](https://cursor.com)