### PR TITLE
feat(ci): automate Modrinth upload and Discord release announcements

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,10 @@ jobs:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
 
       - name: Generate release notes
+        id: notes
         env:
           TAG: ${{ github.ref_name }}
+          MOD_VERSION: ${{ steps.version.outputs.mod_version }}
         run: |
           python3 <<'PY'
           import json
@@ -55,19 +57,34 @@ jobs:
           from pathlib import Path
 
           tag = os.environ["TAG"]
+          mod_version_prop = os.environ["MOD_VERSION"]
           version = tag[1:] if tag.startswith("v") else tag
           match = re.fullmatch(r"(\d+\.\d+(?:\.\d+)?)-(\d+\.\d+\.\d+)", version)
           if not match:
               raise SystemExit(f"Tag {tag!r} does not match v{{minecraft}}-{{mod}} (e.g. v1.21.4-1.2.0)")
 
           minecraft_version, mod_version = match.group(1), match.group(2)
+          if mod_version != mod_version_prop:
+              raise SystemExit(
+                  f"Tag mod version {mod_version!r} does not match gradle mod_version {mod_version_prop!r}"
+              )
+
           root = json.loads(Path("version.json").read_text(encoding="utf-8"))
           entry = root.get(minecraft_version, {}).get(mod_version)
           lines = [f"## {version}", ""]
+          detail_lines = []
+          summary = ""
 
           if not entry:
               lines.append("_No changelog entry found in version.json for this release._")
           else:
