### PR TITLE
fix(boti): render First Doctor console in exterior preview

### DIFF
--- a/src/client/java/com/adamkali/dwm/render/boti/BotiInteriorMeshCache.java
+++ b/src/client/java/com/adamkali/dwm/render/boti/BotiInteriorMeshCache.java
@@ -1,5 +1,7 @@
 package com.adamkali.dwm.render.boti;
 
+import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.network.RequestBotiInteriorC2SPayload;
 import com.adamkali.dwm.render.boti.BotiEntityMotion.EntityInterpState;
 import com.adamkali.dwm.render.boti.BotiEntityMotion.LerpedPose;
@@ -39,15 +41,18 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Per-TARDIS BOTI placement cache. Prefers synced live snapshots (blocks + BE NBT + entities);
- * falls back to the First Doctor blueprint until a snapshot arrives.
+ * falls back to the First Doctor blueprint (blocks + synthetic console BE) until a snapshot arrives.
  */
 public final class BotiInteriorMeshCache {
     private static final long REQUEST_COOLDOWN_MS = 2000L;
     private static final String PLAYER_ENTITY_ID = "minecraft:player";
+    /** Local console position in {@link FirstDoctorConsoleRoomLayout}. */
+    private static final BlockPos BLUEPRINT_CONSOLE_POS = new BlockPos(5, 1, 5);
 
     private static final Map<UUID, CachedSnapshot> SNAPSHOTS = new ConcurrentHashMap<>();
     private static final Map<UUID, Long> LAST_REQUEST_MS = new ConcurrentHashMap<>();
     private static Map<BlockPos, BlockState> blueprintFallback = Map.of();
+    private static List<BlockEntity> blueprintBlockEntities;
 
     private BotiInteriorMeshCache() {
     }
@@ -91,7 +96,7 @@ public final class BotiInteriorMeshCache {
         }
         CachedSnapshot cached = SNAPSHOTS.get(tardisId);
         if (cached == null) {
-            return List.of();
+            return blueprintBlockEntities();
         }
         if (!cached.renderedBlockEntities().isEmpty()) {
             return cached.renderedBlockEntities();
@@ -200,6 +205,7 @@ public final class BotiInteriorMeshCache {
         SNAPSHOTS.clear();
         LAST_REQUEST_MS.clear();
         blueprintFallback = Map.of();
+        blueprintBlockEntities = null;
     }
 
     public static void render(
@@ -490,6 +496,21 @@ public final class BotiInteriorMeshCache {
             blueprintFallback = Map.copyOf(FirstDoctorConsoleRoomLayout.botiVisiblePlacements());
         }
         return blueprintFallback;
+    }
+
+    /**
+     * Synthetic BER targets for the blueprint fallback (First Doctor console at room center).
+     */
+    private static List<BlockEntity> blueprintBlockEntities() {
+        if (blueprintBlockEntities == null) {
+            BlockState state = FirstDoctorConsoleRoomLayout.placements().get(BLUEPRINT_CONSOLE_POS);
+            if (state != null && state.isOf(DWMBlocks.FIRST_DOCTOR_CONSOLE)) {
+                blueprintBlockEntities = List.of(new FirstDoctorConsoleBlockEntity(BLUEPRINT_CONSOLE_POS, state));
+            } else {
+                blueprintBlockEntities = List.of();
+            }
+        }
+        return blueprintBlockEntities;
     }
 
     private record ReconcileResult(List<Entity> entities, Map<UUID, EntityInterpState> interp) {

--- a/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -48,13 +48,16 @@ public final class BotiInteriorSampler {
     private BotiInteriorSampler() {
     }
 
-    /** Whether a block should appear in the exterior BOTI preview. */
+    /**
+     * Whether a block should appear in the exterior BOTI preview.
+     * Interior doors stay excluded (no dedicated interior-door BER in BOTI yet).
+     * The First Doctor console is included so its BER can draw via synced BE NBT.
+     */
     public static boolean isBotiVisible(BlockState state) {
         return state != null
                 && !state.isAir()
                 && !state.isOf(Blocks.LIGHT)
-                && !state.isOf(DWMBlocks.TARDIS_INTERIOR_DOOR)
-                && !state.isOf(DWMBlocks.FIRST_DOCTOR_CONSOLE);
+                && !state.isOf(DWMBlocks.TARDIS_INTERIOR_DOOR);
     }
 
     /**
@@ -92,7 +95,8 @@ public final class BotiInteriorSampler {
     }
 
     /**
-     * Samples chunk-sync NBT for block entities in the footprint (interior doors excluded).
+     * Samples chunk-sync NBT for block entities in the footprint
+     * ({@link #isBotiVisible} — interior doors excluded).
      * Each compound includes the BE type {@code id} for client reconstruction.
      */
     public static Map<BlockPos, NbtCompound> sampleBlockEntities(ServerWorld interiorWorld, UUID tardisId) {

--- a/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomLayout.java
+++ b/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomLayout.java
@@ -40,7 +40,8 @@ public final class FirstDoctorConsoleRoomLayout {
     }
 
     /**
-     * Blocks that should be tessellated for the exterior BOTI preview (no air/light/door slabs).
+     * Blocks that should appear in the exterior BOTI preview (no air/light/interior doors).
+     * Includes the First Doctor console (INVISIBLE + BER).
      */
     public static Map<BlockPos, BlockState> botiVisiblePlacements() {
         return BotiInteriorSampler.filterVisible(placements());

--- a/src/test/java/com/adamkali/dwm/render/boti/BotiInteriorMeshCacheTest.java
+++ b/src/test/java/com/adamkali/dwm/render/boti/BotiInteriorMeshCacheTest.java
@@ -2,11 +2,13 @@ package com.adamkali.dwm.render.boti;
 
 import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.tardis.boti.BotiEntitySample;
 import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
+import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.ChestBlockEntity;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.registry.BuiltinRegistries;
@@ -42,6 +44,19 @@ class BotiInteriorMeshCacheTest {
         UUID id = UUID.randomUUID();
         Map<BlockPos, BlockState> visible = BotiInteriorMeshCache.getVisibleBlocks(id);
         assertEquals(FirstDoctorConsoleRoomLayout.botiVisiblePlacements(), visible);
+        assertFalse(BotiInteriorMeshCache.hasSnapshot(id));
+        assertTrue(visible.containsKey(new BlockPos(5, 1, 5)));
+        assertEquals(DWMBlocks.FIRST_DOCTOR_CONSOLE, visible.get(new BlockPos(5, 1, 5)).getBlock());
+    }
+
+    @Test
+    void getBlockEntities_FallsBackToBlueprintConsoleWithoutSnapshot() {
+        UUID id = UUID.randomUUID();
+        List<BlockEntity> entities = BotiInteriorMeshCache.getBlockEntities(id);
+        assertEquals(1, entities.size());
+        BlockEntity be = entities.getFirst();
+        assertInstanceOf(FirstDoctorConsoleBlockEntity.class, be);
+        assertEquals(new BlockPos(5, 1, 5), be.getPos());
         assertFalse(BotiInteriorMeshCache.hasSnapshot(id));
     }
 

--- a/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
@@ -34,7 +34,7 @@ class BotiInteriorSamplerTest {
     }
 
     @Test
-    void filterVisible_excludesAirLightInteriorDoorAndConsole() {
+    void filterVisible_excludesAirLightAndInteriorDoorIncludesConsole() {
         Map<BlockPos, BlockState> input = new HashMap<>();
         input.put(new BlockPos(0, 0, 0), DWMBlocks.WHITE_TARDIS_WALL.getDefaultState());
         input.put(new BlockPos(1, 0, 0), Blocks.AIR.getDefaultState());
@@ -44,8 +44,9 @@ class BotiInteriorSamplerTest {
 
         Map<BlockPos, BlockState> visible = BotiInteriorSampler.filterVisible(input);
 
-        assertEquals(1, visible.size());
+        assertEquals(2, visible.size());
         assertTrue(visible.containsKey(new BlockPos(0, 0, 0)));
+        assertTrue(visible.containsKey(new BlockPos(4, 0, 0)));
     }
 
     @Test
@@ -70,9 +71,9 @@ class BotiInteriorSamplerTest {
     }
 
     @Test
-    void isBotiVisible_excludesInteriorDoorAndConsoleIncludesChest() {
+    void isBotiVisible_excludesInteriorDoorIncludesConsoleAndChest() {
         assertFalse(BotiInteriorSampler.isBotiVisible(DWMBlocks.TARDIS_INTERIOR_DOOR.getDefaultState()));
-        assertFalse(BotiInteriorSampler.isBotiVisible(DWMBlocks.FIRST_DOCTOR_CONSOLE.getDefaultState()));
+        assertTrue(BotiInteriorSampler.isBotiVisible(DWMBlocks.FIRST_DOCTOR_CONSOLE.getDefaultState()));
         assertTrue(BotiInteriorSampler.isBotiVisible(Blocks.CHEST.getDefaultState()));
         assertFalse(BotiInteriorSampler.isBotiVisible(Blocks.LIGHT.getDefaultState()));
     }

--- a/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
@@ -103,7 +103,8 @@ class TardisInteriorUnitTest {
         assertTrue(placements.get(new BlockPos(5, 2, 5)).isAir(), "no stacked roundel above console");
 
         Map<BlockPos, BlockState> boti = FirstDoctorConsoleRoomLayout.botiVisiblePlacements();
-        assertFalse(boti.containsKey(consolePos), "console must be excluded from BOTI tessellation");
+        assertEquals(DWMBlocks.FIRST_DOCTOR_CONSOLE, boti.get(consolePos).getBlock(),
+                "console must be included in BOTI so its BER can draw");
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Looking through open TARDIS doors should show the First Doctor console in the BOTI interior preview; without it the room looks empty at the center.

## Proposed Implementation

- Include `FIRST_DOCTOR_CONSOLE` in `BotiInteriorSampler.isBotiVisible()` so live snapshots sync block state and BE NBT (interior doors remain excluded).
- Inject a synthetic `FirstDoctorConsoleBlockEntity` at `(5, 1, 5)` in `BotiInteriorMeshCache` blueprint fallback so the BER draws before a snapshot arrives.
- Update sampler/layout/mesh-cache unit tests to expect the console in BOTI.

## Problems Encountered / Decisions Made

- Left interior doors excluded from BOTI (existing docs note; out of scope for this fix).

Made with [Cursor](https://cursor.com)