### PR TITLE
feat(ci): manual Create Release Tag workflow from version.json

### DIFF
--- a/.github/workflows/create-release-tag.yml
+++ b/.github/workflows/create-release-tag.yml
@@ -1,0 +1,76 @@
+name: Create Release Tag
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve tag from version.json
+        id: resolve
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = json.loads(Path("version.json").read_text(encoding="utf-8"))
+          latest = (root.get("promos") or {}).get("latest")
+          if not latest or not isinstance(latest, str):
+              raise SystemExit("version.json promos.latest is missing or not a string")
+
+          if not re.fullmatch(r"\d+\.\d+(?:\.\d+)?-\d+\.\d+\.\d+", latest):
+              raise SystemExit(
+                  f"promos.latest {latest!r} does not match "
+                  "{minecraft}-{mod} (e.g. 1.21.4-1.2.0)"
+              )
+
+          tag = f"v{latest}"
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"latest={latest}\n")
+              out.write(f"tag={tag}\n")
+          print(f"Resolved tag {tag} from promos.latest={latest}")
+          PY
+
+      - name: Create and push tag if missing
+        id: tag
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            echo "Tag ${TAG} already exists on origin; nothing to do."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+          echo "Created and pushed tag ${TAG}."
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      # GITHUB_TOKEN pushes do not trigger other workflows; dispatch Release explicitly.
+      - name: Trigger Release workflow
+        if: steps.tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          gh workflow run release.yml --ref "${TAG}"
+          echo "Dispatched Release workflow for ${TAG}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - "v*"
+  # Also allow explicit dispatch (e.g. after Create Release Tag pushes with GITHUB_TOKEN,
+  # which does not re-trigger workflows on tag push).
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -79,7 +79,7 @@ Ship a patch immediately for:
 1. On `main`, bump `mod_version` in `gradle.properties` (and `minecraft_version` if needed).
 2. Run `./gradlew syncVersionJson`, then fill `added` / `changed` / `removed` for the new version in `version.json`.
 3. Confirm `./gradlew build` is green.
-4. Commit, merge to `main`, tag `v{minecraft_version}-{mod_version}`, and push the tag.
+4. Commit, merge to `main`, then create and push tag `v{minecraft_version}-{mod_version}` (manually, or via the **Create Release Tag** workflow, which tags `promos.latest` from `version.json` on `main` if that tag is missing).
 5. Confirm the **Release** GitHub Actions workflow succeeds:
    - GitHub Release with remapped JAR (+ sources JAR)
    - Release notes generated from `version.json`
@@ -93,6 +93,7 @@ Modrinth upload and the Discord `#releases` post remain **manual** in this polic
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
 | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) | `pull_request`, push to `main` | `./gradlew build` (compile + unit tests + version sync check) |
-| [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*` | Build, publish GitHub Release artifacts and notes from `version.json` |
+| [`.github/workflows/create-release-tag.yml`](../.github/workflows/create-release-tag.yml) | `workflow_dispatch` | Create and push `v*` tag from `version.json` `promos.latest` if missing; then dispatch Release |
+| [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*`, or `workflow_dispatch` | Build, publish GitHub Release artifacts and notes from `version.json` |
 
 CircleCI is retired; do not add draft GitHub releases on every `main` merge.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Cutting a release still required a manual git tag push; this adds a one-click Actions trigger that creates the canonical `v{minecraft}-{mod}` tag from `version.json` when it is missing, so release publishing can start without local git operations.

## Proposed Implementation

- Add [`.github/workflows/create-release-tag.yml`](.github/workflows/create-release-tag.yml): `workflow_dispatch`, checkout `main`, read `promos.latest`, push annotated tag `v{latest}` only if absent, then dispatch the Release workflow.
- Allow `workflow_dispatch` on [`.github/workflows/release.yml`](.github/workflows/release.yml) so Release still runs after a `GITHUB_TOKEN` tag push (which does not re-trigger workflows).
- Document the workflow in [`docs/release-policy.md`](docs/release-policy.md) checklist and CI overview.

## Problems Encountered / Decisions Made

- `GITHUB_TOKEN` tag pushes do not start other workflows, so Create Release Tag explicitly dispatches Release after creating a new tag (requires `actions: write` and `workflow_dispatch` on Release).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-631ea7ed-52c9-441b-8fed-0d9ef881eaee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-631ea7ed-52c9-441b-8fed-0d9ef881eaee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

