### PR TITLE
docs(chameleon): make experimental status explicit in interaction flow

### DIFF
--- a/src/main/java/com/adamkali/dwm/block/TardisBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/TardisBlock.java
@@ -19,6 +19,7 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.Text;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.BlockMirror;
 import net.minecraft.util.BlockRotation;
@@ -86,8 +87,13 @@ public class TardisBlock extends BlockWithEntity {
                 tardisBlockEntity.markDirty();
             }
         } else {
-            if (player.isSneaking() && DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)) {
-                ServerPlayNetworking.send((ServerPlayerEntity) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
+            if (player.isSneaking()) {
+                if (DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)) {
+                    player.sendMessage(Text.literal("Experimental: opening TARDIS chameleon selector"), true);
+                    ServerPlayNetworking.send((ServerPlayerEntity) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
+                } else {
+                    player.sendMessage(Text.literal("Experimental: chameleon selector is disabled in config"), true);
+                }
             }
         }
 


### PR DESCRIPTION
## Why this matters
Players should immediately understand that chameleon customization is experimental and optional, not a stable default interaction.

## Proposed Implementation
- Updated `TardisBlock` sneak-use server path to show explicit experimental status messages.
- Added a distinct message when experimental chameleon GUI is disabled in config.
- Kept behavior fully config-gated and did not alter stable door toggle interaction.
- Validated with `./gradlew test`.

## Problems Encountered / Decisions Made
- Implemented this as messaging-only to keep the change low-risk and focused on status transparency.

Made with [Cursor](https://cursor.com)