### PR TITLE
docs: add Doctor Who lore knowledge base for AI agents

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,9 @@ This folder documents implemented player-facing features for The Doctor Who Mod 
 ### Experimental Features
 - [TARDIS Chameleon System](./feature-chameleon-system.md) (config-gated and disabled by default)
 
+## Lore Knowledge Base (AI Agent Context)
+- [Doctor Who Lore Index](./lore/index.md)
+
 ## Brand and Differentiation
 - [Branding Guidelines](./branding-guidelines.md)
 - [Differentiation Strategy](./differentiation-strategy.md)

--- a/docs/lore/companions-unit-and-earth.md
+++ b/docs/lore/companions-unit-and-earth.md
@@ -1,0 +1,52 @@
+# Companions, UNIT, and Earth Perspective
+
+## Why This Matters for DWM
+
+Doctor Who is not only about cosmic lore; it is also about human perspective, discovery, and problem-solving under pressure. Companion-like framing can improve onboarding and progression clarity.
+
+## Core Companion Pattern
+
+Companions typically provide:
+- the audience point of view (questions, surprise, emotional grounding),
+- practical help (field problem-solving),
+- ethical friction (challenging the Doctor's choices),
+- and stakes tied to ordinary life.
+
+For gameplay, this maps to:
+- guided introduction sequences,
+- objective clarity during complex systems,
+- and "learn by doing" interaction loops.
+
+## UNIT and Institutional Response
+
+UNIT (Unified Intelligence Taskforce) represents Earth's organized response to alien threats. Narrative function:
+- bridge between civilians and cosmic events,
+- provide military/scientific support,
+- introduce mission structure and briefings.
+
+Feature implications:
+- mission board style tasks,
+- investigatory steps before full threat reveal,
+- rewards for containment/mitigation rather than pure combat.
+
+## Earth as a Repeated Stage
+
+Many stories use contemporary Earth to:
+- make extraordinary events readable quickly,
+- contrast normal life with alien incursions,
+- and keep stakes familiar.
+
+Gameplay implication: local biome/village contexts can host themed events without requiring fully custom dimensions first.
+
+## Companion-Style Design Heuristics
+
+- **Explain by dialogue/objective text, not walls of lore text.**
+- **Give immediate next action.** ("Scan this", "stabilize that", "open with sonic".)
+- **Use escalating reveals.** Start mundane, then expose bigger threat.
+- **Reward curiosity.** Optional lore snippets, collectibles, or logs.
+
+## Pitfalls to Avoid
+
+- Over-reliance on combat as the only interaction model.
+- Lore dumps with no actionable player behavior.
+- Companion-inspired systems that become mandatory escort mechanics (usually frustrating in Minecraft).

--- a/docs/lore/eras-tone-and-continuity.md
+++ b/docs/lore/eras-tone-and-continuity.md
@@ -1,0 +1,58 @@
+# Eras, Tone, and Continuity
+
+## Why This Matters For DWM
+
+Doctor Who is one franchise with multiple tones. Feature proposals should match the expected feel:
+- adventurous and curious,
+- occasionally scary,
+- often hopeful,
+- and rarely pure power fantasy.
+
+## Era-Level Texture
+
+### Classic Era (1963-1989)
+- More serial structure and slower mystery setup.
+- Strong "problem-solving with limited tools" energy.
+- Distinct monster identity and set-piece storytelling.
+
+Design implication:
+- Good source for focused, puzzle-like mechanics and iconic props.
+
+### Modern Era (2005+)
+- Faster emotional pacing and character arcs.
+- Clear companion POV and Earth-level stakes.
+- Big seasonal payoff concepts (cracks, impossible girl, Flux-level threats).
+
+Design implication:
+- Good source for progression arcs, narrative framing, and reactive world events.
+
+## Tone Guardrails For Suggestions
+
+Prefer:
+- clever interaction chains,
+- tradeoffs and risk/reward decisions,
+- dramatic but understandable feedback,
+- features that invite collaborative play.
+
+Avoid:
+- "god mode" Time Lord powers with no constraints,
+- pure fan-service mechanics that do not affect gameplay,
+- obscure continuity references as required systems.
+
+## Continuity Strategy For Agents
+
+Because Doctor Who has soft continuity:
+
+1. Anchor suggestions in widely recognized canon.
+2. If a detail is disputed, choose the simplest player-facing interpretation.
+3. Keep deep-cut references optional via variants, flavor text, or cosmetic paths.
+
+## Canon-Legibility Scale (Use This)
+
+When proposing a feature, classify lore dependency:
+
+- **High legibility**: nearly all fans recognize it (TARDIS police box, Daleks, sonic utility).
+- **Medium legibility**: known but era-dependent (specific Gallifreyan rituals, UNIT protocols).
+- **Low legibility**: niche expanded-media references.
+
+For core gameplay loops, prioritize high legibility concepts.

--- a/docs/lore/feature-ideation-playbook.md
+++ b/docs/lore/feature-ideation-playbook.md
@@ -1,0 +1,105 @@
+# Feature Ideation Playbook (Lore -> DWM Features)
+
+See also: [Lore Index](./index.md), [TARDIS and Time Travel Rules](./tardis-and-time-travel-rules.md), [Major Villains and Threat Patterns](./major-villains-and-threat-patterns.md)
+
+This playbook helps AI agents convert Doctor Who lore into practical mod proposals without scope creep.
+
+## 1) Start From Existing DWM Pillars
+
+Anchor ideas to current documented product direction:
+- sonic utility interactions,
+- TARDIS exterior identity and interaction loops,
+- builder-first themed content,
+- stable vs experimental clarity.
+
+If an idea does not strengthen one of these, down-rank it.
+
+## 2) Lore-to-Gameplay Translation Rules
+
+Translate lore to **play patterns**, not just references:
+- Regeneration -> player state transition/recovery/progression.
+- Chameleon circuit -> variant selection/disguise mechanics.
+- Time anomalies -> localized rule changes, cooldown windows, or event zones.
+- Villains -> distinct encounter mechanics with clear counters.
+
+Avoid direct lore dumps with no mechanical depth.
+
+## 3) Improvement Ideas for Current Features
+
+### Sonic Screwdrivers (Current)
+Potential improvements:
+- Context-specific feedback package (unique sound/particles/message per target type).
+- "Sonic profile" metadata for each Doctor variant (same base utility, different UX flavor).
+- Optional progression unlocks for additional interactions while preserving balance.
+
+Lore justification:
+- Sonic tools are adaptable and precise, not generic weapons.
+- Different Doctors emphasize style and approach differences.
+
+### TARDIS Exterior Block (Current)
+Potential improvements:
+- Stronger state cues (open/closed/locked visual markers).
+- Ownership and permission layer for multiplayer roleplay trust.
+- Anchoring interactions to "stabilization" actions (low-friction ritual before key interactions).
+
+Lore justification:
+- TARDIS behavior is identity-rich and owner-associated.
+- Exterior state is an important narrative signal.
+
+### Chameleon System (Experimental)
+Potential improvements:
+- Lore framing in UI ("chameleon circuit calibration" language).
+- Variant categories by era/theme for easier player choice.
+- Failure-state polish (clear error responses when disabled by config or blocked server-side).
+
+Lore justification:
+- Chameleon circuits are iconic, imperfect, and often narrative-significant.
+
+## 4) New Feature Candidate Shapes (Small/Medium Scope)
+
+### A) Time Rift Events (Small-Medium)
+- Spawn rare world anomalies that create temporary rules (mob behavior shifts, sound cues, visual distortion).
+- Reward investigation with themed items/components.
+
+Why it fits lore:
+- Doctor Who frequently uses localized temporal instability.
+
+Why it fits DWM:
+- Creates reusable interaction loops without requiring full dimension travel.
+
+### B) UNIT Signal Beacon (Small)
+- Placeable block that detects nearby anomalies/hostile incursions and provides directional hints.
+
+Why it fits lore:
+- UNIT is Earth's organized response to unusual threats.
+
+Why it fits DWM:
+- Clear utility object for builders and survival players.
+
+### C) Villain Encounter Modules (Medium)
+- Modular encounter templates (Dalek patrol, Cyber conversion event, Angel zone challenge).
+- Each module has one clear "read and counter" rule.
+
+Why it fits lore:
+- Villains are memorable because they impose specific tactical constraints.
+
+Why it fits DWM:
+- Supports curated quality over broad content sprawl.
+
+## 5) Canon-Safe Guardrails
+
+- Keep the Doctor non-playable by default; focus on being a participant in Doctor Who-style events.
+- Do not hard-lock ideas to one era unless intended.
+- Preserve wonder and tension: combine danger + clever solutions, not pure combat escalation.
+- Ensure descriptions distinguish:
+  - **canon-inspired**, and
+  - **strictly canonical**.
+
+## 6) Proposal Quality Checklist
+
+Before recommending a feature, verify:
+1. Is the core loop understandable in under 2 in-game attempts?
+2. Does it improve utility, building cohesion, or both?
+3. Is the lore reference recognizable to a broad audience?
+4. Can behavior be tested with unit tests, integration tests, or GameTests?
+5. Does it avoid becoming a disconnected fan-service one-off?

--- a/docs/lore/gallifrey-and-time-lords.md
+++ b/docs/lore/gallifrey-and-time-lords.md
@@ -1,0 +1,39 @@
+# Gallifrey and Time Lords
+
+## Core Lore
+
+- **Gallifrey** is the Doctor's home world and the center of Time Lord civilization.
+- **Time Lords** are Gallifreyans with advanced temporal knowledge and technology.
+- The Time Lords have historically acted as powerful but often aloof stewards of time.
+- High-level institutions include:
+  - the **High Council** (governance/political authority),
+  - advanced scientific and temporal academies,
+  - strict cultural rules around time intervention.
+
+## The Time War Legacy
+
+- Modern Doctor Who strongly frames many arcs through the aftermath of the **Time War**.
+- The Time War reinforces themes of:
+  - moral cost of escalation,
+  - responsibility when holding superior technology,
+  - survival of culture through artifacts and memory.
+
+## Gameplay Translation
+
+Use Time Lord lore for systems that feel advanced, ritualized, or rule-governed:
+- identity/ownership binding,
+- controlled access and authorization,
+- "old but superior" technology fantasy,
+- non-linear progression unlocked by knowledge rather than raw materials alone.
+
+## Design Guardrails
+
+- Avoid making Time Lords a generic "magic race."
+- Favor pseudo-scientific framing (calibration, harmonics, temporal signatures).
+- Respect that the Doctor often opposes Time Lord authoritarianism; systems can include ethical choices rather than pure hierarchy.
+
+## DWM-Relevant Hooks
+
+- **TARDIS ownership and permissions:** owner link, trusted users, multiplayer-safe access policy.
+- **Lore-flavored progression:** unlock advanced functions via structured milestones (for example, calibration tasks).
+- **Ancient-tech feel in UI copy:** "stabilize artron flow," "synchronize temporal keyprint."

--- a/docs/lore/index.md
+++ b/docs/lore/index.md
@@ -1,0 +1,36 @@
+# Doctor Who Lore Knowledge Base (For AI Agents)
+
+This section provides a practical, canon-aware lore reference for AI agents working on The Doctor Who Mod (DWM).
+
+Use this to:
+- understand core Doctor Who concepts,
+- ground suggestions in recognizable franchise identity, and
+- propose feature improvements/new features that fit the mod's existing direction.
+
+## Scope and Canon Guidance
+
+- Prioritize TV canon from:
+  - **Classic era** (1963-1989),
+  - **Modern era** (2005+), and
+  - anniversary specials.
+- Treat expanded media (novels, comics, audio dramas) as optional inspiration unless a concept is broadly known.
+- When continuity conflicts exist, prefer the interpretation most legible to players.
+
+## Topic Map
+
+- [The Doctor and Regeneration](./the-doctor-and-regeneration.md)
+- [TARDIS and Time Travel Rules](./tardis-and-time-travel-rules.md)
+- [Gallifrey and Time Lords](./gallifrey-and-time-lords.md)
+- [Companions, UNIT, and Earth Perspective](./companions-unit-and-earth.md)
+- [Major Villains and Threat Patterns](./major-villains-and-threat-patterns.md)
+- [Eras, Tone, and Continuity](./eras-tone-and-continuity.md)
+- [Feature Ideation Playbook](./feature-ideation-playbook.md)
+
+## Agent Usage Pattern
+
+1. Start from one current feature doc in `docs/` (for example TARDIS block, sonic screwdrivers, chameleon system).
+2. Pull matching lore constraints from this folder.
+3. Generate suggestions in two buckets:
+   - **Improve current feature** (better feedback, better usability, stronger fantasy fit).
+   - **Add new feature** (small, coherent, testable additions aligned with DWM identity).
+4. Reject ideas that are lore-famous but low gameplay value.

--- a/docs/lore/major-villains-and-threat-patterns.md
+++ b/docs/lore/major-villains-and-threat-patterns.md
@@ -1,0 +1,88 @@
+# Major Villains and Threat Patterns
+
+See also: [Lore Index](./index.md), [Eras, Tone, and Continuity](./eras-tone-and-continuity.md)
+
+## Why Villains Matter for DWM
+
+Doctor Who threats are not just combat encounters; they usually encode:
+- a **moral or social problem**,
+- a **specific interaction puzzle**, and
+- a memorable **audio/visual identity**.
+
+For DWM, this supports utility mechanics, stealth pressure, puzzle states, and atmospheric worldbuilding.
+
+## Daleks
+
+### Lore Essentials
+- Created by Davros; iconic mantra: "Exterminate."
+- Core traits: militaristic, supremacist, relentless, technologically advanced.
+- Often shown as overwhelming force plus ideological threat.
+
+### Design Translation
+- Favor high-threat, high-clarity encounters over generic mobs.
+- Build around line-of-sight pressure, area denial, and alarm states.
+- Let sonic/TARDIS systems provide tactical counterplay, not easy nullification.
+
+### Good DWM Feature Seeds
+- Dalek patrol structures with escalating alert phases.
+- Interactable "Dalek lockout" tech requiring specific sonic action order.
+- Broadcast-style warning audio to signal nearby threat levels.
+
+## Cybermen
+
+### Lore Essentials
+- Conversion-driven faction: survival through cybernetic replacement.
+- Different Cybermen variants exist across eras, but conversion theme is central.
+- Horror comes from loss of identity, not just physical danger.
+
+### Design Translation
+- Use conversion-like mechanics as status/persistence pressure (with clear reversibility rules).
+- Emphasize rescue/containment objectives over pure kill loops.
+- Introduce slow, inevitable threat progression if players ignore warning signs.
+
+### Good DWM Feature Seeds
+- "Conversion chamber" dungeon objective where players interrupt staged process.
+- Temporary debuff chain themed as cyber-conversion pressure.
+- Sonic utility interaction that delays or disrupts conversion machinery.
+
+## Weeping Angels
+
+### Lore Essentials
+- Quantum-locked predators: cannot move while observed.
+- Predation style often involves displacement in time, not direct damage.
+- Fear pattern is observation management and environment uncertainty.
+
+### Design Translation
+- Implement strict line-of-sight/observation logic for movement gating.
+- Use time displacement effects as resource/logistics disruption.
+- Keep fairness high: players must understand cause-and-effect.
+
+### Good DWM Feature Seeds
+- Statue entities that reposition only when unobserved by players.
+- "Temporal displacement" penalty moving player to prior world position checkpoint.
+- Puzzle rooms where camera direction and cooperative watching matter.
+
+## The Master and Other Time Lord Antagonists
+
+### Lore Essentials
+- The Master mirrors the Doctor: similar capabilities, opposite ethics.
+- Recurrent themes: manipulation, identity games, long plans.
+- Time Lord antagonists often use social engineering, not brute force.
+
+### Design Translation
+- Add deception mechanics (false signals, disguised objectives, misinformation devices).
+- Include multi-stage quest lines with reveal moments.
+- Avoid one-note boss fights; prefer narrative/systemic misdirection.
+
+### Good DWM Feature Seeds
+- "Signal hijack" event where UI hints become unreliable until fixed.
+- Multi-step investigation chain ending in antagonist reveal.
+- Rival Time Lord device that competes with player TARDIS controls.
+
+## Recurring Threat Pattern Template (Agent Shortcut)
+
+When turning any villain into a feature, ensure all four are present:
+1. **Identity:** instantly recognizable behavior/audio.
+2. **Constraint:** a rule the player must respect.
+3. **Counterplay:** at least one tool-based response.
+4. **Narrative hook:** why this threat appears in this location/story beat.

--- a/docs/lore/tardis-and-time-travel-rules.md
+++ b/docs/lore/tardis-and-time-travel-rules.md
@@ -1,0 +1,52 @@
+# TARDIS and Time Travel Rules
+
+See also: [Lore Index](./index.md), [Feature: TARDIS Exterior Block](../feature-tardis-block.md), [Feature: TARDIS Chameleon System](../feature-chameleon-system.md)
+
+## Canon Core
+
+- **TARDIS** stands for Time And Relative Dimension In Space.
+- It is a sentient/semi-sentient time machine and spacecraft associated with Time Lords.
+- The Doctor's TARDIS is famously stuck as a 1960s blue British police box due to a **faulty chameleon circuit**.
+- TARDIS interiors are "bigger on the inside," supporting impossible internal spaces.
+
+## High-Signal Lore Rules for Gameplay Design
+
+1. **Identity over realism:** The police box silhouette is iconic and should remain central.
+2. **Travel has constraints:** Time travel is powerful but not consequence-free; stories emphasize tradeoffs and danger.
+3. **Control instability is thematic:** The Doctor often struggles with precise control, creating unpredictability.
+4. **The TARDIS has agency:** It can be treated as more than a passive vehicle/UI shell.
+
+## Chameleon Circuit Guidance
+
+- Canonically, the chameleon circuit is for camouflage in local contexts.
+- In DWM terms, variant swapping should feel like:
+  - expressive customization,
+  - a meaningful decision (not random skin spam),
+  - and still readable to other players.
+- Keep "blue box default" as a first-class state even if many variants are available.
+
+## Time Travel Constraints Worth Emulating
+
+- **Fixed points:** some events should resist change.
+- **Paradox risk:** careless time manipulation has consequences.
+- **Limited precision:** arrival location/time can be imperfect.
+
+For Minecraft-friendly design, implement these as bounded mechanics:
+- cooldowns,
+- fuel/resource costs,
+- destination inaccuracies,
+- progression gates.
+
+## Agent Checklist: TARDIS Suggestions
+
+When suggesting TARDIS improvements/new systems, validate:
+- Is the blue-box identity preserved?
+- Is power balanced by clear constraints?
+- Is interaction feedback immediate (sound, particles, states)?
+- Can it be explained in under 3 UI/tooltips?
+
+## Example Idea Seeds (Lore-Aligned)
+
+- **Current-feature improvement:** Better chameleon UI preview and revert option to prevent accidental identity loss.
+- **New feature:** "Unstable hop" travel mode with slight destination jitter but lower resource cost.
+- **New feature:** "Fixed-point lock" destinations that cannot be overwritten once discovered.

--- a/docs/lore/the-doctor-and-regeneration.md
+++ b/docs/lore/the-doctor-and-regeneration.md
@@ -1,0 +1,42 @@
+# The Doctor and Regeneration
+
+## Core Lore
+
+- The Doctor is a Time Lord from Gallifrey who travels in the TARDIS.
+- The central character identity is stable (values, memories, mission), but personality and style shift across incarnations.
+- Regeneration allows body/personality renewal after lethal damage or biological limits.
+- The show frequently uses "same person, different expression" as the emotional core of change.
+
+## Canon-Safe Principles for Gameplay
+
+- **Identity continuity:** progression and ownership should persist through major state changes.
+- **Behavioral variation:** variants can emphasize different interaction styles (technical, diplomatic, eccentric) without invalidating existing progress.
+- **Costed transformation:** major form changes should have meaningful triggers/cooldowns, not be free cosmetic spam.
+
+## DWM Translation Heuristics
+
+Use regeneration-inspired design for systems where players expect change without reset:
+
+- TARDIS personalization profiles.
+- Sonic screwdriver "persona" loadouts.
+- Cosmetic skin swaps tied to milestones.
+
+## Suggestions for Existing Features
+
+### Sonic Screwdrivers
+- Add optional "incarnation profiles" per sonic model with tiny behavior flavor (sound set, particle color, UI text tone), while keeping functional parity for balance.
+- Track a "stability" or "charge cycle" meter to create a light rhythm of use/recovery.
+
+### TARDIS Exterior / Chameleon
+- Preserve TARDIS UUID and ownership across all chameleon changes to reflect continuity-through-change.
+- Provide a one-click "revert to default police box" action as an in-world identity anchor.
+
+## New Feature Seeds
+
+- **Regeneration Echo:** when a player upgrades a sonic or TARDIS tier, show a short audiovisual transition and preserve stored settings.
+- **Legacy Traits:** unlock cosmetic-only traits from prior milestone choices, reinforcing that history matters.
+
+## Anti-Patterns
+
+- Do not treat regeneration as random reroll chaos; it should be dramatic but legible.
+- Do not make players lose core progression when changing form/variant.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- AI-assisted feature planning for DWM needs a shared, canon-aware Doctor Who context so suggestions stay recognizable, useful, and aligned with the mod identity.
- A structured lore reference reduces low-value fan-service ideas and improves consistency when proposing improvements to existing systems (sonic, TARDIS, chameleon).

## Proposed Implementation

- Added a new `docs/lore/` knowledge base with topic-focused markdown files:
  - `index.md`
  - `the-doctor-and-regeneration.md`
  - `tardis-and-time-travel-rules.md`
  - `gallifrey-and-time-lords.md`
  - `companions-unit-and-earth.md`
  - `major-villains-and-threat-patterns.md`
  - `eras-tone-and-continuity.md`
  - `feature-ideation-playbook.md`
- Linked the lore section from `docs/index.md` under a dedicated "Lore Knowledge Base (AI Agent Context)" heading.
- Documented canon guidance, gameplay translation heuristics, ideation guardrails, and a quality checklist to help agents map lore to actionable mod improvements.

## Problems Encountered / Decisions Made

- Decision: prioritized broad TV-canon concepts and high-legibility references over deep-cut continuity to keep docs practical for feature ideation.
- Decision: kept this as documentation-only scope (no gameplay/code changes) and emphasized ties to already documented DWM features.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-29ee98ea-2841-4030-802b-4e9157fa5572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-29ee98ea-2841-4030-802b-4e9157fa5572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

