### PR TITLE
feat(console): prevent players from breaking the First Doctor console

### DIFF
--- a/src/main/java/com/adamkali/dwm/block/DWMBlocks.java
+++ b/src/main/java/com/adamkali/dwm/block/DWMBlocks.java
@@ -1,5 +1,7 @@
 package com.adamkali.dwm.block;
 
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
 import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
 import net.minecraft.block.AbstractBlock;
 import net.minecraft.block.Block;
@@ -10,6 +12,7 @@ import net.minecraft.registry.Registries;
 import net.minecraft.registry.Registry;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.registry.RegistryKeys;
+import net.minecraft.util.ActionResult;
 import net.minecraft.util.Identifier;
 
 import java.util.function.Function;
@@ -132,6 +135,16 @@ public class DWMBlocks {
     public static final Block TARDIS_DOOR_BUTTON = register(TardisButtonBlock::new, DWMBlockSettings.BUTTON_SETTINGS, "tardis_door_button");
 
     public static void initialize() {
+        PlayerBlockBreakEvents.BEFORE.register((world, player, pos, state, blockEntity) ->
+                !FirstDoctorConsoleBlock.isPlayerBreakDenied(state));
+
+        AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+            if (FirstDoctorConsoleBlock.isPlayerBreakDenied(world.getBlockState(pos))) {
+                return ActionResult.FAIL;
+            }
+            return ActionResult.PASS;
+        });
+
         ItemGroupEvents.modifyEntriesEvent(ItemGroups.BUILDING_BLOCKS).register(content -> {
             content.add(BLACK_ROUNDEL_A);
             content.add(BLUE_ROUNDEL_A);

--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
@@ -55,6 +55,11 @@ public class FirstDoctorConsoleBlock extends BlockWithEntity {
         this.setDefaultState(this.stateManager.getDefaultState().with(FACING, Direction.NORTH));
     }
 
+    /** True when players must not break this block (survival or creative left-click). */
+    public static boolean isPlayerBreakDenied(BlockState state) {
+        return state.isOf(DWMBlocks.FIRST_DOCTOR_CONSOLE);
+    }
+
     @Override
     protected MapCodec<FirstDoctorConsoleBlock> getCodec() {
         return CODEC;

--- a/src/test/java/com/adamkali/dwm/block/FirstDoctorConsoleBlockTest.java
+++ b/src/test/java/com/adamkali/dwm/block/FirstDoctorConsoleBlockTest.java
@@ -1,0 +1,29 @@
+package com.adamkali.dwm.block;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import net.minecraft.block.Blocks;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FirstDoctorConsoleBlockTest {
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+    }
+
+    @Test
+    void isPlayerBreakDenied_trueForConsole() {
+        assertTrue(FirstDoctorConsoleBlock.isPlayerBreakDenied(
+                DWMBlocks.FIRST_DOCTOR_CONSOLE.getDefaultState()));
+    }
+
+    @Test
+    void isPlayerBreakDenied_falseForOtherBlocks() {
+        assertFalse(FirstDoctorConsoleBlock.isPlayerBreakDenied(Blocks.STONE.getDefaultState()));
+        assertFalse(FirstDoctorConsoleBlock.isPlayerBreakDenied(
+                DWMBlocks.WHITE_TARDIS_WALL.getDefaultState()));
+    }
+}


### PR DESCRIPTION
## Why this matters

- The First Doctor console is a core interior fixture; players should not be able to destroy it in survival or creative and break the TARDIS interior.

## Proposed Implementation

- Keep existing bedrock-like hardness for survival mining.
- Register `PlayerBlockBreakEvents.BEFORE` and `AttackBlockCallback` to deny console breaks/attacks in both game modes.
- Add `FirstDoctorConsoleBlock.isPlayerBreakDenied` helper with unit coverage.

## Problems Encountered / Decisions Made

- Scoped to the First Doctor console only (exterior shell and interior doors unchanged).
- Commands and structure placement remain unaffected.

Made with [Cursor](https://cursor.com)