+              summary = (entry.get("summary") or "").strip()
+              if not summary:
+                  raise SystemExit(
+                      f"version.json entry for {minecraft_version}/{mod_version} is missing a non-blank summary"
+                  )
+              lines.append(summary)
+              lines.append("")
               for section, heading in (
                   ("added", "Added"),
                   ("changed", "Changed"),
@@ -76,12 +93,42 @@ jobs:
                   items = entry.get(section) or []
                   if not items:
                       continue
-                  lines.append(f"### {heading}")
-                  lines.extend(f"- {item}" for item in items)
-                  lines.append("")
+                  detail_lines.append(f"### {heading}")
+                  detail_lines.extend(f"- {item}" for item in items)
+                  detail_lines.append("")
+              lines.extend(detail_lines)
 
           Path("release-notes.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
           print(Path("release-notes.md").read_text(encoding="utf-8"))
+
+          changelog_body = "\n".join([summary, ""] + detail_lines).strip() if entry else ""
+          modrinth_data = {
+              "name": version,
+              "version_number": version,
+              "changelog": changelog_body,
+              "dependencies": [
+                  {"project_id": "P7dR8mSH", "dependency_type": "required"},
+              ],
+              "game_versions": [minecraft_version],
+              "version_type": "release",
+              "loaders": ["fabric"],
+              "featured": False,
+              "status": "listed",
+              "project_id": "CY3ponKT",
+              "file_parts": ["primary", "sources"],
+              "primary_file": "primary",
+          }
+          Path("modrinth-data.json").write_text(
+              json.dumps(modrinth_data, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"minecraft_version={minecraft_version}\n")
+              out.write(f"release_version={version}\n")
+              out.write("summary<<EOF\n")
+              out.write(f"{summary}\n")
+              out.write("EOF\n")
           PY
 
       - name: Create GitHub Release
@@ -96,3 +143,91 @@ jobs:
           fail_on_unmatched_files: true
           draft: false
           prerelease: false
+
+      - name: Publish to Modrinth
+        id: modrinth
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          MOD_VERSION: ${{ steps.version.outputs.mod_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MODRINTH_TOKEN:-}" ]; then
+            echo "MODRINTH_TOKEN secret is not set" >&2
+            exit 1
+          fi
+          JAR="build/libs/dwm-${MOD_VERSION}.jar"
+          SOURCES="build/libs/dwm-${MOD_VERSION}-sources.jar"
+          if [ ! -f "$JAR" ] || [ ! -f "$SOURCES" ]; then
+            echo "Missing build artifacts: $JAR and/or $SOURCES" >&2
+            exit 1
+          fi
+          RESPONSE=$(curl -fsS -X POST "https://api.modrinth.com/v2/version" \
+            -H "Authorization: ${MODRINTH_TOKEN}" \
+            -H "User-Agent: adam-k-ali/DWM (https://github.com/adam-k-ali/DWM)" \
+            -F "data=@modrinth-data.json;type=application/json" \
+            -F "primary=@${JAR}" \
+            -F "sources=@${SOURCES}")
+          echo "$RESPONSE" | tee modrinth-response.json
+          VERSION_ID=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$RESPONSE")
+          VERSION_URL="https://modrinth.com/mod/the-doctor-who-mod/version/${VERSION_ID}"
+          echo "modrinth_version_id=${VERSION_ID}" >> "$GITHUB_OUTPUT"
+          echo "modrinth_version_url=${VERSION_URL}" >> "$GITHUB_OUTPUT"
+          echo "Published Modrinth version: ${VERSION_URL}"
+
+      - name: Announce on Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_VERSION: ${{ steps.notes.outputs.release_version }}
+          MINECRAFT_VERSION: ${{ steps.notes.outputs.minecraft_version }}
+          SUMMARY: ${{ steps.notes.outputs.summary }}
+          MODRINTH_VERSION_URL: ${{ steps.modrinth.outputs.modrinth_version_url }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          webhook = os.environ.get("DISCORD_WEBHOOK_URL", "").strip()
+          if not webhook:
+              raise SystemExit("DISCORD_WEBHOOK_URL secret is not set")
+
+          release_version = os.environ["RELEASE_VERSION"]
+          minecraft_version = os.environ["MINECRAFT_VERSION"]
+          summary = os.environ["SUMMARY"].strip()
+          modrinth_url = os.environ["MODRINTH_VERSION_URL"]
+          if not summary:
+              raise SystemExit("Release summary is empty")
+
+          # Discord embed description max length
+          if len(summary) > 4096:
+              summary = summary[:4093] + "..."
+
+          payload = {
+              "embeds": [
+                  {
+                      "title": f"New Release: {release_version}",
+                      "url": modrinth_url,
+                      "description": summary,
+                      "color": 1911355,
+                      "footer": {"text": f"Fabric · Minecraft {minecraft_version}"},
+                      "thumbnail": {
+                          "url": "https://cdn.modrinth.com/data/CY3ponKT/03858742885c853698edb03ac20d719e38575f8e_96.webp"
+                      },
+                  }
+              ]
+          }
+          data = json.dumps(payload).encode("utf-8")
+          req = urllib.request.Request(
+              webhook,
+              data=data,
+              headers={"Content-Type": "application/json"},
+              method="POST",
+          )
+          try:
+              with urllib.request.urlopen(req) as resp:
+                  print(f"Discord webhook status: {resp.status}")
+          except urllib.error.HTTPError as exc:
+              body = exc.read().decode("utf-8", errors="replace")
+              raise SystemExit(f"Discord webhook failed ({exc.code}): {body}") from exc
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@
 - CI runs on GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)); CircleCI is retired.
 - Releases are intentional git tags `v{minecraft}-{mod}` — see [docs/release-policy.md](docs/release-policy.md).
 - Do not bump `mod_version` or `version.json` promos except when cutting a release; use `./gradlew syncVersionJson` at cut time.
-- The release workflow publishes the GitHub Release from `version.json` notes; Modrinth + Discord `#releases` stay manual per the policy.
+- The release workflow publishes the GitHub Release, Modrinth version, and Discord `#releases` announcement from `version.json` (`summary` + changelog lists). Requires `MODRINTH_TOKEN` and `DISCORD_WEBHOOK_URL` secrets.
 
 ## Change Scope & Safety
 - Keep unrelated files untouched.

--- a/build.gradle
+++ b/build.gradle
@@ -89,7 +89,8 @@ def versionJsonFile = file("version.json")
 
 /**
  * Rewrites version.json promos from gradle.properties and stubs an empty changelog
- * section for the current mod_version when missing. Changelog bullets stay hand-written.
+ * section for the current mod_version when missing (summary + added/changed/removed).
+ * Changelog bullets and summary stay hand-written.
  * Run after bumping mod_version / minecraft_version: ./gradlew syncVersionJson
  */
 tasks.register("syncVersionJson") {
@@ -121,7 +122,7 @@ tasks.register("syncVersionJson") {
 
         def mcMap = root[mc] as Map
         if (!mcMap.containsKey(mv)) {
-            def stub = [added: [], changed: [], removed: []] as LinkedHashMap
+            def stub = [summary: "", added: [], changed: [], removed: []] as LinkedHashMap
             def reorderedMc = new LinkedHashMap()
             reorderedMc[mv] = stub
             mcMap.each { k, v -> reorderedMc[k] = v }
@@ -172,7 +173,15 @@ tasks.register("checkVersionSync") {
         if (!(root[mc] instanceof Map) || !((root[mc] as Map).containsKey(mv))) {
             throw new GradleException(
                     "version.json is missing changelog for ${mc}/${mv}. " +
-                            "Run ./gradlew syncVersionJson and fill in added/changed/removed."
+                            "Run ./gradlew syncVersionJson and fill in summary/added/changed/removed."
+            )
+        }
+        def entry = (root[mc] as Map)[mv]
+        def summary = entry instanceof Map ? entry.summary : null
+        if (!(summary instanceof String) || summary.trim().isEmpty()) {
+            throw new GradleException(
+                    "version.json changelog for ${mc}/${mv} is missing a non-blank summary. " +
+                            "Fill in summary for Discord/GitHub/Modrinth release notes."
             )
         }
         def promos = root.promos instanceof Map ? root.promos as Map : null

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -24,7 +24,14 @@ Example: `v1.21.4-1.2.0` → Minecraft `1.21.4`, mod `1.2.0`.
 | --- | --- |
 | `minecraft_version` | [`gradle.properties`](../gradle.properties) |
 | `mod_version` | [`gradle.properties`](../gradle.properties) (SemVer piece only) |
-| Player changelog + promos | [`version.json`](../version.json) (source for GitHub Release notes) |
+| Player changelog + promos | [`version.json`](../version.json) (source for GitHub Release notes, Modrinth changelog, and Discord) |
+
+Each per-version entry under `version.json` → `{minecraft_version}` → `{mod_version}` includes:
+
+| Field | Purpose |
+| --- | --- |
+| `summary` | Short player-facing blurb (required, non-blank). Leads the GitHub Release body and Modrinth changelog; used as the Discord embed description. |
+| `added` / `changed` / `removed` | Detailed changelog bullets for GitHub and Modrinth. |
 
 ### SemVer meaning for `mod_version`
 
@@ -59,7 +66,7 @@ Ship a patch immediately for:
 ## Quality bar before cut
 
 - `./gradlew test` and `./gradlew build` green (includes `checkVersionSync`)
-- Player-facing notes filled in for the new entry under `version.json` → `{minecraft_version}` → `{mod_version}`
+- Player-facing notes filled in for the new entry under `version.json` → `{minecraft_version}` → `{mod_version}`: non-blank `summary` plus `added` / `changed` / `removed` as needed
 - `promos.latest` and `promos.recommended` match `{minecraft_version}-{mod_version}` (use `./gradlew syncVersionJson` at cut time)
 - Experimental features remain clearly labeled in docs and configs
 - Release notes describe **shipped behavior only** (no roadmap fluff)
@@ -71,22 +78,26 @@ Ship a patch immediately for:
 
 ## Source of truth
 
-- **[`version.json`](../version.json)** is the only release-notes and promo channel (GitHub Release body).
+- **[`version.json`](../version.json)** is the only release-notes and promo channel (GitHub Release body, Modrinth changelog, Discord summary).
 - Do not maintain a separate changelog file; dual ledgers drift.
 
 ## Distribution checklist
 
 1. On `main`, bump `mod_version` in `gradle.properties` (and `minecraft_version` if needed).
-2. Run `./gradlew syncVersionJson`, then fill `added` / `changed` / `removed` for the new version in `version.json`.
+2. Run `./gradlew syncVersionJson`, then fill `summary` and `added` / `changed` / `removed` for the new version in `version.json`.
 3. Confirm `./gradlew build` is green.
 4. Commit, merge to `main`, then create and push tag `v{minecraft_version}-{mod_version}` (manually, or via the **Create Release Tag** workflow, which tags `promos.latest` from `version.json` on `main` if that tag is missing).
 5. Confirm the **Release** GitHub Actions workflow succeeds:
-   - GitHub Release with remapped JAR (+ sources JAR)
-   - Release notes generated from `version.json`
-6. Upload the remapped JAR from the GitHub Release to **Modrinth** (correct Minecraft + Fabric loaders).
-7. Post in Discord **`#releases`**: short summary of shipped behavior + Modrinth link.
+   - GitHub Release with remapped JAR (+ sources JAR) and notes from `version.json` (`summary` + detailed lists)
+   - Modrinth version upload (Fabric + Minecraft from the tag; Fabric API dependency)
+   - Discord `#releases` embed (summary + Modrinth link)
 
-Modrinth upload and the Discord `#releases` post remain **manual** in this policy. Automating them (Modrinth token / Discord webhook) is a follow-up.
+### Required GitHub Actions secrets
+
+| Secret | Purpose |
+| --- | --- |
+| `MODRINTH_TOKEN` | Modrinth personal access token with `VERSION_CREATE` |
+| `DISCORD_WEBHOOK_URL` | Incoming webhook for Discord `#releases` |
 
 ## CI overview
 
@@ -94,6 +105,6 @@ Modrinth upload and the Discord `#releases` post remain **manual** in this polic
 | --- | --- | --- |
 | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) | `pull_request`, push to `main` | `./gradlew build` (compile + unit tests + version sync check) |
 | [`.github/workflows/create-release-tag.yml`](../.github/workflows/create-release-tag.yml) | `workflow_dispatch` | Create and push `v*` tag from `version.json` `promos.latest` if missing; then dispatch Release |
-| [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*`, or `workflow_dispatch` | Build, publish GitHub Release artifacts and notes from `version.json` |
+| [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*`, or `workflow_dispatch` | Build; publish GitHub Release, Modrinth version, and Discord announcement from `version.json` |
 
 CircleCI is retired; do not add draft GitHub releases on every `main` merge.

--- a/src/test/java/com/adamkali/dwm/VersionJsonSyncTest.java
+++ b/src/test/java/com/adamkali/dwm/VersionJsonSyncTest.java
@@ -31,6 +31,12 @@ class VersionJsonSyncTest {
                 root.getJSONObject(minecraftVersion).has(modVersion),
                 "version.json must include changelog for " + minecraftVersion + "/" + modVersion
         );
+        JSONObject entry = root.getJSONObject(minecraftVersion).getJSONObject(modVersion);
+        assertTrue(
+                entry.has("summary") && !entry.getString("summary").isBlank(),
+                "version.json changelog for " + minecraftVersion + "/" + modVersion
+                        + " must include a non-blank summary"
+        );
     }
 
     private static Properties loadGradleProperties() throws IOException {

--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "1.21.4": {
     "1.1.0": {
+      "summary": "Colored chronoplasm powder, TARDIS walls, and roundels — plus the sonic screwdriver advancement.",
       "added": [
         "Block: Black Chronoplasm Powder",
         "Block: Blue Chronoplasm Powder",
@@ -112,6 +113,7 @@
       "removed": []
     },
     "1.0.0": {
+      "summary": "Initial release with Doctor Who sonic screwdrivers.",
       "added": [
         "Item: Sonic Screwdriver (Second Doctor)",
         "Item: Sonic Screwdriver (Third Doctor)",


### PR DESCRIPTION
## Why this matters

- Tagged releases can reach Modrinth and Discord `#releases` automatically, matching the distribution checklist without manual upload/post steps.
- A required `summary` in `version.json` gives a curated player-facing blurb for GitHub, Modrinth, and Discord instead of dumping long changelog lists into Discord.

## Proposed Implementation

- Extended [`.github/workflows/release.yml`](.github/workflows/release.yml) to publish via `POST /v2/version` (JAR + sources, Fabric API dependency) and announce with a Discord webhook embed.
- Added required `summary` to changelog entries; `syncVersionJson` / `checkVersionSync` / `VersionJsonSyncTest` enforce it.
- Updated [`docs/release-policy.md`](docs/release-policy.md) and [`AGENTS.md`](AGENTS.md); document `MODRINTH_TOKEN` and `DISCORD_WEBHOOK_URL` secrets.

## Problems Encountered / Decisions Made

- Hardcoded Modrinth project id `CY3ponKT` (stable) rather than slug.
- Discord uses only `summary` in an embed (no role ping, no GitHub link); full lists remain on GitHub/Modrinth.

Made with [Cursor](https://cursor.com)