### PR TITLE
docs(agents): add Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,14 @@ After creating or updating a pull request, apply the appropriate label(s) using 
 - **`bug`** — the PR fixes a defect / unintended behaviour
 
 A single PR may carry more than one label if it touches multiple categories.
+
+## Cursor Cloud specific instructions
+
+These notes are for agents running in the Cursor Cloud VM. The standard build/test/datagen commands are already documented above (`./gradlew build`, `./gradlew test`, `./gradlew runDatagen`); this section only captures non-obvious environment caveats.
+
+- Java 21 is preinstalled and is what Gradle uses (`./gradlew` picks up the system JDK; no `JAVA_HOME` tweaking needed).
+- The startup update script runs `./gradlew dependencies -q`, which resolves all configurations and lets Fabric Loom provision Minecraft, Yarn mappings, and remap the mod dependencies. The very first Loom configuration on a cold cache is slow and network-heavy (it decompiles Minecraft and remaps ~50 mods from `maven.fabricmc.net`, `maven.shedaniel.me`, `maven.terraformersmc.com`, and Maven Central); once cached, subsequent Gradle invocations are fast.
+- Running the mod end-to-end without a display: use `./gradlew runGametest`. This boots a real headless Minecraft server, loads the mod, and executes the registered in-world Fabric GameTests (TARDIS door/interior flows and chameleon networking). It is the best headless smoke test of core gameplay.
+- `./gradlew runClient` and `./gradlew runServer` start the actual game; `runClient` needs a GUI/display and will not work in the headless VM. Prefer `runGametest` for automated verification.
+- `./gradlew build` also compiles the `client` source set and runs the full JUnit suite (currently 186 tests), so a green `build` covers both compile and unit-test confidence.
+- `./gradlew runDatagen` writes generated resources under `src/main/generated/` and also leaves an untracked `src/main/generated/.cache/` directory — delete that `.cache` dir before committing to avoid stray churn.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Future Cursor Cloud agents need a reliable, documented way to spin up and verify this Fabric mod without re-discovering headless-run caveats each time. This captures the non-obvious environment details so agents can build, test, and run the mod immediately.

## Proposed Implementation

- Add a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering: Java 21 is preinstalled, the startup dependency-refresh command (`./gradlew dependencies -q`), the cold-cache Loom provisioning cost, how to run the mod end-to-end headlessly via `./gradlew runGametest` (vs `runClient` which needs a display), that `./gradlew build` also runs the 186-test JUnit suite, and the untracked `.cache` churn from `runDatagen`.
- No source or dependency changes; docs only.

## Problems Encountered / Decisions Made

- `runClient` cannot run in the headless VM (no display), so `runGametest` is documented as the automated end-to-end smoke test. It boots a real Minecraft server and passes all 6 in-world GameTests.
- Chose `./gradlew dependencies -q` as the update script because it resolves all configurations and triggers Loom setup without compiling repo source, keeping startup robust to in-flight code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4fd2fab-b15a-4be6-83b6-6e4623f1e64d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4fd2fab-b15a-4be6-83b6-6e4623f1e64d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

