### PR TITLE
fix(console): render First Doctor console with translucent layer

### DIFF
--- a/src/client/java/com/adamkali/dwm/render/FirstDoctorConsoleBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/FirstDoctorConsoleBlockEntityRenderer.java
@@ -53,7 +53,7 @@ public class FirstDoctorConsoleBlockEntityRenderer implements BlockEntityRendere
         matrices.push();
         applyTransforms(matrices, facing);
         VertexConsumer consoleVertices = vertexConsumers.getBuffer(
-                RenderLayer.getEntityCutout(FirstDoctorConsoleModel.TEXTURE_LOCATION));
+                RenderLayer.getEntityTranslucent(FirstDoctorConsoleModel.TEXTURE_LOCATION));
         model.render(matrices, consoleVertices, light, overlay);
 
         matrices.push();


### PR DESCRIPTION
## Why this matters

- The First Doctor console time-rotor glass uses semi-transparent texture pixels, but cutout rendering drew them fully opaque, so the glass column never looked see-through.

## Proposed Implementation

- Switch the console mesh buffer in `FirstDoctorConsoleBlockEntityRenderer` from `RenderLayer.getEntityCutout` to `RenderLayer.getEntityTranslucent`.
- Leave biome selector and materialisation lever on cutout.
- Validated with `./gradlew compileClientJava`. Manual in-game check: glass column should alpha-blend.

## Problems Encountered / Decisions Made

- Whole console mesh uses translucent (minimal fix). Split opaque/glass draw passes only if sorting artifacts appear later.
- No automated test — render-layer choice is client visual behavior.

Made with [Cursor](https://cursor.com)