### PR TITLE
fix(datagen): self-drop loot tables for existing blocks

### DIFF
--- a/src/client/java/com/adamkali/dwm/DWMClientDataGenerator.java
+++ b/src/client/java/com/adamkali/dwm/DWMClientDataGenerator.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm;
 import com.adamkali.dwm.datagen.DWMBlockTagProvider;
 import com.adamkali.dwm.datagen.DWMItemTagProvider;
 import com.adamkali.dwm.datagen.DWMLanguageProvider;
+import com.adamkali.dwm.datagen.DWMLootTableProvider;
 import com.adamkali.dwm.datagen.DWMModelProvider;
 import com.adamkali.dwm.datagen.DWMRecipeProvider;
 import com.adamkali.dwm.item.DWMItemTags;
@@ -41,6 +42,7 @@ public class DWMClientDataGenerator implements DataGeneratorEntrypoint {
         DWMBlockTagProvider blockTagProvider = pack.addProvider(DWMBlockTagProvider::new);
         pack.addProvider((output, registries) -> new DWMItemTagProvider(output, registries, blockTagProvider));
         pack.addProvider(DWMModelProvider::new);
+        pack.addProvider(DWMLootTableProvider::new);
     }
 
     static class AdvancementsProvider extends FabricAdvancementProvider {

--- a/src/main/generated/data/dwm/loot_table/blocks/black_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/black_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:black_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/black_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/black_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:black_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/black_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/black_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:black_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/black_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/black_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:black_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/black_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/black_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:black_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/black_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/black_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:black_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/blue_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/blue_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:blue_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/blue_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/blue_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:blue_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/blue_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/blue_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:blue_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/blue_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/blue_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:blue_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/blue_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/blue_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:blue_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/blue_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/blue_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:blue_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/brown_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/brown_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:brown_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/brown_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/brown_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:brown_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/brown_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/brown_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:brown_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/brown_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/brown_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:brown_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/brown_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/brown_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:brown_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/brown_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/brown_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:brown_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/chiseled_gallifrey_stone_bricks.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/chiseled_gallifrey_stone_bricks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:chiseled_gallifrey_stone_bricks"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cracked_gallifrey_stone_bricks.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cracked_gallifrey_stone_bricks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cracked_gallifrey_stone_bricks"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cyan_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cyan_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cyan_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cyan_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cyan_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cyan_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cyan_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cyan_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cyan_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cyan_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cyan_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cyan_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cyan_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cyan_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cyan_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/cyan_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/cyan_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:cyan_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_chiseled_sandstone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_chiseled_sandstone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_chiseled_sandstone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_coarse_dirt.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_coarse_dirt.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_coarse_dirt"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_cobblestone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_cobblestone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_cobblestone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_cut_sandstone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_cut_sandstone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_cut_sandstone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_dirt.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_dirt.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_dirt"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_mossy_cobblestone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_mossy_cobblestone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_mossy_cobblestone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_sand.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_sand.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_sand"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_sandstone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_sandstone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_sandstone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_smooth_stone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_smooth_stone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_smooth_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_stone.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_stone.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_stone"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gallifrey_stone_bricks.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gallifrey_stone_bricks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gallifrey_stone_bricks"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gray_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gray_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gray_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gray_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gray_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gray_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gray_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gray_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gray_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gray_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gray_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gray_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gray_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gray_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gray_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/gray_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/gray_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:gray_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/green_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/green_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:green_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/green_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/green_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:green_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/green_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/green_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:green_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/green_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/green_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:green_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/green_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/green_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:green_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/green_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/green_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:green_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_blue_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_blue_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_blue_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_blue_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_blue_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_blue_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_blue_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_blue_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_blue_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_blue_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_blue_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_blue_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_blue_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_blue_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_blue_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_blue_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_blue_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_blue_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_gray_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_gray_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_gray_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_gray_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_gray_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_gray_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_gray_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_gray_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_gray_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_gray_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_gray_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_gray_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_gray_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_gray_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_gray_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/light_gray_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/light_gray_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:light_gray_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/lime_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/lime_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:lime_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/lime_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/lime_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:lime_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/lime_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/lime_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:lime_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/lime_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/lime_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:lime_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/lime_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/lime_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:lime_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/lime_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/lime_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:lime_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/magenta_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/magenta_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:magenta_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/magenta_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/magenta_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:magenta_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/magenta_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/magenta_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:magenta_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/magenta_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/magenta_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:magenta_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/magenta_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/magenta_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:magenta_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/magenta_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/magenta_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:magenta_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/mossy_gallifrey_stone_bricks.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/mossy_gallifrey_stone_bricks.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:mossy_gallifrey_stone_bricks"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/orange_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/orange_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:orange_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/orange_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/orange_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:orange_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/orange_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/orange_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:orange_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/orange_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/orange_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:orange_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/orange_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/orange_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:orange_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/orange_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/orange_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:orange_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/pink_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/pink_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:pink_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/pink_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/pink_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:pink_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/pink_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/pink_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:pink_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/pink_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/pink_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:pink_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/pink_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/pink_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:pink_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/pink_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/pink_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:pink_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/purple_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/purple_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:purple_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/purple_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/purple_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:purple_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/purple_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/purple_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:purple_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/purple_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/purple_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:purple_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/purple_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/purple_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:purple_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/purple_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/purple_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:purple_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/red_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/red_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:red_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/red_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/red_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:red_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/red_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/red_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:red_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/red_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/red_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:red_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/red_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/red_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:red_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/red_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/red_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:red_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/tardis_door_button.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/tardis_door_button.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:tardis_door_button"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/teal_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/teal_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:teal_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/teal_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/teal_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:teal_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/teal_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/teal_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:teal_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/teal_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/teal_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:teal_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/teal_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/teal_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:teal_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/teal_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/teal_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:teal_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/white_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/white_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:white_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/white_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/white_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:white_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/white_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/white_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:white_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/white_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/white_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:white_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/white_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/white_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:white_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/white_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/white_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:white_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/yellow_big_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/yellow_big_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:yellow_big_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/yellow_big_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/yellow_big_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:yellow_big_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/yellow_chronoplasm_powder.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/yellow_chronoplasm_powder.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:yellow_chronoplasm_powder"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/yellow_roundel_a.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/yellow_roundel_a.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:yellow_roundel_a"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/yellow_roundel_b.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/yellow_roundel_b.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:yellow_roundel_b"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/loot_table/blocks/yellow_tardis_wall.json
+++ b/src/main/generated/data/dwm/loot_table/blocks/yellow_tardis_wall.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "dwm:yellow_tardis_wall"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/java/com/adamkali/dwm/datagen/DWMLootTableProvider.java
+++ b/src/main/java/com/adamkali/dwm/datagen/DWMLootTableProvider.java
@@ -1,0 +1,138 @@
+package com.adamkali.dwm.datagen;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import net.fabricmc.fabric.api.datagen.v1.FabricDataOutput;
+import net.fabricmc.fabric.api.datagen.v1.provider.FabricBlockLootTableProvider;
+import net.minecraft.block.Block;
+import net.minecraft.registry.RegistryWrapper;
+
+import java.util.concurrent.CompletableFuture;
+
+public class DWMLootTableProvider extends FabricBlockLootTableProvider {
+    public DWMLootTableProvider(FabricDataOutput dataOutput, CompletableFuture<RegistryWrapper.WrapperLookup> registryLookup) {
+        super(dataOutput, registryLookup);
+    }
+
+    @Override
+    public void generate() {
+        for (Block block : DWMBlocks.GALLIFREY_STONE_FAMILY) {
+            addDrop(block);
+        }
+
+        // Existing building blocks that previously had no loot tables.
+        addDrop(DWMBlocks.BLACK_ROUNDEL_A);
+        addDrop(DWMBlocks.BLUE_ROUNDEL_A);
+        addDrop(DWMBlocks.BROWN_ROUNDEL_A);
+        addDrop(DWMBlocks.CYAN_ROUNDEL_A);
+        addDrop(DWMBlocks.GREEN_ROUNDEL_A);
+        addDrop(DWMBlocks.LIGHT_BLUE_ROUNDEL_A);
+        addDrop(DWMBlocks.LIGHT_GRAY_ROUNDEL_A);
+        addDrop(DWMBlocks.LIME_ROUNDEL_A);
+        addDrop(DWMBlocks.MAGENTA_ROUNDEL_A);
+        addDrop(DWMBlocks.ORANGE_ROUNDEL_A);
+        addDrop(DWMBlocks.PINK_ROUNDEL_A);
+        addDrop(DWMBlocks.RED_ROUNDEL_A);
+        addDrop(DWMBlocks.WHITE_ROUNDEL_A);
+        addDrop(DWMBlocks.YELLOW_ROUNDEL_A);
+        addDrop(DWMBlocks.GRAY_ROUNDEL_A);
+        addDrop(DWMBlocks.PURPLE_ROUNDEL_A);
+        addDrop(DWMBlocks.TEAL_ROUNDEL_A);
+
+        addDrop(DWMBlocks.BLACK_ROUNDEL_B);
+        addDrop(DWMBlocks.BLUE_ROUNDEL_B);
+        addDrop(DWMBlocks.BROWN_ROUNDEL_B);
+        addDrop(DWMBlocks.CYAN_ROUNDEL_B);
+        addDrop(DWMBlocks.GREEN_ROUNDEL_B);
+        addDrop(DWMBlocks.LIGHT_BLUE_ROUNDEL_B);
+        addDrop(DWMBlocks.LIGHT_GRAY_ROUNDEL_B);
+        addDrop(DWMBlocks.LIME_ROUNDEL_B);
+        addDrop(DWMBlocks.MAGENTA_ROUNDEL_B);
+        addDrop(DWMBlocks.ORANGE_ROUNDEL_B);
+        addDrop(DWMBlocks.PINK_ROUNDEL_B);
+        addDrop(DWMBlocks.RED_ROUNDEL_B);
+        addDrop(DWMBlocks.WHITE_ROUNDEL_B);
+        addDrop(DWMBlocks.YELLOW_ROUNDEL_B);
+        addDrop(DWMBlocks.GRAY_ROUNDEL_B);
+        addDrop(DWMBlocks.PURPLE_ROUNDEL_B);
+        addDrop(DWMBlocks.TEAL_ROUNDEL_B);
+
+        addDrop(DWMBlocks.BLACK_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.BLUE_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.BROWN_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.CYAN_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.GREEN_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.LIGHT_BLUE_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.LIGHT_GRAY_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.LIME_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.MAGENTA_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.ORANGE_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.PINK_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.RED_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.WHITE_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.YELLOW_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.GRAY_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.PURPLE_BIG_ROUNDEL_A);
+        addDrop(DWMBlocks.TEAL_BIG_ROUNDEL_A);
+
+        addDrop(DWMBlocks.BLACK_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.BLUE_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.BROWN_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.CYAN_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.GREEN_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.LIGHT_BLUE_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.LIGHT_GRAY_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.LIME_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.MAGENTA_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.ORANGE_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.PINK_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.RED_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.WHITE_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.YELLOW_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.GRAY_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.PURPLE_BIG_ROUNDEL_B);
+        addDrop(DWMBlocks.TEAL_BIG_ROUNDEL_B);
+
+        addDrop(DWMBlocks.BLACK_TARDIS_WALL);
+        addDrop(DWMBlocks.BLUE_TARDIS_WALL);
+        addDrop(DWMBlocks.BROWN_TARDIS_WALL);
+        addDrop(DWMBlocks.CYAN_TARDIS_WALL);
+        addDrop(DWMBlocks.GREEN_TARDIS_WALL);
+        addDrop(DWMBlocks.LIGHT_BLUE_TARDIS_WALL);
+        addDrop(DWMBlocks.LIGHT_GRAY_TARDIS_WALL);
+        addDrop(DWMBlocks.LIME_TARDIS_WALL);
+        addDrop(DWMBlocks.MAGENTA_TARDIS_WALL);
+        addDrop(DWMBlocks.ORANGE_TARDIS_WALL);
+        addDrop(DWMBlocks.PINK_TARDIS_WALL);
+        addDrop(DWMBlocks.RED_TARDIS_WALL);
+        addDrop(DWMBlocks.WHITE_TARDIS_WALL);
+        addDrop(DWMBlocks.YELLOW_TARDIS_WALL);
+        addDrop(DWMBlocks.GRAY_TARDIS_WALL);
+        addDrop(DWMBlocks.PURPLE_TARDIS_WALL);
+        addDrop(DWMBlocks.TEAL_TARDIS_WALL);
+
+        addDrop(DWMBlocks.BLACK_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.BLUE_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.BROWN_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.CYAN_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.GREEN_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.LIGHT_BLUE_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.LIGHT_GRAY_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.LIME_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.MAGENTA_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.ORANGE_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.PINK_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.RED_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.WHITE_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.YELLOW_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.GRAY_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.PURPLE_CHRONOPLASM_POWDER);
+        addDrop(DWMBlocks.TEAL_CHRONOPLASM_POWDER);
+
+        addDrop(DWMBlocks.TARDIS_DOOR_BUTTON);
+
+        // Unbreakable / special blocks: empty drops, excluded from strict validation if needed.
+        excludeFromStrictValidation(DWMBlocks.TARDIS_BLOCK);
+        excludeFromStrictValidation(DWMBlocks.TARDIS_INTERIOR_DOOR);
+        excludeFromStrictValidation(DWMBlocks.FIRST_DOCTOR_CONSOLE);
+    }
+}


### PR DESCRIPTION
## Why this matters

- Existing building blocks (roundels, TARDIS walls, chronoplasm powder, Gallifrey stone family, door button) previously had no loot tables and dropped nothing when broken in survival.
- Establishes the Fabric block loot-table datagen provider so later wood/building PRs can extend it instead of inventing a parallel path.

## Proposed Implementation

- Add `DWMLootTableProvider` with self-drops for Gallifrey stone family and existing colored building blocks; exclude unbreakable/special blocks from strict validation.
- Register the provider in `DWMClientDataGenerator`.
- Commit generated loot JSON under `src/main/generated/data/dwm/loot_table/blocks/`.

## Problems Encountered / Decisions Made

- Split out of #73 so ash wood review is not buried under ~117 unrelated loot-table files.