### PR TITLE
fix(tardis): avoid crash when remote clients lack save directory

### DIFF
--- a/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
+++ b/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
@@ -5,6 +5,7 @@ import com.adamkali.dwm.gui.TardisChameleonGui;
 import com.adamkali.dwm.render.portal.PortalRenderTarget;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.sound.TardisTravelSoundController;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
@@ -26,6 +27,7 @@ public class ClientPayloadTypeRegistry {
             PortalSceneStore.invalidateAll();
             PortalRenderTarget.closeGlobal();
             TardisTravelSoundController.stopAll();
+            TardisDataLoader.clearCache();
         });
     }
 
@@ -41,7 +43,17 @@ public class ClientPayloadTypeRegistry {
     }
 
     private static void syncPortalMeta(SyncPortalMetaS2CPayload payload, ClientPlayNetworking.Context context) {
-        context.client().execute(() -> PortalSceneStore.applyMeta(payload));
+        context.client().execute(() -> {
+            PortalSceneStore.applyMeta(payload);
+            // Remote clients have no save directory; seed the shared cache so exterior
+            // tick/render can animate doors without hitting disk.
+            TardisDataLoader.applyClientShell(
+                    payload.tardisId(),
+                    payload.variant(),
+                    payload.doorSwing(),
+                    payload.isOpen()
+            );
+        });
     }
 
     private static void syncPortalChunk(SyncPortalChunkS2CPayload payload, ClientPlayNetworking.Context context) {

--- a/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
+++ b/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.tardis.data;
 
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -40,6 +41,11 @@ public class TardisDataLoader {
         if (uuid == null) {
             return null;
         }
+        // Remote clients never run SERVER_STARTED, so the save directory stays unset.
+        // Treat that as a cache-only mode instead of crashing during block-entity ticks.
+        if (tardisSaveDirectory == null) {
+            return null;
+        }
 
         File file = TardisDataLoader.getTardisDataFile(uuid, false);
         if (!file.exists()) {
@@ -75,6 +81,42 @@ public class TardisDataLoader {
         }
 
         return TardisDataLoader.load(uuid);
+    }
+
+    /**
+     * Seeds or updates an ephemeral client-side model from S2C portal shell meta.
+     * No-ops when the save directory is set (integrated server owns the shared cache).
+     */
+    public static void applyClientShell(
+            @NotNull UUID uuid,
+            @NotNull TardisChameleonVariant variant,
+            float doorSwing,
+            boolean isOpen
+    ) {
+        if (tardisSaveDirectory != null) {
+            return;
+        }
+        TardisDataModel model = tardisData.get(uuid);
+        if (model == null) {
+            model = new TardisDataModel();
+            model.uuid = uuid;
+            tardisData.put(uuid, model);
+        }
+        model.variant = variant;
+        model.doorState.isOpen = isOpen;
+        model.doorState.doorSwing = doorSwing;
+    }
+
+    /**
+     * Drops all cached models. Used when a remote client disconnects so the next
+     * session does not reuse another world's ephemeral shell state.
+     * No-ops when the save directory is set so integrated/server persistence is preserved.
+     */
+    public static void clearCache() {
+        if (tardisSaveDirectory != null) {
+            return;
+        }
+        tardisData.clear();
     }
 
     private static void save(TardisDataModel dataModel) throws IOException {

--- a/src/test/java/com/adamkali/dwm/tardis/data/TardisDataLoaderTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/data/TardisDataLoaderTest.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.tardis.data;
 
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.google.gson.Gson;
 import org.junit.jupiter.api.AfterEach;
@@ -90,6 +91,59 @@ public class TardisDataLoaderTest {
 
         // Assert
         assertNull(result, "Should return null for nonexistent file");
+    }
+
+    @Test
+    void get_ReturnsNullWhenSaveDirectoryUnset() {
+        TardisDataLoader.tardisSaveDirectory = null;
+        UUID uuid = UUID.randomUUID();
+
+        assertNull(TardisDataLoader.get(uuid), "Remote clients must not crash when save dir is unset");
+    }
+
+    @Test
+    void applyClientShell_SeedsCacheWhenSaveDirectoryUnset() {
+        TardisDataLoader.tardisSaveDirectory = null;
+        UUID uuid = UUID.randomUUID();
+
+        TardisDataLoader.applyClientShell(uuid, TardisChameleonVariant.FIRST_DOCTOR_BOX, 0.5f, true);
+
+        TardisDataModel model = TardisDataLoader.get(uuid);
+        assertNotNull(model);
+        assertEquals(TardisChameleonVariant.FIRST_DOCTOR_BOX, model.variant);
+        assertTrue(model.doorState.isOpen);
+        assertEquals(0.5f, model.doorState.doorSwing, 0.001f);
+        assertFalse(model.needsSaving(), "Client shell seed must not mark dirty for persistence");
+    }
+
+    @Test
+    void applyClientShell_NoOpsWhenSaveDirectorySet() {
+        UUID uuid = UUID.randomUUID();
+
+        TardisDataLoader.applyClientShell(uuid, TardisChameleonVariant.FIRST_DOCTOR_BOX, 1.0f, true);
+
+        assertNull(TardisDataLoader.get(uuid), "Integrated/server cache must not be overwritten by client meta");
+    }
+
+    @Test
+    void clearCache_RemovesCachedModels() {
+        TardisDataLoader.tardisSaveDirectory = null;
+        UUID uuid = UUID.randomUUID();
+        TardisDataLoader.applyClientShell(uuid, TardisChameleonVariant.TT_CAPSULE, 0.0f, false);
+
+        TardisDataLoader.clearCache();
+
+        assertNull(TardisDataLoader.get(uuid));
+    }
+
+    @Test
+    void clearCache_NoOpsWhenSaveDirectorySet() {
+        TardisDataModel model = TardisDataLoader.create();
+        UUID uuid = model.uuid;
+
+        TardisDataLoader.clearCache();
+
+        assertSame(model, TardisDataLoader.get(uuid), "Server/integrated cache must survive clearCache");
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Joining a dedicated/LAN server crashed the client with `Tardis save directory has not been set` while ticking a TARDIS block entity.

## Proposed Implementation

- Treat an unset `tardisSaveDirectory` as cache-only mode in `TardisDataLoader.get`/`load` instead of throwing.
- Seed ephemeral client shell state (variant/door) from `SyncPortalMetaS2CPayload` when no save directory is present.
- Clear that ephemeral cache on remote disconnect; leave integrated/server cache alone.
- Regression coverage in `TardisDataLoaderTest`.

## Problems Encountered / Decisions Made

- Portal meta is the existing S2C path for shell/door fields, so it seeds the client cache rather than introducing a new door-sync packet.
- `applyClientShell` / `clearCache` no-op when the save directory is set so integrated singleplayer keeps owning the shared cache.

Made with [Cursor](https://cursor.com)