### PR TITLE
fix(network): harden chameleon payload validation and gating

### DIFF
--- a/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
+++ b/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.network;
 
+import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
@@ -24,6 +25,15 @@ public class ServerPayloadTypeRegistry {
 
     static boolean safelyHandleChameleonUpdate(UpdateTardisChameleonC2SPayload payload, String playerName) {
         try {
+            if (!DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)) {
+                LOGGER.warn("Rejected chameleon update while experimental feature is disabled from {}", playerName);
+                return false;
+            }
+            if (payload == null || payload.tardisId() == null || payload.variantId() == null) {
+                LOGGER.warn("Rejected malformed chameleon payload from {}", playerName);
+                return false;
+            }
+
             TardisDataModel tardis = TardisDataLoader.get(payload.tardisId());
             if (tardis == null) {
                 LOGGER.warn("Rejected chameleon update for unknown tardisId {} from {}", payload.tardisId(), playerName);

--- a/src/test/java/com/adamkali/dwm/network/ServerPayloadTypeRegistryTest.java
+++ b/src/test/java/com/adamkali/dwm/network/ServerPayloadTypeRegistryTest.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.network;
 
+import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
@@ -40,8 +41,10 @@ class ServerPayloadTypeRegistryTest {
                 unknownId
         );
 
-        try (MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+        try (MockedStatic<DWMConfig> config = Mockito.mockStatic(DWMConfig.class);
+             MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
              MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            config.when(() -> DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)).thenReturn(true);
             loader.when(() -> TardisDataLoader.get(unknownId)).thenReturn(null);
 
             boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
@@ -59,8 +62,10 @@ class ServerPayloadTypeRegistryTest {
                 tardisId
         );
 
-        try (MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+        try (MockedStatic<DWMConfig> config = Mockito.mockStatic(DWMConfig.class);
+             MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
              MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            config.when(() -> DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)).thenReturn(true);
             loader.when(() -> TardisDataLoader.get(tardisId)).thenReturn(new TardisDataModel());
 
             boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
@@ -76,8 +81,10 @@ class ServerPayloadTypeRegistryTest {
         TardisChameleonVariant variant = TardisChameleonVariant.SEVENTH_DOCTOR_BOX;
         UpdateTardisChameleonC2SPayload payload = new UpdateTardisChameleonC2SPayload(variant.getId(), tardisId);
 
-        try (MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+        try (MockedStatic<DWMConfig> config = Mockito.mockStatic(DWMConfig.class);
+             MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
              MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            config.when(() -> DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)).thenReturn(true);
             loader.when(() -> TardisDataLoader.get(tardisId)).thenReturn(new TardisDataModel());
 
             boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
@@ -96,7 +103,11 @@ class ServerPayloadTypeRegistryTest {
                 tardisId
         );
 
-        boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+        boolean accepted;
+        try (MockedStatic<DWMConfig> config = Mockito.mockStatic(DWMConfig.class)) {
+            config.when(() -> DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)).thenReturn(true);
+            accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+        }
         TardisDataLoader.save();
 
         Field field = TardisDataLoader.class.getDeclaredField("tardisData");
@@ -109,5 +120,26 @@ class ServerPayloadTypeRegistryTest {
         assertTrue(accepted);
         assertTrue(loaded != null);
         assertTrue(loaded.variant == TardisChameleonVariant.SIXTH_DOCTOR_BOX);
+    }
+
+    @Test
+    void safelyHandleChameleonUpdate_rejectsWhenExperimentalFeatureDisabled() {
+        UUID tardisId = UUID.randomUUID();
+        UpdateTardisChameleonC2SPayload payload = new UpdateTardisChameleonC2SPayload(
+                TardisChameleonVariant.FOURTH_DOCTOR_BOX.getId(),
+                tardisId
+        );
+
+        try (MockedStatic<DWMConfig> config = Mockito.mockStatic(DWMConfig.class);
+             MockedStatic<TardisDataLoader> loader = Mockito.mockStatic(TardisDataLoader.class);
+             MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            config.when(() -> DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)).thenReturn(false);
+            loader.when(() -> TardisDataLoader.get(tardisId)).thenReturn(new TardisDataModel());
+
+            boolean accepted = ServerPayloadTypeRegistry.safelyHandleChameleonUpdate(payload, "playerA");
+
+            assertFalse(accepted);
+            logic.verifyNoInteractions();
+        }
     }
 }


### PR DESCRIPTION
## Why this matters
Multiplayer chameleon updates should be server-safe and respect the feature's experimental gating to avoid desyncs and unintended state changes.

## Proposed Implementation
- Added server-side guardrails in `ServerPayloadTypeRegistry` to reject updates when chameleon is disabled in config.
- Added malformed payload checks (`null` payload/tardis/variant IDs) before lookup and apply.
- Expanded `ServerPayloadTypeRegistryTest` to mock config gating and cover disabled-feature rejection.
- Validated with `./gradlew test --tests \"com.adamkali.dwm.network.ServerPayloadTypeRegistryTest\"` and `./gradlew test`.

## Problems Encountered / Decisions Made
- Existing persistence test needed explicit config mocking after introducing config-gated handling.

Made with [Cursor](https://cursor.com)