### PR TITLE
docs(features): add quick-start usage recipes for shipped systems

### DIFF
--- a/docs/feature-building-content.md
+++ b/docs/feature-building-content.md
@@ -24,6 +24,12 @@ Enable players to quickly build coherent Doctor Who-inspired interiors and exter
 2. Craft themed block components from provided recipes.
 3. Combine families to create room panels, corridors, and console-like spaces.
 
+## Quick-Start Recipe
+- Start with one pair from each family: `Roundel A/B`, `Big Roundel A/B`, and `TARDIS Wall`.
+- Use Chronoplasm Powder variants as accent materials to define room zones.
+- Build one small wall module first, then duplicate it to keep visual consistency.
+- Expand by color-swapping within the same family to preserve a cohesive style.
+
 ## Known Constraints
 - Current focus is on strong decorative breadth and consistency.
 - Some visual polish relies on the completeness of bundled texture assets.

--- a/docs/feature-chameleon-system.md
+++ b/docs/feature-chameleon-system.md
@@ -21,6 +21,12 @@ Allow players to personalize TARDIS exterior identity through selectable visual 
 2. Sneak-use the TARDIS interaction path that opens the variant selector.
 3. Pick a variant; client sends update payload; server applies new variant data.
 
+## Quick-Start Recipe (Experimental)
+- Confirm this system is marked Experimental and disabled by default.
+- Enable chameleon GUI in config before launching your world/session.
+- Sneak-use the TARDIS interaction path to open the selector and pick a variant.
+- Re-open the selector once to verify your chosen variant persists.
+
 ## Known Constraints
 - This feature is experimental and disabled by default.
 - Stability and UX polish are still evolving.

--- a/docs/feature-sonic-screwdrivers.md
+++ b/docs/feature-sonic-screwdrivers.md
@@ -20,6 +20,12 @@ Give players a recognizable Doctor Who utility tool that feels versatile, tactil
 2. Use it on supported blocks/entities.
 3. The action is resolved based on target context.
 
+## Quick-Start Recipe
+- Craft any available sonic variant first (Second/Third/Fourth/Fifth Doctor).
+- Test on an iron trapdoor or iron door to confirm toggle behavior.
+- Try one entity interaction (for example, sheep) to learn context-specific outcomes.
+- If a target is unsupported, no sonic utility action is applied.
+
 Current interactions include:
 - Toggle iron doors and iron trapdoors.
 - Prime TNT safely.

--- a/docs/feature-tardis-block.md
+++ b/docs/feature-tardis-block.md
@@ -21,6 +21,12 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 2. Interact with the block to toggle door-state behavior.
 3. Door swing/state persists through block entity data and render updates.
 
+## Quick-Start Recipe
+- Place one `tardis_block` in a safe open area.
+- Right-click once to open, then interact again to close.
+- Observe that the exterior state remains consistent after normal world saves.
+- Use this as the anchor piece for exterior-themed builds.
+
 ## Known Constraints
 - This is currently an exterior interaction feature, not full interior travel gameplay.
 - Visual fidelity depends on available client-side model/texture assets.

--- a/docs/feature-tardis-door-button.md
+++ b/docs/feature-tardis-door-button.md
@@ -21,6 +21,12 @@ Provide a compact, thematic interaction block that feels mechanically readable a
 2. Interact to press it.
 3. Button enters active state briefly, then returns to default state.
 
+## Quick-Start Recipe
+- Place `tardis_door_button` near your TARDIS wall/door area.
+- Press it once and verify active state + click feedback.
+- Wait for automatic reset to confirm the short interaction loop.
+- Repeat in different orientations to confirm facing behavior for your build.
+
 ## Known Constraints
 - Purpose is focused on concise interaction feedback, not complex control logic.
 - Shape and orientation follow defined facing-based rules.


### PR DESCRIPTION
## Why this matters
Players should be able to use DWM’s shipped features immediately without relying on external walkthroughs.

## Proposed Implementation
- Added `Quick-Start Recipe` sections to feature docs for Sonic Screwdrivers, TARDIS block, TARDIS door button, and Building Content.
- Added `Quick-Start Recipe (Experimental)` section for the chameleon system with explicit opt-in status.
- Kept all guidance tied to currently implemented behavior only.

## Problems Encountered / Decisions Made
- Kept recipes concise and implementation-aligned to avoid roadmap ambiguity in player-facing docs.

Made with [Cursor](https://cursor.com)