### PR TITLE
perf(portal): SOTO pass batching, hitch cull, and portal perf diagnostics

### DIFF
--- a/src/client/java/com/adamkali/dwm/DWMClient.java
+++ b/src/client/java/com/adamkali/dwm/DWMClient.java
@@ -4,6 +4,8 @@ import com.adamkali.dwm.network.ClientPayloadTypeRegistry;
 import com.adamkali.dwm.client.DWMEntityRenderers;
 import com.adamkali.dwm.render.ConsoleControlHud;
 import com.adamkali.dwm.render.ConsoleHitboxDebugRenderer;
+import com.adamkali.dwm.render.portal.PortalPerfDebugHud;
+import com.adamkali.dwm.render.portal.PortalPerfDebugLog;
 import com.adamkali.dwm.render.portal.PortalSupport;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.sound.TardisHumController;
@@ -21,6 +23,8 @@ public class DWMClient implements ClientModInitializer {
         TardisHumController.initialize();
         ConsoleControlHud.initialize();
         ConsoleHitboxDebugRenderer.initialize();
+        PortalPerfDebugHud.initialize();
+        PortalPerfDebugLog.resetForSession();
         PortalSupport.initialize();
         ClientTickEvents.END_CLIENT_TICK.register(client -> PortalSceneStore.clientTick());
     }

--- a/src/client/java/com/adamkali/dwm/DWMModMenuIntegration.java
+++ b/src/client/java/com/adamkali/dwm/DWMModMenuIntegration.java
@@ -21,6 +21,7 @@ public class DWMModMenuIntegration implements ModMenuApi {
             ConfigEntryBuilder entryBuilder = builder.entryBuilder();
             general.addEntry(entryBuilder.startBooleanToggle(Component.translatable("dwm.config.option.chameleon_gui"), DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)).setDefaultValue(DWMConfig.ENABLE_CHAMELEON_GUI.getDefaultValue()).setSaveConsumer((newValue) -> DWMConfig.setBoolean(DWMConfig.ENABLE_CHAMELEON_GUI, newValue)).build());
             general.addEntry(entryBuilder.startBooleanToggle(Component.translatable("dwm.config.option.enable_door_portals"), DWMConfig.getBoolean(DWMConfig.ENABLE_DOOR_PORTALS)).setDefaultValue(DWMConfig.ENABLE_DOOR_PORTALS.getDefaultValue()).setTooltip(Component.translatable("dwm.config.option.enable_door_portals.tooltip")).setSaveConsumer((newValue) -> DWMConfig.setBoolean(DWMConfig.ENABLE_DOOR_PORTALS, newValue)).build());
+            general.addEntry(entryBuilder.startBooleanToggle(Component.translatable("dwm.config.option.show_portal_perf_debug"), DWMConfig.getBoolean(DWMConfig.SHOW_PORTAL_PERF_DEBUG)).setDefaultValue(DWMConfig.SHOW_PORTAL_PERF_DEBUG.getDefaultValue()).setTooltip(Component.translatable("dwm.config.option.show_portal_perf_debug.tooltip")).setSaveConsumer((newValue) -> DWMConfig.setBoolean(DWMConfig.SHOW_PORTAL_PERF_DEBUG, newValue)).build());
             return builder.alwaysShowTabs().build();
         };
     }

--- a/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
+++ b/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.ClientTardis;
 import com.adamkali.dwm.gui.PlayerLocatorScreen;
 import com.adamkali.dwm.gui.TardisChameleonGui;
 import com.adamkali.dwm.gui.WaypointScreen;
+import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalRenderTarget;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.sound.TardisTravelSoundController;
@@ -26,6 +27,7 @@ public class ClientPayloadTypeRegistry {
         ClientPlayNetworking.registerGlobalReceiver(SyncPortalEntitySpawnS2CPayload.ID, ClientPayloadTypeRegistry::spawnPortalEntity);
         ClientPlayNetworking.registerGlobalReceiver(SyncPortalEntityUpdateS2CPayload.ID, ClientPayloadTypeRegistry::updatePortalEntity);
         ClientPlayNetworking.registerGlobalReceiver(SyncPortalEntityRemoveS2CPayload.ID, ClientPayloadTypeRegistry::removePortalEntity);
+        ClientPlayNetworking.registerGlobalReceiver(SyncPortalPerfS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalPerf);
         ClientPlayNetworking.registerGlobalReceiver(TravelAudioS2CPayload.ID, ClientPayloadTypeRegistry::travelAudio);
         ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
             PortalSceneStore.invalidateAll();
@@ -111,6 +113,10 @@ public class ClientPayloadTypeRegistry {
 
     private static void removePortalEntity(SyncPortalEntityRemoveS2CPayload payload, ClientPlayNetworking.Context context) {
         context.client().execute(() -> PortalSceneStore.removeEntity(payload));
+    }
+
+    private static void syncPortalPerf(SyncPortalPerfS2CPayload payload, ClientPlayNetworking.Context context) {
+        context.client().execute(() -> PortalPerfStats.applyServerDiag(payload));
     }
 
     private static void travelAudio(TravelAudioS2CPayload payload, ClientPlayNetworking.Context context) {

--- a/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -44,7 +44,9 @@ public final class BotiPortalContent implements PortalContent {
             return false;
         }
         PortalSceneStore.requestIfNeeded(PortalStreamKind.BOTI, tardisId);
-        return true;
+        // Same spirit as SOTO: skip the full-window FBO until ghost meshes exist.
+        // Blueprint fallback remains available as a BER placeholder when not ready.
+        return SotoGhostMeshCache.hasMeshes(PortalStreamKind.BOTI, tardisId);
     }
 
     @Override
@@ -87,23 +89,23 @@ public final class BotiPortalContent implements PortalContent {
                 PortalStreamKind.BOTI,
                 id,
                 hitch.viewMatrix(),
-                SotoGhostMeshCache.TerrainPass.OPAQUE
+                SotoGhostMeshCache.TerrainPass.OPAQUE,
+                hitch
         );
-        context.bindTarget();
         SotoGhostMeshCache.drawLayer(
                 PortalStreamKind.BOTI,
                 id,
                 hitch.viewMatrix(),
-                SotoGhostMeshCache.TerrainPass.CUTOUT
+                SotoGhostMeshCache.TerrainPass.CUTOUT,
+                hitch
         );
-        context.bindTarget();
         SotoGhostMeshCache.drawLayer(
                 PortalStreamKind.BOTI,
                 id,
                 hitch.viewMatrix(),
-                SotoGhostMeshCache.TerrainPass.TRANSLUCENT
+                SotoGhostMeshCache.TerrainPass.TRANSLUCENT,
+                hitch
         );
-        context.bindTarget();
         try {
             PortalFeatureFlush featureFlush = context.featureFlush();
             if (featureFlush != null) {

--- a/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.render.portal.PortalCameraTransform;
 import com.adamkali.dwm.render.portal.PortalContent;
 import com.adamkali.dwm.render.portal.PortalContentContext;
 import com.adamkali.dwm.render.portal.PortalFeatureFlush;
+import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.render.soto.SotoExteriorMeshCache;
 import com.adamkali.dwm.render.soto.SotoSkyFogRenderer;
@@ -85,6 +86,7 @@ public final class BotiPortalContent implements PortalContent {
         PoseStack sceneMatrices = context.sceneMatrices();
 
         context.bindTarget();
+        long opaqueStart = PortalPerfStats.begin();
         SotoGhostMeshCache.drawLayer(
                 PortalStreamKind.BOTI,
                 id,
@@ -92,6 +94,9 @@ public final class BotiPortalContent implements PortalContent {
                 SotoGhostMeshCache.TerrainPass.OPAQUE,
                 hitch
         );
+        PortalPerfStats.end(PortalPerfStats.Stage.TERRAIN_OPAQUE, opaqueStart);
+
+        long cutoutStart = PortalPerfStats.begin();
         SotoGhostMeshCache.drawLayer(
                 PortalStreamKind.BOTI,
                 id,
@@ -99,6 +104,9 @@ public final class BotiPortalContent implements PortalContent {
                 SotoGhostMeshCache.TerrainPass.CUTOUT,
                 hitch
         );
+        PortalPerfStats.end(PortalPerfStats.Stage.TERRAIN_CUTOUT, cutoutStart);
+
+        long translucentStart = PortalPerfStats.begin();
         SotoGhostMeshCache.drawLayer(
                 PortalStreamKind.BOTI,
                 id,
@@ -106,6 +114,9 @@ public final class BotiPortalContent implements PortalContent {
                 SotoGhostMeshCache.TerrainPass.TRANSLUCENT,
                 hitch
         );
+        PortalPerfStats.end(PortalPerfStats.Stage.TERRAIN_TRANSLUCENT, translucentStart);
+
+        long featuresStart = PortalPerfStats.begin();
         try {
             PortalFeatureFlush featureFlush = context.featureFlush();
             if (featureFlush != null) {
@@ -142,35 +153,42 @@ public final class BotiPortalContent implements PortalContent {
                 }
             }
         } catch (Throwable ignored) {
+        } finally {
+            PortalPerfStats.end(PortalPerfStats.Stage.GHOST_FEATURES, featuresStart);
         }
     }
 
     private void renderBlueprintFallback(PortalContentContext context) {
-        PortalFeatureFlush featureFlush = context.featureFlush();
-        if (featureFlush == null) {
-            return;
-        }
-        PoseStack sceneMatrices = context.sceneMatrices();
-        SubmitNodeStorage submitStorage = context.submitStorage();
-        CameraRenderState cameraState = context.cameraState();
-        Matrix4fStack featureModelView = RenderSystem.getModelViewStack();
-        featureModelView.pushMatrix();
+        long featuresStart = PortalPerfStats.begin();
         try {
-            context.portalCamera().getViewRotationMatrix(featureModelView);
-            BotiInteriorMeshCache.renderForPortal(
-                    sceneMatrices,
-                    submitStorage,
-                    cameraState,
-                    context.portalCamera(),
-                    FULLBRIGHT,
-                    context.tickDelta(),
-                    tardisId
-            );
-            context.bindTarget();
-            featureFlush.renderAllFeatures(submitStorage);
-            context.bindTarget();
+            PortalFeatureFlush featureFlush = context.featureFlush();
+            if (featureFlush == null) {
+                return;
+            }
+            PoseStack sceneMatrices = context.sceneMatrices();
+            SubmitNodeStorage submitStorage = context.submitStorage();
+            CameraRenderState cameraState = context.cameraState();
+            Matrix4fStack featureModelView = RenderSystem.getModelViewStack();
+            featureModelView.pushMatrix();
+            try {
+                context.portalCamera().getViewRotationMatrix(featureModelView);
+                BotiInteriorMeshCache.renderForPortal(
+                        sceneMatrices,
+                        submitStorage,
+                        cameraState,
+                        context.portalCamera(),
+                        FULLBRIGHT,
+                        context.tickDelta(),
+                        tardisId
+                );
+                context.bindTarget();
+                featureFlush.renderAllFeatures(submitStorage);
+                context.bindTarget();
+            } finally {
+                featureModelView.popMatrix();
+            }
         } finally {
-            featureModelView.popMatrix();
+            PortalPerfStats.end(PortalPerfStats.Stage.GHOST_FEATURES, featuresStart);
         }
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
@@ -41,6 +41,8 @@ public final class PortalDoorRenderer {
             return;
         }
         PortalScheduler.schedule(scene);
+        PortalPerfStats.noteScheduled(scene.key());
+        long compositeStart = PortalPerfStats.begin();
         PortalRenderer.PortalTexture portalTexture =
                 PortalScheduler.peekCompositeTexture(scene.key());
         matrices.pushPose();
@@ -57,6 +59,7 @@ public final class PortalDoorRenderer {
             }
         } finally {
             matrices.popPose();
+            PortalPerfStats.end(PortalPerfStats.Stage.COMPOSITE, compositeStart);
         }
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalFrameCache.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalFrameCache.java
@@ -1,0 +1,116 @@
+package com.adamkali.dwm.render.portal;
+
+import com.adamkali.dwm.tardis.portal.PortalStreamKind;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Dirty / last-writer tracking for the shared portal FBO.
+ * <p>
+ * A portal key may reuse the last color texture across frames only when it is clean
+ * and was the last successful writer (shared FBO: last writer wins).
+ */
+public final class PortalFrameCache {
+    private static final Set<PortalKey> CLEAN = ConcurrentHashMap.newKeySet();
+    private static volatile PortalKey lastWriter;
+
+    private PortalFrameCache() {
+    }
+
+    public static PortalKey toPortalKey(PortalStreamKind kind, UUID tardisId) {
+        if (kind == null || tardisId == null) {
+            return null;
+        }
+        return switch (kind) {
+            case BOTI -> PortalKey.boti(tardisId);
+            case SOTO -> PortalKey.soto(tardisId);
+        };
+    }
+
+    public static void markDirty(PortalStreamKind kind, UUID tardisId) {
+        markDirty(toPortalKey(kind, tardisId));
+    }
+
+    public static void markDirty(PortalKey key) {
+        if (key == null) {
+            return;
+        }
+        CLEAN.remove(key);
+    }
+
+    public static void markAllDirty() {
+        CLEAN.clear();
+        lastWriter = null;
+    }
+
+    /**
+     * Missing / unknown keys are treated as dirty (must redraw).
+     */
+    public static boolean isDirty(PortalKey key) {
+        return key == null || !CLEAN.contains(key);
+    }
+
+    public static void clearDirty(PortalKey key) {
+        if (key != null) {
+            CLEAN.add(key);
+        }
+    }
+
+    public static boolean wasLastWriter(PortalKey key) {
+        return key != null && key.equals(lastWriter);
+    }
+
+    public static PortalKey lastWriter() {
+        return lastWriter;
+    }
+
+    /**
+     * Records that {@code key} just wrote the shared FBO.
+     * Marks the previous last writer dirty when it differs.
+     *
+     * @return previous last writer, or null
+     */
+    public static PortalKey noteRendered(PortalKey key) {
+        if (key == null) {
+            return null;
+        }
+        PortalKey previous = lastWriter;
+        lastWriter = key;
+        if (previous != null && !previous.equals(key)) {
+            markDirty(previous);
+        }
+        return previous;
+    }
+
+    /**
+     * Keys that must drop {@code renderedReady} after {@code key} overwrote the shared FBO.
+     */
+    public static Set<PortalKey> overwrittenReadyKeys(PortalKey key, Set<PortalKey> readyKeys) {
+        if (key == null || readyKeys == null || readyKeys.isEmpty()) {
+            return Set.of();
+        }
+        Set<PortalKey> overwritten = new HashSet<>();
+        for (PortalKey ready : readyKeys) {
+            if (ready != null && !ready.equals(key)) {
+                markDirty(ready);
+                overwritten.add(ready);
+            }
+        }
+        return overwritten;
+    }
+
+    /**
+     * FBO resize/close: no prior color texture remains valid.
+     */
+    public static void invalidateForResize() {
+        markAllDirty();
+    }
+
+    static void resetForTests() {
+        CLEAN.clear();
+        lastWriter = null;
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugHud.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugHud.java
@@ -1,0 +1,154 @@
+package com.adamkali.dwm.render.portal;
+
+import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.config.DWMConfig;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.ARGB;
+
+import java.util.EnumMap;
+import java.util.List;
+
+/**
+ * F3-style top-left overlay for shared portal pipeline timings (averages + graphs).
+ * Gated by {@link DWMConfig#SHOW_PORTAL_PERF_DEBUG}.
+ */
+public final class PortalPerfDebugHud {
+    private static final Identifier ELEMENT_ID =
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "portal_perf_debug_hud");
+    private static final int TEXT_COLOR = ARGB.opaque(0xE0E0E0);
+    private static final int MAX_COLOR = ARGB.opaque(0xFFDD66);
+    private static final int PANEL_COLOR = 0x88000000;
+    private static final int SPARK_COLOR = ARGB.opaque(0x66AAFF);
+    private static final int LINE_HEIGHT = 10;
+    private static final int PAD_X = 4;
+    private static final int PAD_Y = 4;
+    private static final int SPARK_WIDTH = 120;
+    private static final int SPARK_HEIGHT = 24;
+    private static final int STACK_WIDTH = 180;
+    private static final int STACK_HEIGHT = 10;
+
+    private static final EnumMap<PortalPerfStats.Stage, Integer> LEAF_COLORS = new EnumMap<>(PortalPerfStats.Stage.class);
+
+    static {
+        LEAF_COLORS.put(PortalPerfStats.Stage.SKY_FOG, ARGB.opaque(0x88CCFF));
+        LEAF_COLORS.put(PortalPerfStats.Stage.TERRAIN_OPAQUE, ARGB.opaque(0x55DD66));
+        LEAF_COLORS.put(PortalPerfStats.Stage.TERRAIN_CUTOUT, ARGB.opaque(0xDDCC44));
+        LEAF_COLORS.put(PortalPerfStats.Stage.TERRAIN_TRANSLUCENT, ARGB.opaque(0x66DDDD));
+        LEAF_COLORS.put(PortalPerfStats.Stage.GHOST_FEATURES, ARGB.opaque(0xDD77FF));
+        LEAF_COLORS.put(PortalPerfStats.Stage.PASS_BATCH_REBUILD, ARGB.opaque(0xFF8844));
+        LEAF_COLORS.put(PortalPerfStats.Stage.MESH_BAKE, ARGB.opaque(0xFF5555));
+        LEAF_COLORS.put(PortalPerfStats.Stage.COMPOSITE, ARGB.opaque(0xAAAAAA));
+    }
+
+    private PortalPerfDebugHud() {
+    }
+
+    public static void initialize() {
+        // No DEBUG element in Fabric 1.21+ VanillaHudElements; MISC_OVERLAYS is the early HUD slot.
+        HudElementRegistry.attachElementAfter(VanillaHudElements.MISC_OVERLAYS, ELEMENT_ID, PortalPerfDebugHud::extract);
+    }
+
+    private static void extract(GuiGraphicsExtractor graphics, DeltaTracker tickCounter) {
+        if (!DWMConfig.getBoolean(DWMConfig.SHOW_PORTAL_PERF_DEBUG)) {
+            return;
+        }
+        Minecraft client = Minecraft.getInstance();
+        if (client.player == null || client.level == null) {
+            return;
+        }
+        PortalPerfStats.DisplaySnapshot snap = PortalPerfStats.displaySnapshot();
+        List<String> lines = PortalPerfStats.formatLines(snap);
+        int y = PAD_Y;
+        for (String line : lines) {
+            int color = line.startsWith("*") || line.startsWith("maxAvg:") ? MAX_COLOR : TEXT_COLOR;
+            graphics.text(client.font, line, PAD_X, y, color);
+            y += LINE_HEIGHT;
+        }
+        y += 2;
+        y = drawSparkline(graphics, PAD_X, y);
+        y += 4;
+        drawStackedBar(graphics, client, snap, PAD_X, y);
+    }
+
+    private static int drawSparkline(GuiGraphicsExtractor graphics, int x, int y) {
+        float[] totals = PortalPerfStats.historyTotalsMs();
+        graphics.fill(x, y, x + SPARK_WIDTH, y + SPARK_HEIGHT, PANEL_COLOR);
+        if (totals.length == 0) {
+            return y + SPARK_HEIGHT;
+        }
+        float max = 0.001f;
+        for (float total : totals) {
+            if (total > max) {
+                max = total;
+            }
+        }
+        int samples = Math.min(totals.length, SPARK_WIDTH);
+        int start = Math.max(0, totals.length - samples);
+        for (int i = 0; i < samples; i++) {
+            float value = totals[start + i];
+            int barH = Math.max(1, Math.round((value / max) * (SPARK_HEIGHT - 2)));
+            int bx = x + i;
+            int by = y + SPARK_HEIGHT - 1 - barH;
+            graphics.fill(bx, by, bx + 1, y + SPARK_HEIGHT - 1, SPARK_COLOR);
+        }
+        return y + SPARK_HEIGHT;
+    }
+
+    private static void drawStackedBar(
+            GuiGraphicsExtractor graphics,
+            Minecraft client,
+            PortalPerfStats.DisplaySnapshot snap,
+            int x,
+            int y
+    ) {
+        graphics.fill(x, y, x + STACK_WIDTH, y + STACK_HEIGHT, PANEL_COLOR);
+        if (snap == null || snap == PortalPerfStats.DisplaySnapshot.IDLE) {
+            return;
+        }
+        double sum = 0.0;
+        for (PortalPerfStats.Stage stage : PortalPerfStats.Stage.LEAF_STAGES) {
+            sum += Math.max(0.0, snap.avgStageMs().getOrDefault(stage, 0.0));
+        }
+        if (sum <= 0.0) {
+            return;
+        }
+        int cursor = x;
+        for (PortalPerfStats.Stage stage : PortalPerfStats.Stage.LEAF_STAGES) {
+            double ms = Math.max(0.0, snap.avgStageMs().getOrDefault(stage, 0.0));
+            if (ms <= 0.0) {
+                continue;
+            }
+            int width = Math.max(1, (int) Math.round((ms / sum) * STACK_WIDTH));
+            if (cursor + width > x + STACK_WIDTH) {
+                width = x + STACK_WIDTH - cursor;
+            }
+            if (width <= 0) {
+                break;
+            }
+            int color = LEAF_COLORS.getOrDefault(stage, TEXT_COLOR);
+            graphics.fill(cursor, y, cursor + width, y + STACK_HEIGHT, color);
+            cursor += width;
+        }
+        int legendY = y + STACK_HEIGHT + 2;
+        int legendX = x;
+        for (PortalPerfStats.Stage stage : PortalPerfStats.Stage.LEAF_STAGES) {
+            double ms = snap.avgStageMs().getOrDefault(stage, 0.0);
+            if (ms <= 0.0) {
+                continue;
+            }
+            int color = LEAF_COLORS.getOrDefault(stage, TEXT_COLOR);
+            String label = stage.label();
+            graphics.text(client.font, label, legendX, legendY, color);
+            legendX += client.font.width(label) + 6;
+            if (legendX > x + STACK_WIDTH + 40) {
+                legendX = x;
+                legendY += LINE_HEIGHT;
+            }
+        }
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
@@ -110,7 +110,8 @@ public final class PortalPerfDebugLog {
         field(sb, "entities", snap.entityCount(), true);
         field(sb, "cullKept", snap.chunksKept(), true);
         field(sb, "cullCulled", snap.chunksCulled(), true);
-        // remove trailing comma from last field helper by rewriting last fields carefully
+        field(sb, "avgBakeCount", snap.avgBakeCount(), true);
+        field(sb, "avgBakeSkipCount", snap.avgBakeSkipCount(), true);
         // field() always appends comma — strip final comma before closing
         if (sb.charAt(sb.length() - 1) == ',') {
             sb.setLength(sb.length() - 1);

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
@@ -1,0 +1,200 @@
+package com.adamkali.dwm.render.portal;
+
+import com.mojang.logging.LogUtils;
+import org.slf4j.Logger;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.Locale;
+
+import net.minecraft.client.Minecraft;
+
+/**
+ * Appends ~1 Hz JSONL portal-perf samples while the debug HUD is enabled.
+ * Truncated once per client launch via {@link #resetForSession()}.
+ */
+public final class PortalPerfDebugLog {
+    private static final Logger LOGGER = LogUtils.getLogger();
+    private static final String FILE_NAME = "dwm-portal-perf.jsonl";
+    private static final long APPEND_INTERVAL_MS = 1000L;
+
+    private static BufferedWriter writer;
+    private static long lastAppendMs;
+    private static boolean ioFailedLogged;
+    private static Path logPath;
+
+    private PortalPerfDebugLog() {
+    }
+
+    /**
+     * Truncates (or creates) the session log file under {@code {gameDir}/logs/}.
+     * Call once from client init so each game start begins a fresh log.
+     */
+    public static void resetForSession() {
+        close();
+        ioFailedLogged = false;
+        lastAppendMs = 0L;
+        try {
+            Path path = resolveLogPath();
+            if (path == null) {
+                return;
+            }
+            Files.createDirectories(path.getParent());
+            Files.writeString(path, "", StandardCharsets.UTF_8, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+            logPath = path;
+        } catch (IOException e) {
+            logIoFailure("Failed to truncate portal perf log", e);
+        }
+    }
+
+    public static void maybeAppend(PortalPerfStats.DisplaySnapshot snap) {
+        if (snap == null || snap == PortalPerfStats.DisplaySnapshot.IDLE || snap.key() == null) {
+            return;
+        }
+        if (!PortalPerfStats.isEnabled()) {
+            close();
+            return;
+        }
+        long now = System.currentTimeMillis();
+        if (lastAppendMs > 0L && now - lastAppendMs < APPEND_INTERVAL_MS) {
+            return;
+        }
+        lastAppendMs = now;
+        String line = formatLine(now, snap);
+        appendLine(line);
+    }
+
+    public static void close() {
+        BufferedWriter current = writer;
+        writer = null;
+        if (current == null) {
+            return;
+        }
+        try {
+            current.flush();
+            current.close();
+        } catch (IOException e) {
+            logIoFailure("Failed to close portal perf log", e);
+        }
+    }
+
+    /** Pure formatter for tests. */
+    static String formatLine(long tsMs, PortalPerfStats.DisplaySnapshot snap) {
+        PortalKey key = snap.key();
+        StringBuilder sb = new StringBuilder(256);
+        sb.append('{');
+        field(sb, "ts", tsMs, true);
+        field(sb, "kind", key != null ? key.kind().name() : "null", false);
+        field(sb, "tardisId", key != null ? key.tardisId().toString() : "", false);
+        field(sb, "outcome", snap.outcome().label(), false);
+        field(sb, "avgTotalMs", snap.avgTotalMs(), true);
+        field(sb, "emaTotalMs", snap.emaTotalMs(), true);
+        field(sb, "window", snap.windowCount(), true);
+        sb.append("\"avgStages\":{");
+        boolean firstStage = true;
+        for (PortalPerfStats.Stage stage : PortalPerfStats.Stage.HUD_ORDER) {
+            if (!firstStage) {
+                sb.append(',');
+            }
+            firstStage = false;
+            sb.append('"').append(stage.label()).append("\":");
+            appendNumber(sb, snap.avgStageMs().getOrDefault(stage, 0.0));
+        }
+        sb.append("},");
+        field(sb, "chunks", snap.chunkCount(), true);
+        field(sb, "mesh", snap.meshChunkCount(), true);
+        field(sb, "entities", snap.entityCount(), true);
+        field(sb, "cullKept", snap.chunksKept(), true);
+        field(sb, "cullCulled", snap.chunksCulled(), true);
+        // remove trailing comma from last field helper by rewriting last fields carefully
+        // field() always appends comma — strip final comma before closing
+        if (sb.charAt(sb.length() - 1) == ',') {
+            sb.setLength(sb.length() - 1);
+        }
+        sb.append('}');
+        return sb.toString();
+    }
+
+    static Path resolveLogPathForTest(Path gameDir) {
+        return gameDir.resolve("logs").resolve(FILE_NAME);
+    }
+
+    private static Path resolveLogPath() {
+        if (logPath != null) {
+            return logPath;
+        }
+        Minecraft client = Minecraft.getInstance();
+        if (client == null || client.gameDirectory == null) {
+            return null;
+        }
+        logPath = client.gameDirectory.toPath().resolve("logs").resolve(FILE_NAME);
+        return logPath;
+    }
+
+    private static void appendLine(String line) {
+        try {
+            Path path = resolveLogPath();
+            if (path == null) {
+                return;
+            }
+            if (writer == null) {
+                Files.createDirectories(path.getParent());
+                writer = Files.newBufferedWriter(
+                        path,
+                        StandardCharsets.UTF_8,
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND
+                );
+            }
+            writer.write(line);
+            writer.newLine();
+            writer.flush();
+        } catch (IOException e) {
+            logIoFailure("Failed to append portal perf log", e);
+            close();
+        }
+    }
+
+    private static void field(StringBuilder sb, String name, Object value, boolean numeric) {
+        sb.append('"').append(name).append("\":");
+        if (numeric) {
+            if (value instanceof Double d) {
+                appendNumber(sb, d);
+            } else if (value instanceof Float f) {
+                appendNumber(sb, f);
+            } else {
+                sb.append(value);
+            }
+        } else {
+            sb.append('"').append(escape(String.valueOf(value))).append('"');
+        }
+        sb.append(',');
+    }
+
+    private static void appendNumber(StringBuilder sb, double value) {
+        sb.append(String.format(Locale.ROOT, "%.4f", value));
+    }
+
+    private static String escape(String raw) {
+        return raw.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+
+    private static void logIoFailure(String message, Exception e) {
+        if (ioFailedLogged) {
+            return;
+        }
+        ioFailedLogged = true;
+        LOGGER.warn(message, e);
+    }
+
+    static void resetForTests() {
+        close();
+        lastAppendMs = 0L;
+        ioFailedLogged = false;
+        logPath = null;
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
@@ -112,6 +112,12 @@ public final class PortalPerfDebugLog {
         field(sb, "cullCulled", snap.chunksCulled(), true);
         field(sb, "avgBakeCount", snap.avgBakeCount(), true);
         field(sb, "avgBakeSkipCount", snap.avgBakeSkipCount(), true);
+        field(sb, "avgEntityUpdates", snap.avgEntityUpdates(), true);
+        field(sb, "maxPoseDelta", snap.avgMaxPoseDelta(), true);
+        field(sb, "partialTickUsed", (double) snap.partialTickUsed(), true);
+        field(sb, "itemAgeInTicks", (double) snap.itemAgeInTicks(), true);
+        field(sb, "avgIdentityInterp", snap.avgIdentityInterp(), true);
+        field(sb, "avgAdvanceInterp", snap.avgAdvanceInterp(), true);
         // field() always appends comma — strip final comma before closing
         if (sb.charAt(sb.length() - 1) == ',') {
             sb.setLength(sb.length() - 1);

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugLog.java
@@ -113,11 +113,22 @@ public final class PortalPerfDebugLog {
         field(sb, "avgBakeCount", snap.avgBakeCount(), true);
         field(sb, "avgBakeSkipCount", snap.avgBakeSkipCount(), true);
         field(sb, "avgEntityUpdates", snap.avgEntityUpdates(), true);
+        field(sb, "avgEntitySpawns", snap.avgEntitySpawns(), true);
+        field(sb, "avgEntityRemoves", snap.avgEntityRemoves(), true);
         field(sb, "maxPoseDelta", snap.avgMaxPoseDelta(), true);
         field(sb, "partialTickUsed", (double) snap.partialTickUsed(), true);
         field(sb, "itemAgeInTicks", (double) snap.itemAgeInTicks(), true);
         field(sb, "avgIdentityInterp", snap.avgIdentityInterp(), true);
         field(sb, "avgAdvanceInterp", snap.avgAdvanceInterp(), true);
+        PortalPerfStats.ServerDiag srv = snap.serverDiag();
+        if (srv != null && srv.isPresent()) {
+            field(sb, "msptMs", (double) srv.msptMs(), true);
+            field(sb, "syncFlushMs", (double) srv.syncFlushMs(), true);
+            field(sb, "srvEntityUpdates", srv.entityUpdates(), true);
+            field(sb, "srvEntitySpawns", srv.entitySpawns(), true);
+            field(sb, "srvFullResyncs", srv.fullResyncs(), true);
+            field(sb, "srvViewers", srv.viewers(), true);
+        }
         // field() always appends comma — strip final comma before closing
         if (sb.charAt(sb.length() - 1) == ',') {
             sb.setLength(sb.length() - 1);

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
@@ -36,6 +36,14 @@ public final class PortalPerfStats {
     private static int meshBakeCountThisFrame;
     private static int meshBakeSkipCountThisFrame;
     private static long lastMeshBakeNs;
+    private static int entityUpdatesThisFrame;
+    private static int entitySpawnsThisFrame;
+    private static int entityRemovesThisFrame;
+    private static double maxPoseDeltaThisFrame;
+    private static int identityInterpThisFrame;
+    private static int advanceInterpThisFrame;
+    private static float partialTickThisFrame = Float.NaN;
+    private static float itemAgeInTicksThisFrame = Float.NaN;
     private static volatile Snapshot published = Snapshot.IDLE;
     private static volatile DisplaySnapshot display = DisplaySnapshot.IDLE;
     private static double totalEmaMs;
@@ -127,6 +135,65 @@ public final class PortalPerfStats {
         meshBakeSkipCountThisFrame++;
     }
 
+    public static void noteEntityUpdate() {
+        if (!isEnabled()) {
+            return;
+        }
+        entityUpdatesThisFrame++;
+    }
+
+    public static void noteEntitySpawn() {
+        if (!isEnabled()) {
+            return;
+        }
+        entitySpawnsThisFrame++;
+    }
+
+    public static void noteEntityRemove() {
+        if (!isEnabled()) {
+            return;
+        }
+        entityRemovesThisFrame++;
+    }
+
+    /** Records a pose movement sample; keeps the max for the current frame. */
+    public static void notePoseDelta(double delta) {
+        if (!isEnabled() || !(delta > 0.0)) {
+            return;
+        }
+        if (delta > maxPoseDeltaThisFrame) {
+            maxPoseDeltaThisFrame = delta;
+        }
+    }
+
+    public static void noteIdentityInterp() {
+        if (!isEnabled()) {
+            return;
+        }
+        identityInterpThisFrame++;
+    }
+
+    public static void noteAdvanceInterp() {
+        if (!isEnabled()) {
+            return;
+        }
+        advanceInterpThisFrame++;
+    }
+
+    public static void notePartialTick(float partialTick) {
+        if (!isEnabled()) {
+            return;
+        }
+        partialTickThisFrame = partialTick;
+    }
+
+    public static void noteItemAgeInTicks(float ageInTicks) {
+        if (!isEnabled()) {
+            return;
+        }
+        itemAgeInTicksThisFrame = ageInTicks;
+    }
+
     /**
      * Publishes the current frame into history + display averages and resets transient timers.
      */
@@ -160,7 +227,15 @@ public final class PortalPerfStats {
                 MapCopy.copyDoubles(stageMs),
                 totalMs,
                 meshBakeCountThisFrame,
-                meshBakeSkipCountThisFrame
+                meshBakeSkipCountThisFrame,
+                entityUpdatesThisFrame,
+                entitySpawnsThisFrame,
+                entityRemovesThisFrame,
+                maxPoseDeltaThisFrame,
+                identityInterpThisFrame,
+                advanceInterpThisFrame,
+                partialTickThisFrame,
+                itemAgeInTicksThisFrame
         );
         pushHistory(sample);
 
@@ -178,7 +253,9 @@ public final class PortalPerfStats {
                 lastMeshBakeNs,
                 totalMs,
                 totalEmaMs,
-                maxStage
+                maxStage,
+                partialTickThisFrame,
+                itemAgeInTicksThisFrame
         );
         published = snap;
         display = buildDisplay(snap);
@@ -186,6 +263,14 @@ public final class PortalPerfStats {
         meshBakeNsThisFrame = 0L;
         meshBakeCountThisFrame = 0;
         meshBakeSkipCountThisFrame = 0;
+        entityUpdatesThisFrame = 0;
+        entitySpawnsThisFrame = 0;
+        entityRemovesThisFrame = 0;
+        maxPoseDeltaThisFrame = 0.0;
+        identityInterpThisFrame = 0;
+        advanceInterpThisFrame = 0;
+        partialTickThisFrame = Float.NaN;
+        itemAgeInTicksThisFrame = Float.NaN;
 
         PortalPerfDebugLog.maybeAppend(display);
     }
@@ -271,6 +356,16 @@ public final class PortalPerfStats {
                     snap.avgBakeSkipCount()
             ));
         }
+        lines.add(String.format(
+                Locale.ROOT,
+                "ent upd: %.2f  poseΔ: %.4f  partial: %.3f  itemAge: %.2f  id/adv: %.2f/%.2f",
+                snap.avgEntityUpdates(),
+                snap.avgMaxPoseDelta(),
+                snap.partialTickUsed(),
+                snap.itemAgeInTicks(),
+                snap.avgIdentityInterp(),
+                snap.avgAdvanceInterp()
+        ));
         if (snap.maxAvgStage() != null) {
             lines.add(String.format(
                     Locale.ROOT,
@@ -343,11 +438,39 @@ public final class PortalPerfStats {
     }
 
     static void pushSampleForTest(EnumMap<Stage, Double> stageMs, double totalMs, int bakeCount, int bakeSkipCount) {
+        pushSampleForTest(stageMs, totalMs, bakeCount, bakeSkipCount, 0, 0.0, 0, 0, Float.NaN, Float.NaN);
+    }
+
+    static void pushSampleForTest(
+            EnumMap<Stage, Double> stageMs,
+            double totalMs,
+            int bakeCount,
+            int bakeSkipCount,
+            int entityUpdates,
+            double maxPoseDelta,
+            int identityInterp,
+            int advanceInterp,
+            float partialTick,
+            float itemAgeInTicks
+    ) {
         EnumMap<Stage, Double> copy = MapCopy.copyDoubles(stageMs);
         for (Stage stage : Stage.HUD_ORDER) {
             copy.putIfAbsent(stage, 0.0);
         }
-        pushHistory(new FrameSample(copy, totalMs, bakeCount, bakeSkipCount));
+        pushHistory(new FrameSample(
+                copy,
+                totalMs,
+                bakeCount,
+                bakeSkipCount,
+                entityUpdates,
+                0,
+                0,
+                maxPoseDelta,
+                identityInterp,
+                advanceInterp,
+                partialTick,
+                itemAgeInTicks
+        ));
         totalEmaMs = updateEma(totalEmaMs, totalMs, EMA_ALPHA);
         display = buildDisplay(new Snapshot(
                 activeKey != null ? activeKey : PortalKey.soto(UUID.fromString("00000000-0000-0000-0000-000000000001")),
@@ -363,7 +486,9 @@ public final class PortalPerfStats {
                 0L,
                 totalMs,
                 totalEmaMs,
-                findMaxAvgStage(copy)
+                findMaxAvgStage(copy),
+                partialTick,
+                itemAgeInTicks
         ));
     }
 
@@ -390,6 +515,14 @@ public final class PortalPerfStats {
         meshBakeCountThisFrame = 0;
         meshBakeSkipCountThisFrame = 0;
         lastMeshBakeNs = 0L;
+        entityUpdatesThisFrame = 0;
+        entitySpawnsThisFrame = 0;
+        entityRemovesThisFrame = 0;
+        maxPoseDeltaThisFrame = 0.0;
+        identityInterpThisFrame = 0;
+        advanceInterpThisFrame = 0;
+        partialTickThisFrame = Float.NaN;
+        itemAgeInTicksThisFrame = Float.NaN;
         published = Snapshot.IDLE;
         display = DisplaySnapshot.IDLE;
         totalEmaMs = 0.0;
@@ -423,16 +556,35 @@ public final class PortalPerfStats {
         double[] totals = new double[window];
         double[] bakeCounts = new double[window];
         double[] bakeSkipCounts = new double[window];
+        double[] entityUpdates = new double[window];
+        double[] maxPoseDeltas = new double[window];
+        double[] identityInterps = new double[window];
+        double[] advanceInterps = new double[window];
         for (int i = 0; i < window; i++) {
             FrameSample sample = historyAt(historySize - window + i);
             totals[i] = sample.totalMs();
             bakeCounts[i] = sample.bakeCount();
             bakeSkipCounts[i] = sample.bakeSkipCount();
+            entityUpdates[i] = sample.entityUpdates();
+            maxPoseDeltas[i] = sample.maxPoseDelta();
+            identityInterps[i] = sample.identityInterp();
+            advanceInterps[i] = sample.advanceInterp();
         }
         double avgTotal = windowAverage(totals, window);
         double avgBake = windowAverage(bakeCounts, window);
         double avgBakeSkip = windowAverage(bakeSkipCounts, window);
         Stage maxAvg = findMaxAvgStage(avgStages);
+        float partial = latest.partialTickUsed();
+        float itemAge = latest.itemAgeInTicks();
+        if (window > 0) {
+            FrameSample newest = historyAt(historySize - 1);
+            if (Float.isNaN(partial) && !Float.isNaN(newest.partialTick())) {
+                partial = newest.partialTick();
+            }
+            if (Float.isNaN(itemAge) && !Float.isNaN(newest.itemAgeInTicks())) {
+                itemAge = newest.itemAgeInTicks();
+            }
+        }
         return new DisplaySnapshot(
                 latest.key(),
                 latest.outcome(),
@@ -447,7 +599,13 @@ public final class PortalPerfStats {
                 window,
                 avgBake,
                 avgBakeSkip,
-                maxAvg
+                maxAvg,
+                windowAverage(entityUpdates, window),
+                windowAverage(maxPoseDeltas, window),
+                Float.isNaN(partial) ? 0.0f : partial,
+                Float.isNaN(itemAge) ? 0.0f : itemAge,
+                windowAverage(identityInterps, window),
+                windowAverage(advanceInterps, window)
         );
     }
 
@@ -573,7 +731,9 @@ public final class PortalPerfStats {
             long lastMeshBakeNs,
             double totalMs,
             double totalEmaMs,
-            Stage maxStage
+            Stage maxStage,
+            float partialTickUsed,
+            float itemAgeInTicks
     ) {
         static final Snapshot IDLE = new Snapshot(
                 null,
@@ -582,7 +742,9 @@ public final class PortalPerfStats {
                 0, 0, 0, 0, 0,
                 0L, 0, 0L,
                 0.0, 0.0,
-                null
+                null,
+                Float.NaN,
+                Float.NaN
         );
     }
 
@@ -600,7 +762,13 @@ public final class PortalPerfStats {
             int windowCount,
             double avgBakeCount,
             double avgBakeSkipCount,
-            Stage maxAvgStage
+            Stage maxAvgStage,
+            double avgEntityUpdates,
+            double avgMaxPoseDelta,
+            float partialTickUsed,
+            float itemAgeInTicks,
+            double avgIdentityInterp,
+            double avgAdvanceInterp
     ) {
         static final DisplaySnapshot IDLE = new DisplaySnapshot(
                 null,
@@ -608,7 +776,8 @@ public final class PortalPerfStats {
                 new EnumMap<>(Stage.class),
                 0, 0, 0, 0, 0,
                 0.0, 0.0, 0, 0.0, 0.0,
-                null
+                null,
+                0.0, 0.0, 0.0f, 0.0f, 0.0, 0.0
         );
     }
 
@@ -616,7 +785,15 @@ public final class PortalPerfStats {
             EnumMap<Stage, Double> stageMs,
             double totalMs,
             int bakeCount,
-            int bakeSkipCount
+            int bakeSkipCount,
+            int entityUpdates,
+            int entitySpawns,
+            int entityRemoves,
+            double maxPoseDelta,
+            int identityInterp,
+            int advanceInterp,
+            float partialTick,
+            float itemAgeInTicks
     ) {
     }
 

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.render.portal;
 
 import com.adamkali.dwm.config.DWMConfig;
+import com.adamkali.dwm.network.SyncPortalPerfS2CPayload;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -44,6 +45,7 @@ public final class PortalPerfStats {
     private static int advanceInterpThisFrame;
     private static float partialTickThisFrame = Float.NaN;
     private static float itemAgeInTicksThisFrame = Float.NaN;
+    private static volatile ServerDiag serverDiag = ServerDiag.NONE;
     private static volatile Snapshot published = Snapshot.IDLE;
     private static volatile DisplaySnapshot display = DisplaySnapshot.IDLE;
     private static double totalEmaMs;
@@ -194,6 +196,18 @@ public final class PortalPerfStats {
         itemAgeInTicksThisFrame = ageInTicks;
     }
 
+    /** Applies the latest ~1 Hz server portal-sync diagnostics snapshot. */
+    public static void applyServerDiag(SyncPortalPerfS2CPayload payload) {
+        if (!isEnabled() || payload == null || Float.isNaN(payload.msptMs())) {
+            return;
+        }
+        serverDiag = ServerDiag.fromPayload(payload);
+        DisplaySnapshot current = display;
+        if (current != null && current != DisplaySnapshot.IDLE) {
+            display = current.withServerDiag(serverDiag);
+        }
+    }
+
     /**
      * Publishes the current frame into history + display averages and resets transient timers.
      */
@@ -202,6 +216,7 @@ public final class PortalPerfStats {
         if (!enabled) {
             if (wasEnabled) {
                 PortalPerfDebugLog.close();
+                serverDiag = ServerDiag.NONE;
                 wasEnabled = false;
             }
             return;
@@ -358,14 +373,29 @@ public final class PortalPerfStats {
         }
         lines.add(String.format(
                 Locale.ROOT,
-                "ent upd: %.2f  poseΔ: %.4f  partial: %.3f  itemAge: %.2f  id/adv: %.2f/%.2f",
+                "ent upd: %.2f  spawn/rm: %.2f/%.2f  poseΔ: %.4f  partial: %.3f  itemAge: %.2f  id/adv: %.2f/%.2f",
                 snap.avgEntityUpdates(),
+                snap.avgEntitySpawns(),
+                snap.avgEntityRemoves(),
                 snap.avgMaxPoseDelta(),
                 snap.partialTickUsed(),
                 snap.itemAgeInTicks(),
                 snap.avgIdentityInterp(),
                 snap.avgAdvanceInterp()
         ));
+        if (snap.serverDiag() != null && snap.serverDiag().isPresent()) {
+            ServerDiag srv = snap.serverDiag();
+            lines.add(String.format(
+                    Locale.ROOT,
+                    "srv mspt: %.1f  sync: %.2fms  upd: %d  spawn: %d  resync: %d  viewers: %d",
+                    srv.msptMs(),
+                    srv.syncFlushMs(),
+                    srv.entityUpdates(),
+                    srv.entitySpawns(),
+                    srv.fullResyncs(),
+                    srv.viewers()
+            ));
+        }
         if (snap.maxAvgStage() != null) {
             lines.add(String.format(
                     Locale.ROOT,
@@ -523,6 +553,7 @@ public final class PortalPerfStats {
         advanceInterpThisFrame = 0;
         partialTickThisFrame = Float.NaN;
         itemAgeInTicksThisFrame = Float.NaN;
+        serverDiag = ServerDiag.NONE;
         published = Snapshot.IDLE;
         display = DisplaySnapshot.IDLE;
         totalEmaMs = 0.0;
@@ -557,6 +588,8 @@ public final class PortalPerfStats {
         double[] bakeCounts = new double[window];
         double[] bakeSkipCounts = new double[window];
         double[] entityUpdates = new double[window];
+        double[] entitySpawns = new double[window];
+        double[] entityRemoves = new double[window];
         double[] maxPoseDeltas = new double[window];
         double[] identityInterps = new double[window];
         double[] advanceInterps = new double[window];
@@ -566,6 +599,8 @@ public final class PortalPerfStats {
             bakeCounts[i] = sample.bakeCount();
             bakeSkipCounts[i] = sample.bakeSkipCount();
             entityUpdates[i] = sample.entityUpdates();
+            entitySpawns[i] = sample.entitySpawns();
+            entityRemoves[i] = sample.entityRemoves();
             maxPoseDeltas[i] = sample.maxPoseDelta();
             identityInterps[i] = sample.identityInterp();
             advanceInterps[i] = sample.advanceInterp();
@@ -601,11 +636,14 @@ public final class PortalPerfStats {
                 avgBakeSkip,
                 maxAvg,
                 windowAverage(entityUpdates, window),
+                windowAverage(entitySpawns, window),
+                windowAverage(entityRemoves, window),
                 windowAverage(maxPoseDeltas, window),
                 Float.isNaN(partial) ? 0.0f : partial,
                 Float.isNaN(itemAge) ? 0.0f : itemAge,
                 windowAverage(identityInterps, window),
-                windowAverage(advanceInterps, window)
+                windowAverage(advanceInterps, window),
+                serverDiag
         );
     }
 
@@ -764,11 +802,14 @@ public final class PortalPerfStats {
             double avgBakeSkipCount,
             Stage maxAvgStage,
             double avgEntityUpdates,
+            double avgEntitySpawns,
+            double avgEntityRemoves,
             double avgMaxPoseDelta,
             float partialTickUsed,
             float itemAgeInTicks,
             double avgIdentityInterp,
-            double avgAdvanceInterp
+            double avgAdvanceInterp,
+            ServerDiag serverDiag
     ) {
         static final DisplaySnapshot IDLE = new DisplaySnapshot(
                 null,
@@ -777,8 +818,73 @@ public final class PortalPerfStats {
                 0, 0, 0, 0, 0,
                 0.0, 0.0, 0, 0.0, 0.0,
                 null,
-                0.0, 0.0, 0.0f, 0.0f, 0.0, 0.0
+                0.0, 0.0, 0.0, 0.0, 0.0f, 0.0f, 0.0, 0.0,
+                ServerDiag.NONE
         );
+
+        DisplaySnapshot withServerDiag(ServerDiag diag) {
+            return new DisplaySnapshot(
+                    key,
+                    outcome,
+                    avgStageMs,
+                    chunkCount,
+                    meshChunkCount,
+                    entityCount,
+                    chunksKept,
+                    chunksCulled,
+                    avgTotalMs,
+                    emaTotalMs,
+                    windowCount,
+                    avgBakeCount,
+                    avgBakeSkipCount,
+                    maxAvgStage,
+                    avgEntityUpdates,
+                    avgEntitySpawns,
+                    avgEntityRemoves,
+                    avgMaxPoseDelta,
+                    partialTickUsed,
+                    itemAgeInTicks,
+                    avgIdentityInterp,
+                    avgAdvanceInterp,
+                    diag == null ? ServerDiag.NONE : diag
+            );
+        }
+    }
+
+    public record ServerDiag(
+            float msptMs,
+            float syncFlushMs,
+            float syncEntitiesMs,
+            int entityUpdates,
+            int entitySpawns,
+            int entityRemoves,
+            int fullResyncs,
+            int viewers,
+            int activeStreams,
+            int serverTick
+    ) {
+        static final ServerDiag NONE = new ServerDiag(
+                Float.NaN, 0.0f, 0.0f, 0, 0, 0, 0, 0, 0, 0
+        );
+
+        static ServerDiag fromPayload(SyncPortalPerfS2CPayload payload) {
+            return new ServerDiag(
+                    payload.msptMs(),
+                    payload.syncFlushMs(),
+                    payload.syncEntitiesMs(),
+                    payload.entityUpdates(),
+                    payload.entitySpawns(),
+                    payload.entityRemoves(),
+                    payload.fullResyncs(),
+                    payload.viewers(),
+                    payload.activeStreams(),
+                    payload.serverTick()
+            );
+        }
+
+        public boolean isPresent() {
+            return !Float.isNaN(msptMs);
+        }
     }
 
     private record FrameSample(

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
@@ -34,6 +34,7 @@ public final class PortalPerfStats {
     private static int chunksCulled;
     private static long meshBakeNsThisFrame;
     private static int meshBakeCountThisFrame;
+    private static int meshBakeSkipCountThisFrame;
     private static long lastMeshBakeNs;
     private static volatile Snapshot published = Snapshot.IDLE;
     private static volatile DisplaySnapshot display = DisplaySnapshot.IDLE;
@@ -118,6 +119,14 @@ public final class PortalPerfStats {
         addStageNs(Stage.MESH_BAKE, bakeNs);
     }
 
+    /** Records a skipped mesh bake (unchanged chunk content with drawable mesh). */
+    public static void noteBakeSkip() {
+        if (!isEnabled()) {
+            return;
+        }
+        meshBakeSkipCountThisFrame++;
+    }
+
     /**
      * Publishes the current frame into history + display averages and resets transient timers.
      */
@@ -150,7 +159,8 @@ public final class PortalPerfStats {
         FrameSample sample = new FrameSample(
                 MapCopy.copyDoubles(stageMs),
                 totalMs,
-                meshBakeCountThisFrame
+                meshBakeCountThisFrame,
+                meshBakeSkipCountThisFrame
         );
         pushHistory(sample);
 
@@ -175,6 +185,7 @@ public final class PortalPerfStats {
         STAGE_NS.clear();
         meshBakeNsThisFrame = 0L;
         meshBakeCountThisFrame = 0;
+        meshBakeSkipCountThisFrame = 0;
 
         PortalPerfDebugLog.maybeAppend(display);
     }
@@ -251,12 +262,13 @@ public final class PortalPerfStats {
                 snap.chunksCulled()
         ));
         double bakeAvg = snap.avgStageMs().getOrDefault(Stage.MESH_BAKE, 0.0);
-        if (bakeAvg > 0.0 || snap.avgBakeCount() > 0.0) {
+        if (bakeAvg > 0.0 || snap.avgBakeCount() > 0.0 || snap.avgBakeSkipCount() > 0.0) {
             lines.add(String.format(
                     Locale.ROOT,
-                    "bakeAvg: %.2fms  bakeCount/frame: %.2f",
+                    "bakeAvg: %.2fms  bakeCount/frame: %.2f  bakeSkip/frame: %.2f",
                     bakeAvg,
-                    snap.avgBakeCount()
+                    snap.avgBakeCount(),
+                    snap.avgBakeSkipCount()
             ));
         }
         if (snap.maxAvgStage() != null) {
@@ -327,11 +339,15 @@ public final class PortalPerfStats {
 
     /** Test helper: push a synthetic sample without requiring config/timers. */
     static void pushSampleForTest(EnumMap<Stage, Double> stageMs, double totalMs, int bakeCount) {
+        pushSampleForTest(stageMs, totalMs, bakeCount, 0);
+    }
+
+    static void pushSampleForTest(EnumMap<Stage, Double> stageMs, double totalMs, int bakeCount, int bakeSkipCount) {
         EnumMap<Stage, Double> copy = MapCopy.copyDoubles(stageMs);
         for (Stage stage : Stage.HUD_ORDER) {
             copy.putIfAbsent(stage, 0.0);
         }
-        pushHistory(new FrameSample(copy, totalMs, bakeCount));
+        pushHistory(new FrameSample(copy, totalMs, bakeCount, bakeSkipCount));
         totalEmaMs = updateEma(totalEmaMs, totalMs, EMA_ALPHA);
         display = buildDisplay(new Snapshot(
                 activeKey != null ? activeKey : PortalKey.soto(UUID.fromString("00000000-0000-0000-0000-000000000001")),
@@ -372,6 +388,7 @@ public final class PortalPerfStats {
         chunksCulled = 0;
         meshBakeNsThisFrame = 0L;
         meshBakeCountThisFrame = 0;
+        meshBakeSkipCountThisFrame = 0;
         lastMeshBakeNs = 0L;
         published = Snapshot.IDLE;
         display = DisplaySnapshot.IDLE;
@@ -405,13 +422,16 @@ public final class PortalPerfStats {
         }
         double[] totals = new double[window];
         double[] bakeCounts = new double[window];
+        double[] bakeSkipCounts = new double[window];
         for (int i = 0; i < window; i++) {
             FrameSample sample = historyAt(historySize - window + i);
             totals[i] = sample.totalMs();
             bakeCounts[i] = sample.bakeCount();
+            bakeSkipCounts[i] = sample.bakeSkipCount();
         }
         double avgTotal = windowAverage(totals, window);
         double avgBake = windowAverage(bakeCounts, window);
+        double avgBakeSkip = windowAverage(bakeSkipCounts, window);
         Stage maxAvg = findMaxAvgStage(avgStages);
         return new DisplaySnapshot(
                 latest.key(),
@@ -426,6 +446,7 @@ public final class PortalPerfStats {
                 latest.totalEmaMs(),
                 window,
                 avgBake,
+                avgBakeSkip,
                 maxAvg
         );
     }
@@ -578,6 +599,7 @@ public final class PortalPerfStats {
             double emaTotalMs,
             int windowCount,
             double avgBakeCount,
+            double avgBakeSkipCount,
             Stage maxAvgStage
     ) {
         static final DisplaySnapshot IDLE = new DisplaySnapshot(
@@ -585,7 +607,7 @@ public final class PortalPerfStats {
                 Outcome.IDLE,
                 new EnumMap<>(Stage.class),
                 0, 0, 0, 0, 0,
-                0.0, 0.0, 0, 0.0,
+                0.0, 0.0, 0, 0.0, 0.0,
                 null
         );
     }
@@ -593,7 +615,8 @@ public final class PortalPerfStats {
     private record FrameSample(
             EnumMap<Stage, Double> stageMs,
             double totalMs,
-            int bakeCount
+            int bakeCount,
+            int bakeSkipCount
     ) {
     }
 

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
@@ -2,12 +2,16 @@ package com.adamkali.dwm.render.portal;
 
 import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.network.SyncPortalPerfS2CPayload;
+import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Config-gated CPU wall-time instrumentation for the shared BOTI/SOTO portal pipeline.
@@ -45,16 +49,27 @@ public final class PortalPerfStats {
     private static int advanceInterpThisFrame;
     private static float partialTickThisFrame = Float.NaN;
     private static float itemAgeInTicksThisFrame = Float.NaN;
+    /**
+     * Inter-frame pose baselines for {@link #noteLerpedPose}. Keyed by stream so BOTI/SOTO never share.
+     * Updated at most once per entity per published frame ({@link #SAMPLED_THIS_FRAME}).
+     */
+    private static final Map<PoseTrackKey, PoseXyz> LAST_POSES = new ConcurrentHashMap<>();
+    private static final Set<PoseTrackKey> SAMPLED_THIS_FRAME = ConcurrentHashMap.newKeySet();
     private static volatile ServerDiag serverDiag = ServerDiag.NONE;
     private static volatile Snapshot published = Snapshot.IDLE;
     private static volatile DisplaySnapshot display = DisplaySnapshot.IDLE;
     private static double totalEmaMs;
     private static boolean wasEnabled;
+    /** Non-null in unit tests to bypass {@link DWMConfig} (null = use config). */
+    private static Boolean enabledOverrideForTest;
 
     private PortalPerfStats() {
     }
 
     public static boolean isEnabled() {
+        if (enabledOverrideForTest != null) {
+            return enabledOverrideForTest;
+        }
         return DWMConfig.getBoolean(DWMConfig.SHOW_PORTAL_PERF_DEBUG);
     }
 
@@ -168,6 +183,64 @@ public final class PortalPerfStats {
         }
     }
 
+    /**
+     * Samples a ghost entity's lerped pose for inter-frame movement stats.
+     * <p>
+     * Only the first sample per {@code (kind, tardisId, entityUuid)} in a published frame
+     * compares against the previous frame's pose and updates the baseline. Later calls in the
+     * same frame (e.g. repeated {@code getRenderableEntities}) are ignored so intra-frame
+     * re-entry cannot shrink or replace the inter-frame delta.
+     */
+    public static void noteLerpedPose(
+            PortalStreamKind kind,
+            UUID tardisId,
+            UUID entityUuid,
+            double x,
+            double y,
+            double z
+    ) {
+        if (!isEnabled() || kind == null || tardisId == null || entityUuid == null) {
+            return;
+        }
+        PoseTrackKey key = new PoseTrackKey(kind, tardisId, entityUuid);
+        if (!SAMPLED_THIS_FRAME.add(key)) {
+            return;
+        }
+        PoseXyz previous = LAST_POSES.put(key, new PoseXyz(x, y, z));
+        if (previous == null) {
+            return;
+        }
+        double dx = x - previous.x();
+        double dy = y - previous.y();
+        double dz = z - previous.z();
+        notePoseDelta(Math.sqrt(dx * dx + dy * dy + dz * dz));
+    }
+
+    /** Drops pose baselines for one entity (remove / despawn). */
+    public static void clearPoseTracking(PortalStreamKind kind, UUID tardisId, UUID entityUuid) {
+        if (kind == null || tardisId == null || entityUuid == null) {
+            return;
+        }
+        PoseTrackKey key = new PoseTrackKey(kind, tardisId, entityUuid);
+        LAST_POSES.remove(key);
+        SAMPLED_THIS_FRAME.remove(key);
+    }
+
+    /** Drops pose baselines for an entire portal stream (invalidate). */
+    public static void clearPoseTracking(PortalStreamKind kind, UUID tardisId) {
+        if (kind == null || tardisId == null) {
+            return;
+        }
+        LAST_POSES.keySet().removeIf(k -> k.kind() == kind && k.tardisId().equals(tardisId));
+        SAMPLED_THIS_FRAME.removeIf(k -> k.kind() == kind && k.tardisId().equals(tardisId));
+    }
+
+    /** Drops all pose baselines (client disconnect / invalidateAll). */
+    public static void clearAllPoseTracking() {
+        LAST_POSES.clear();
+        SAMPLED_THIS_FRAME.clear();
+    }
+
     public static void noteIdentityInterp() {
         if (!isEnabled()) {
             return;
@@ -217,6 +290,8 @@ public final class PortalPerfStats {
             if (wasEnabled) {
                 PortalPerfDebugLog.close();
                 serverDiag = ServerDiag.NONE;
+                LAST_POSES.clear();
+                SAMPLED_THIS_FRAME.clear();
                 wasEnabled = false;
             }
             return;
@@ -286,8 +361,15 @@ public final class PortalPerfStats {
         advanceInterpThisFrame = 0;
         partialTickThisFrame = Float.NaN;
         itemAgeInTicksThisFrame = Float.NaN;
+        // Allow the next END_MAIN flush to sample each entity once against LAST_POSES.
+        SAMPLED_THIS_FRAME.clear();
 
         PortalPerfDebugLog.maybeAppend(display);
+    }
+
+    /** Package-visible for tests: max pose delta accumulated since the last {@link #publishFrame()}. */
+    static double maxPoseDeltaThisFrameForTest() {
+        return maxPoseDeltaThisFrame;
     }
 
     public static Snapshot snapshot() {
@@ -553,11 +635,24 @@ public final class PortalPerfStats {
         advanceInterpThisFrame = 0;
         partialTickThisFrame = Float.NaN;
         itemAgeInTicksThisFrame = Float.NaN;
+        LAST_POSES.clear();
+        SAMPLED_THIS_FRAME.clear();
         serverDiag = ServerDiag.NONE;
         published = Snapshot.IDLE;
         display = DisplaySnapshot.IDLE;
         totalEmaMs = 0.0;
         wasEnabled = false;
+        enabledOverrideForTest = null;
+    }
+
+    static void setEnabledOverrideForTest(Boolean enabled) {
+        enabledOverrideForTest = enabled;
+    }
+
+    private record PoseTrackKey(PortalStreamKind kind, UUID tardisId, UUID entityUuid) {
+    }
+
+    private record PoseXyz(double x, double y, double z) {
     }
 
     private static void pushHistory(FrameSample sample) {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfStats.java
@@ -1,0 +1,616 @@
+package com.adamkali.dwm.render.portal;
+
+import com.adamkali.dwm.config.DWMConfig;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * Config-gated CPU wall-time instrumentation for the shared BOTI/SOTO portal pipeline.
+ * Hot paths early-return when {@link DWMConfig#SHOW_PORTAL_PERF_DEBUG} is off.
+ * <p>
+ * HUD/log read rolling-window averages ({@link #AVG_WINDOW}) over a ring history
+ * ({@link #HISTORY_FRAMES}), not raw per-frame spikes.
+ */
+public final class PortalPerfStats {
+    public static final int HISTORY_FRAMES = 120;
+    public static final int AVG_WINDOW = 60;
+    private static final double EMA_ALPHA = 0.2;
+
+    private static final EnumMap<Stage, Long> STAGE_NS = new EnumMap<>(Stage.class);
+    private static final FrameSample[] HISTORY = new FrameSample[HISTORY_FRAMES];
+    private static int historySize;
+    private static int historyWrite;
+
+    private static PortalKey activeKey;
+    private static Outcome outcome = Outcome.IDLE;
+    private static int chunkCount;
+    private static int meshChunkCount;
+    private static int entityCount;
+    private static int chunksKept;
+    private static int chunksCulled;
+    private static long meshBakeNsThisFrame;
+    private static int meshBakeCountThisFrame;
+    private static long lastMeshBakeNs;
+    private static volatile Snapshot published = Snapshot.IDLE;
+    private static volatile DisplaySnapshot display = DisplaySnapshot.IDLE;
+    private static double totalEmaMs;
+    private static boolean wasEnabled;
+
+    private PortalPerfStats() {
+    }
+
+    public static boolean isEnabled() {
+        return DWMConfig.getBoolean(DWMConfig.SHOW_PORTAL_PERF_DEBUG);
+    }
+
+    /** Returns {@code System.nanoTime()} when enabled, else {@code -1} (no-op token). */
+    public static long begin() {
+        return isEnabled() ? System.nanoTime() : -1L;
+    }
+
+    public static void end(Stage stage, long startNs) {
+        if (startNs < 0L || !isEnabled() || stage == null) {
+            return;
+        }
+        addStageNs(stage, System.nanoTime() - startNs);
+    }
+
+    public static void addStageNs(Stage stage, long ns) {
+        if (!isEnabled() || stage == null || ns <= 0L) {
+            return;
+        }
+        STAGE_NS.merge(stage, ns, Long::sum);
+    }
+
+    public static void noteScheduled(PortalKey key) {
+        if (!isEnabled() || key == null) {
+            return;
+        }
+        activeKey = key;
+        if (outcome == Outcome.IDLE) {
+            outcome = Outcome.SCHEDULED;
+        }
+    }
+
+    public static void beginOffMain(PortalKey key) {
+        if (!isEnabled() || key == null) {
+            return;
+        }
+        activeKey = key;
+        outcome = Outcome.RENDERED;
+    }
+
+    public static void setOutcome(Outcome value) {
+        if (!isEnabled() || value == null) {
+            return;
+        }
+        outcome = value;
+    }
+
+    public static void setSceneCounts(int chunks, int meshes, int entities) {
+        if (!isEnabled()) {
+            return;
+        }
+        chunkCount = Math.max(0, chunks);
+        meshChunkCount = Math.max(0, meshes);
+        entityCount = Math.max(0, entities);
+    }
+
+    public static void setCullCounts(int kept, int culled) {
+        if (!isEnabled()) {
+            return;
+        }
+        chunksKept = Math.max(0, kept);
+        chunksCulled = Math.max(0, culled);
+    }
+
+    public static void noteMeshBake(long bakeNs) {
+        if (!isEnabled() || bakeNs <= 0L) {
+            return;
+        }
+        meshBakeNsThisFrame += bakeNs;
+        meshBakeCountThisFrame++;
+        lastMeshBakeNs = bakeNs;
+        addStageNs(Stage.MESH_BAKE, bakeNs);
+    }
+
+    /**
+     * Publishes the current frame into history + display averages and resets transient timers.
+     */
+    public static void publishFrame() {
+        boolean enabled = isEnabled();
+        if (!enabled) {
+            if (wasEnabled) {
+                PortalPerfDebugLog.close();
+                wasEnabled = false;
+            }
+            return;
+        }
+        wasEnabled = true;
+
+        EnumMap<Stage, Long> stages = new EnumMap<>(Stage.class);
+        stages.putAll(STAGE_NS);
+        long totalNs = stages.getOrDefault(Stage.OFF_MAIN_TOTAL, 0L);
+        if (totalNs <= 0L) {
+            totalNs = stages.getOrDefault(Stage.FLUSH_TOTAL, 0L);
+        }
+        double totalMs = nsToMs(totalNs);
+        totalEmaMs = updateEma(totalEmaMs, totalMs, EMA_ALPHA);
+        Stage maxStage = findMaxStage(stages);
+
+        EnumMap<Stage, Double> stageMs = new EnumMap<>(Stage.class);
+        for (Stage stage : Stage.HUD_ORDER) {
+            stageMs.put(stage, nsToMs(stages.getOrDefault(stage, 0L)));
+        }
+
+        FrameSample sample = new FrameSample(
+                MapCopy.copyDoubles(stageMs),
+                totalMs,
+                meshBakeCountThisFrame
+        );
+        pushHistory(sample);
+
+        Snapshot snap = new Snapshot(
+                activeKey,
+                outcome,
+                MapCopy.copy(stages),
+                chunkCount,
+                meshChunkCount,
+                entityCount,
+                chunksKept,
+                chunksCulled,
+                meshBakeNsThisFrame,
+                meshBakeCountThisFrame,
+                lastMeshBakeNs,
+                totalMs,
+                totalEmaMs,
+                maxStage
+        );
+        published = snap;
+        display = buildDisplay(snap);
+        STAGE_NS.clear();
+        meshBakeNsThisFrame = 0L;
+        meshBakeCountThisFrame = 0;
+
+        PortalPerfDebugLog.maybeAppend(display);
+    }
+
+    public static Snapshot snapshot() {
+        return published;
+    }
+
+    public static DisplaySnapshot displaySnapshot() {
+        return display;
+    }
+
+    public static List<String> formatLines(DisplaySnapshot snap) {
+        return formatLinesPure(snap);
+    }
+
+    /** Chronological total-ms history (oldest → newest), length {@code historySize()}. */
+    public static float[] historyTotalsMs() {
+        int size = historySize;
+        float[] out = new float[size];
+        for (int i = 0; i < size; i++) {
+            out[i] = (float) historyAt(i).totalMs();
+        }
+        return out;
+    }
+
+    public static int historySize() {
+        return historySize;
+    }
+
+    /** Pure formatter for tests / HUD — averages first. */
+    static List<String> formatLinesPure(DisplaySnapshot snap) {
+        List<String> lines = new ArrayList<>();
+        if (snap == null || snap == DisplaySnapshot.IDLE || snap.key() == null) {
+            lines.add("Portal Perf [idle]");
+            return lines;
+        }
+        PortalKey key = snap.key();
+        lines.add(String.format(
+                Locale.ROOT,
+                "Portal Perf [%s %s]",
+                key.kind().name(),
+                shortId(key.tardisId())
+        ));
+        lines.add(String.format(
+                Locale.ROOT,
+                "outcome: %s  avg: %.2fms (ema %.2f)  n=%d",
+                snap.outcome().label(),
+                snap.avgTotalMs(),
+                snap.emaTotalMs(),
+                snap.windowCount()
+        ));
+        lines.add(formatStagePair(snap, Stage.FLUSH_TOTAL, "flush", Stage.OFF_MAIN_TOTAL, "offMain"));
+        lines.add(formatStageQuad(
+                snap,
+                Stage.SKY_FOG, "skyFog",
+                Stage.TERRAIN_OPAQUE, "opaque",
+                Stage.TERRAIN_CUTOUT, "cutout",
+                Stage.TERRAIN_TRANSLUCENT, "trans"
+        ));
+        lines.add(formatStageTriple(
+                snap,
+                Stage.GHOST_FEATURES, "features",
+                Stage.PASS_BATCH_REBUILD, "batch",
+                Stage.MESH_BAKE, "bake"
+        ));
+        lines.add(String.format(
+                Locale.ROOT,
+                "chunks: %d mesh: %d ent: %d  cull: %d/%d",
+                snap.chunkCount(),
+                snap.meshChunkCount(),
+                snap.entityCount(),
+                snap.chunksKept(),
+                snap.chunksCulled()
+        ));
+        double bakeAvg = snap.avgStageMs().getOrDefault(Stage.MESH_BAKE, 0.0);
+        if (bakeAvg > 0.0 || snap.avgBakeCount() > 0.0) {
+            lines.add(String.format(
+                    Locale.ROOT,
+                    "bakeAvg: %.2fms  bakeCount/frame: %.2f",
+                    bakeAvg,
+                    snap.avgBakeCount()
+            ));
+        }
+        if (snap.maxAvgStage() != null) {
+            lines.add(String.format(
+                    Locale.ROOT,
+                    "maxAvg: %s (%.2fms)",
+                    snap.maxAvgStage().label(),
+                    snap.avgStageMs().getOrDefault(snap.maxAvgStage(), 0.0)
+            ));
+        }
+        return lines;
+    }
+
+    static double updateEma(double previous, double sampleMs, double alpha) {
+        if (previous <= 0.0) {
+            return sampleMs;
+        }
+        return previous * (1.0 - alpha) + sampleMs * alpha;
+    }
+
+    static double nsToMs(long ns) {
+        return ns / 1_000_000.0;
+    }
+
+    static Stage findMaxStage(EnumMap<Stage, Long> stages) {
+        Stage max = null;
+        long maxNs = 0L;
+        for (Stage stage : Stage.HUD_ORDER) {
+            long ns = stages.getOrDefault(stage, 0L);
+            if (ns > maxNs) {
+                maxNs = ns;
+                max = stage;
+            }
+        }
+        return max;
+    }
+
+    static Stage findMaxAvgStage(EnumMap<Stage, Double> avgMs) {
+        Stage max = null;
+        double maxMs = 0.0;
+        for (Stage stage : Stage.HUD_ORDER) {
+            double ms = avgMs.getOrDefault(stage, 0.0);
+            if (ms > maxMs) {
+                maxMs = ms;
+                max = stage;
+            }
+        }
+        return max;
+    }
+
+    static double windowAverage(double[] samples, int count) {
+        if (count <= 0) {
+            return 0.0;
+        }
+        double sum = 0.0;
+        for (int i = 0; i < count; i++) {
+            sum += samples[i];
+        }
+        return sum / count;
+    }
+
+    static String shortId(UUID id) {
+        if (id == null) {
+            return "????????";
+        }
+        return id.toString().substring(0, 8);
+    }
+
+    /** Test helper: push a synthetic sample without requiring config/timers. */
+    static void pushSampleForTest(EnumMap<Stage, Double> stageMs, double totalMs, int bakeCount) {
+        EnumMap<Stage, Double> copy = MapCopy.copyDoubles(stageMs);
+        for (Stage stage : Stage.HUD_ORDER) {
+            copy.putIfAbsent(stage, 0.0);
+        }
+        pushHistory(new FrameSample(copy, totalMs, bakeCount));
+        totalEmaMs = updateEma(totalEmaMs, totalMs, EMA_ALPHA);
+        display = buildDisplay(new Snapshot(
+                activeKey != null ? activeKey : PortalKey.soto(UUID.fromString("00000000-0000-0000-0000-000000000001")),
+                outcome == Outcome.IDLE ? Outcome.RENDERED : outcome,
+                new EnumMap<>(Stage.class),
+                chunkCount,
+                meshChunkCount,
+                entityCount,
+                chunksKept,
+                chunksCulled,
+                0L,
+                bakeCount,
+                0L,
+                totalMs,
+                totalEmaMs,
+                findMaxAvgStage(copy)
+        ));
+    }
+
+    static void setIdentityForTest(PortalKey key, Outcome outcomeValue) {
+        activeKey = key;
+        outcome = outcomeValue;
+    }
+
+    static void resetForTests() {
+        STAGE_NS.clear();
+        for (int i = 0; i < HISTORY.length; i++) {
+            HISTORY[i] = null;
+        }
+        historySize = 0;
+        historyWrite = 0;
+        activeKey = null;
+        outcome = Outcome.IDLE;
+        chunkCount = 0;
+        meshChunkCount = 0;
+        entityCount = 0;
+        chunksKept = 0;
+        chunksCulled = 0;
+        meshBakeNsThisFrame = 0L;
+        meshBakeCountThisFrame = 0;
+        lastMeshBakeNs = 0L;
+        published = Snapshot.IDLE;
+        display = DisplaySnapshot.IDLE;
+        totalEmaMs = 0.0;
+        wasEnabled = false;
+    }
+
+    private static void pushHistory(FrameSample sample) {
+        HISTORY[historyWrite] = sample;
+        historyWrite = (historyWrite + 1) % HISTORY_FRAMES;
+        if (historySize < HISTORY_FRAMES) {
+            historySize++;
+        }
+    }
+
+    private static FrameSample historyAt(int chronologicalIndex) {
+        int start = (historyWrite - historySize + HISTORY_FRAMES) % HISTORY_FRAMES;
+        return HISTORY[(start + chronologicalIndex) % HISTORY_FRAMES];
+    }
+
+    private static DisplaySnapshot buildDisplay(Snapshot latest) {
+        int window = Math.min(AVG_WINDOW, historySize);
+        EnumMap<Stage, Double> avgStages = new EnumMap<>(Stage.class);
+        for (Stage stage : Stage.HUD_ORDER) {
+            double[] samples = new double[window];
+            for (int i = 0; i < window; i++) {
+                FrameSample sample = historyAt(historySize - window + i);
+                samples[i] = sample.stageMs().getOrDefault(stage, 0.0);
+            }
+            avgStages.put(stage, windowAverage(samples, window));
+        }
+        double[] totals = new double[window];
+        double[] bakeCounts = new double[window];
+        for (int i = 0; i < window; i++) {
+            FrameSample sample = historyAt(historySize - window + i);
+            totals[i] = sample.totalMs();
+            bakeCounts[i] = sample.bakeCount();
+        }
+        double avgTotal = windowAverage(totals, window);
+        double avgBake = windowAverage(bakeCounts, window);
+        Stage maxAvg = findMaxAvgStage(avgStages);
+        return new DisplaySnapshot(
+                latest.key(),
+                latest.outcome(),
+                MapCopy.copyDoubles(avgStages),
+                latest.chunkCount(),
+                latest.meshChunkCount(),
+                latest.entityCount(),
+                latest.chunksKept(),
+                latest.chunksCulled(),
+                avgTotal,
+                latest.totalEmaMs(),
+                window,
+                avgBake,
+                maxAvg
+        );
+    }
+
+    private static String formatStagePair(DisplaySnapshot snap, Stage a, String la, Stage b, String lb) {
+        return markMax(snap, a, la) + formatAvgMs(snap, a)
+                + "  " + markMax(snap, b, lb) + formatAvgMs(snap, b);
+    }
+
+    private static String formatStageTriple(
+            DisplaySnapshot snap,
+            Stage a, String la,
+            Stage b, String lb,
+            Stage c, String lc
+    ) {
+        return markMax(snap, a, la) + formatAvgMs(snap, a)
+                + "  " + markMax(snap, b, lb) + formatAvgMs(snap, b)
+                + "  " + markMax(snap, c, lc) + formatAvgMs(snap, c);
+    }
+
+    private static String formatStageQuad(
+            DisplaySnapshot snap,
+            Stage a, String la,
+            Stage b, String lb,
+            Stage c, String lc,
+            Stage d, String ld
+    ) {
+        return markMax(snap, a, la) + formatAvgMs(snap, a)
+                + "  " + markMax(snap, b, lb) + formatAvgMs(snap, b)
+                + "  " + markMax(snap, c, lc) + formatAvgMs(snap, c)
+                + "  " + markMax(snap, d, ld) + formatAvgMs(snap, d);
+    }
+
+    private static String markMax(DisplaySnapshot snap, Stage stage, String label) {
+        if (snap.maxAvgStage() == stage) {
+            return "*" + label + ": ";
+        }
+        return label + ": ";
+    }
+
+    private static String formatAvgMs(DisplaySnapshot snap, Stage stage) {
+        return String.format(Locale.ROOT, "%.2f", snap.avgStageMs().getOrDefault(stage, 0.0));
+    }
+
+    public enum Stage {
+        FLUSH_TOTAL("flush"),
+        OFF_MAIN_TOTAL("offMain"),
+        SKY_FOG("skyFog"),
+        TERRAIN_OPAQUE("opaque"),
+        TERRAIN_CUTOUT("cutout"),
+        TERRAIN_TRANSLUCENT("trans"),
+        GHOST_FEATURES("features"),
+        MESH_BAKE("bake"),
+        PASS_BATCH_REBUILD("batch"),
+        COMPOSITE("composite");
+
+        static final Stage[] HUD_ORDER = {
+                FLUSH_TOTAL,
+                OFF_MAIN_TOTAL,
+                SKY_FOG,
+                TERRAIN_OPAQUE,
+                TERRAIN_CUTOUT,
+                TERRAIN_TRANSLUCENT,
+                GHOST_FEATURES,
+                PASS_BATCH_REBUILD,
+                MESH_BAKE,
+                COMPOSITE
+        };
+
+        /** Leaf stages for stacked bar (excludes nested flush/offMain totals). */
+        public static final Stage[] LEAF_STAGES = {
+                SKY_FOG,
+                TERRAIN_OPAQUE,
+                TERRAIN_CUTOUT,
+                TERRAIN_TRANSLUCENT,
+                GHOST_FEATURES,
+                PASS_BATCH_REBUILD,
+                MESH_BAKE,
+                COMPOSITE
+        };
+
+        private final String label;
+
+        Stage(String label) {
+            this.label = label;
+        }
+
+        public String label() {
+            return label;
+        }
+    }
+
+    public enum Outcome {
+        IDLE("idle"),
+        SCHEDULED("scheduled"),
+        NOT_READY("notReady"),
+        ONCE_PER_FRAME("oncePerFrame"),
+        FRAME_CACHE_HIT("frameCacheHit"),
+        RENDERED("rendered"),
+        FBO_FAIL("fboFail");
+
+        private final String label;
+
+        Outcome(String label) {
+            this.label = label;
+        }
+
+        public String label() {
+            return label;
+        }
+    }
+
+    public record Snapshot(
+            PortalKey key,
+            Outcome outcome,
+            EnumMap<Stage, Long> stageNs,
+            int chunkCount,
+            int meshChunkCount,
+            int entityCount,
+            int chunksKept,
+            int chunksCulled,
+            long meshBakeNs,
+            int meshBakeCount,
+            long lastMeshBakeNs,
+            double totalMs,
+            double totalEmaMs,
+            Stage maxStage
+    ) {
+        static final Snapshot IDLE = new Snapshot(
+                null,
+                Outcome.IDLE,
+                new EnumMap<>(Stage.class),
+                0, 0, 0, 0, 0,
+                0L, 0, 0L,
+                0.0, 0.0,
+                null
+        );
+    }
+
+    public record DisplaySnapshot(
+            PortalKey key,
+            Outcome outcome,
+            EnumMap<Stage, Double> avgStageMs,
+            int chunkCount,
+            int meshChunkCount,
+            int entityCount,
+            int chunksKept,
+            int chunksCulled,
+            double avgTotalMs,
+            double emaTotalMs,
+            int windowCount,
+            double avgBakeCount,
+            Stage maxAvgStage
+    ) {
+        static final DisplaySnapshot IDLE = new DisplaySnapshot(
+                null,
+                Outcome.IDLE,
+                new EnumMap<>(Stage.class),
+                0, 0, 0, 0, 0,
+                0.0, 0.0, 0, 0.0,
+                null
+        );
+    }
+
+    private record FrameSample(
+            EnumMap<Stage, Double> stageMs,
+            double totalMs,
+            int bakeCount
+    ) {
+    }
+
+    private static final class MapCopy {
+        private MapCopy() {
+        }
+
+        static EnumMap<Stage, Long> copy(EnumMap<Stage, Long> source) {
+            EnumMap<Stage, Long> copy = new EnumMap<>(Stage.class);
+            copy.putAll(source);
+            return copy;
+        }
+
+        static EnumMap<Stage, Double> copyDoubles(EnumMap<Stage, Double> source) {
+            EnumMap<Stage, Double> copy = new EnumMap<>(Stage.class);
+            copy.putAll(source);
+            return copy;
+        }
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalRenderTarget.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalRenderTarget.java
@@ -118,6 +118,7 @@ public final class PortalRenderTarget implements AutoCloseable {
                 width = requiredWidth;
                 height = requiredHeight;
                 renderedFrameByKey.clear();
+                PortalFrameCache.invalidateForResize();
             }
             return isReady();
         } catch (Throwable failure) {
@@ -254,6 +255,7 @@ public final class PortalRenderTarget implements AutoCloseable {
         }
         width = 0;
         height = 0;
+        PortalFrameCache.invalidateForResize();
     }
 
     long clientFrameForTest() {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalRenderer.java
@@ -99,8 +99,10 @@ public final class PortalRenderer {
                     PortalPerfStats.setOutcome(PortalPerfStats.Outcome.ONCE_PER_FRAME);
                     return peekLastRendered(key);
                 }
-                if (!PortalFrameCache.isDirty(key)
-                        && PortalFrameCache.wasLastWriter(key)
+                boolean dirty = PortalFrameCache.isDirty(key);
+                boolean lastWriter = PortalFrameCache.wasLastWriter(key);
+                if (!dirty
+                        && lastWriter
                         && renderedReady.contains(key)) {
                     PortalPerfStats.setOutcome(PortalPerfStats.Outcome.FRAME_CACHE_HIT);
                     return peekLastRendered(key);

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalRenderer.java
@@ -1,5 +1,8 @@
 package com.adamkali.dwm.render.portal;
 
+import com.adamkali.dwm.render.soto.ghost.SotoGhostExterior;
+import com.adamkali.dwm.render.soto.ghost.SotoGhostMeshCache;
+import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.mojang.blaze3d.opengl.GlStateManager;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -67,42 +70,69 @@ public final class PortalRenderer {
         if (client == null || client.level == null || client.gameRenderer == null) {
             return PortalTexture.UNAVAILABLE;
         }
-        PortalContent content = scene.content();
-        if (!content.isReady(client)) {
-            renderedReady.remove(scene.key());
-            return PortalTexture.UNAVAILABLE;
-        }
-        PortalCameraTransform.Result hitch = content.hitch(client);
-        if (hitch == null) {
-            renderedReady.remove(scene.key());
-            return PortalTexture.UNAVAILABLE;
-        }
-
-        try (PortalRenderTarget.RenderStateGuard ignored =
-                     PortalRenderTarget.RenderStateGuard.capture()) {
-            if (!target.ensureReady(client)) {
-                PortalSupport.disableForSession("Portal framebuffer is incomplete", null);
+        PortalKey key = scene.key();
+        PortalPerfStats.beginOffMain(key);
+        long offMainStart = PortalPerfStats.begin();
+        try {
+            PortalContent content = scene.content();
+            if (!content.isReady(client)) {
+                renderedReady.remove(key);
+                PortalPerfStats.setOutcome(PortalPerfStats.Outcome.NOT_READY);
                 return PortalTexture.UNAVAILABLE;
             }
-            PortalKey key = scene.key();
-            if (!target.shouldRenderThisFrame(key)) {
-                return peekLastRendered(key);
+            PortalCameraTransform.Result hitch = content.hitch(client);
+            if (hitch == null) {
+                renderedReady.remove(key);
+                PortalPerfStats.setOutcome(PortalPerfStats.Outcome.NOT_READY);
+                return PortalTexture.UNAVAILABLE;
             }
-            if (!PortalFrameCache.isDirty(key)
-                    && PortalFrameCache.wasLastWriter(key)
-                    && renderedReady.contains(key)) {
-                return peekLastRendered(key);
+            recordSceneCounts(key);
+
+            try (PortalRenderTarget.RenderStateGuard ignored =
+                         PortalRenderTarget.RenderStateGuard.capture()) {
+                if (!target.ensureReady(client)) {
+                    PortalSupport.disableForSession("Portal framebuffer is incomplete", null);
+                    PortalPerfStats.setOutcome(PortalPerfStats.Outcome.FBO_FAIL);
+                    return PortalTexture.UNAVAILABLE;
+                }
+                if (!target.shouldRenderThisFrame(key)) {
+                    PortalPerfStats.setOutcome(PortalPerfStats.Outcome.ONCE_PER_FRAME);
+                    return peekLastRendered(key);
+                }
+                if (!PortalFrameCache.isDirty(key)
+                        && PortalFrameCache.wasLastWriter(key)
+                        && renderedReady.contains(key)) {
+                    PortalPerfStats.setOutcome(PortalPerfStats.Outcome.FRAME_CACHE_HIT);
+                    return peekLastRendered(key);
+                }
+                renderScene(client, scene, hitch, content.clearRgb(client));
+                for (PortalKey overwritten : PortalFrameCache.overwrittenReadyKeys(key, renderedReady)) {
+                    renderedReady.remove(overwritten);
+                }
+                PortalFrameCache.noteRendered(key);
+                PortalFrameCache.clearDirty(key);
+                renderedReady.add(key);
+                PortalPerfStats.setOutcome(PortalPerfStats.Outcome.RENDERED);
+                int colorTex = target.colorTextureId();
+                return new PortalTexture(colorTex, target.width(), target.height(), hitch, true);
             }
-            renderScene(client, scene, hitch, content.clearRgb(client));
-            for (PortalKey overwritten : PortalFrameCache.overwrittenReadyKeys(key, renderedReady)) {
-                renderedReady.remove(overwritten);
-            }
-            PortalFrameCache.noteRendered(key);
-            PortalFrameCache.clearDirty(key);
-            renderedReady.add(key);
-            int colorTex = target.colorTextureId();
-            return new PortalTexture(colorTex, target.width(), target.height(), hitch, true);
+        } finally {
+            PortalPerfStats.end(PortalPerfStats.Stage.OFF_MAIN_TOTAL, offMainStart);
         }
+    }
+
+    private static void recordSceneCounts(PortalKey key) {
+        if (!PortalPerfStats.isEnabled() || key == null) {
+            return;
+        }
+        PortalStreamKind streamKind = key.kind() == PortalKind.SOTO
+                ? PortalStreamKind.SOTO
+                : PortalStreamKind.BOTI;
+        SotoGhostExterior ghost = SotoGhostExterior.get(streamKind, key.tardisId());
+        int chunks = ghost != null ? ghost.chunkCount() : 0;
+        int entities = ghost != null ? ghost.entityCount() : 0;
+        int meshes = SotoGhostMeshCache.meshChunkCount(streamKind, key.tardisId());
+        PortalPerfStats.setSceneCounts(chunks, meshes, entities);
     }
 
     private void renderScene(

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalRenderer.java
@@ -22,6 +22,9 @@ import net.minecraft.util.ARGB;
  * <p>
  * Mid-BER GPU work blacks out the world on 26.2. Call {@link #renderOffMainPass} from
  * {@code LevelRenderEvents.END_MAIN} only; BER uses {@link #peekLastRendered}.
+ * <p>
+ * Hitch-fixed scenes reuse the last color texture when {@link PortalFrameCache} reports
+ * clean content and this key was the last shared-FBO writer.
  */
 public final class PortalRenderer {
     private final PortalRenderTarget target;
@@ -81,11 +84,22 @@ public final class PortalRenderer {
                 PortalSupport.disableForSession("Portal framebuffer is incomplete", null);
                 return PortalTexture.UNAVAILABLE;
             }
-            if (!target.shouldRenderThisFrame(scene.key())) {
-                return peekLastRendered(scene.key());
+            PortalKey key = scene.key();
+            if (!target.shouldRenderThisFrame(key)) {
+                return peekLastRendered(key);
+            }
+            if (!PortalFrameCache.isDirty(key)
+                    && PortalFrameCache.wasLastWriter(key)
+                    && renderedReady.contains(key)) {
+                return peekLastRendered(key);
             }
             renderScene(client, scene, hitch, content.clearRgb(client));
-            renderedReady.add(scene.key());
+            for (PortalKey overwritten : PortalFrameCache.overwrittenReadyKeys(key, renderedReady)) {
+                renderedReady.remove(overwritten);
+            }
+            PortalFrameCache.noteRendered(key);
+            PortalFrameCache.clearDirty(key);
+            renderedReady.add(key);
             int colorTex = target.colorTextureId();
             return new PortalTexture(colorTex, target.width(), target.height(), hitch, true);
         }

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
@@ -50,7 +50,8 @@ public final class PortalSceneStore {
         PortalShellState shell = payload.shellState();
         PortalAtmosphere atmosphere = payload.atmosphere() == null ? PortalAtmosphere.DEFAULT : payload.atmosphere();
         META.put(key, new MetaEntry(payload.revision(), shell, atmosphere));
-        LAST_REQUEST_MS.remove(key);
+        // Do not clear LAST_REQUEST_MS here — that re-armed requestIfNeeded every meta
+        // packet and caused subscribe→sendFullChunks storms.
         PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
@@ -118,6 +119,13 @@ public final class PortalSceneStore {
             return;
         }
         SceneKey key = new SceneKey(kind, tardisId);
+        // Already have a live stream — incremental tick sync keeps it fresh.
+        if (META.containsKey(key)) {
+            SotoGhostExterior ghost = SotoGhostExterior.get(kind, tardisId);
+            if (ghost != null && ghost.chunkCount() > 0) {
+                return;
+            }
+        }
         long now = System.currentTimeMillis();
         Long last = LAST_REQUEST_MS.get(key);
         if (last != null && now - last < REQUEST_COOLDOWN_MS) {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
@@ -91,6 +91,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.applyEntitySpawn(payload.kind(), payload);
+        PortalPerfStats.noteEntitySpawn();
         PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
@@ -99,6 +100,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.applyEntityUpdate(payload.kind(), payload);
+        PortalPerfStats.noteEntityUpdate();
         PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
@@ -107,6 +109,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.removeEntity(payload.kind(), payload.tardisId(), payload.entityUuid());
+        PortalPerfStats.noteEntityRemove();
         PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
@@ -51,6 +51,7 @@ public final class PortalSceneStore {
         PortalAtmosphere atmosphere = payload.atmosphere() == null ? PortalAtmosphere.DEFAULT : payload.atmosphere();
         META.put(key, new MetaEntry(payload.revision(), shell, atmosphere));
         LAST_REQUEST_MS.remove(key);
+        PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
     public static PortalShellState getShell(PortalStreamKind kind, UUID tardisId) {
@@ -74,6 +75,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.applyChunk(payload.kind(), payload);
+        PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
     public static void unloadChunk(UnloadPortalChunkS2CPayload payload) {
@@ -81,6 +83,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.unloadChunk(payload.kind(), payload.tardisId(), payload.chunkX(), payload.chunkZ());
+        PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
     public static void applyEntitySpawn(SyncPortalEntitySpawnS2CPayload payload) {
@@ -88,6 +91,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.applyEntitySpawn(payload.kind(), payload);
+        PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
     public static void applyEntityUpdate(SyncPortalEntityUpdateS2CPayload payload) {
@@ -95,6 +99,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.applyEntityUpdate(payload.kind(), payload);
+        PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
     public static void removeEntity(SyncPortalEntityRemoveS2CPayload payload) {
@@ -102,6 +107,7 @@ public final class PortalSceneStore {
             return;
         }
         SotoGhostExterior.removeEntity(payload.kind(), payload.tardisId(), payload.entityUuid());
+        PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 
     public static void requestIfNeeded(PortalStreamKind kind, UUID tardisId) {
@@ -130,12 +136,14 @@ public final class PortalSceneStore {
         META.remove(key);
         LAST_REQUEST_MS.remove(key);
         SotoGhostExterior.invalidate(kind, tardisId);
+        PortalFrameCache.markDirty(kind, tardisId);
     }
 
     public static void invalidateAll() {
         META.clear();
         LAST_REQUEST_MS.clear();
         SotoGhostExterior.invalidateAll();
+        PortalFrameCache.markAllDirty();
     }
 
     public static void clientTick() {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalScheduler.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalScheduler.java
@@ -42,12 +42,23 @@ public final class PortalScheduler {
         }
         List<PortalScene> batch = new ArrayList<>(PENDING.values());
         PENDING.clear();
-        for (PortalScene scene : batch) {
-            try {
-                RENDERER.renderOffMainPass(scene);
-            } catch (Throwable t) {
-                PortalSupport.disableForSession("Portal END_MAIN flush failed", t);
-                break;
+        if (batch.isEmpty()) {
+            return;
+        }
+        long flushStart = PortalPerfStats.begin();
+        try {
+            for (PortalScene scene : batch) {
+                try {
+                    RENDERER.renderOffMainPass(scene);
+                } catch (Throwable t) {
+                    PortalSupport.disableForSession("Portal END_MAIN flush failed", t);
+                    break;
+                }
+            }
+        } finally {
+            PortalPerfStats.end(PortalPerfStats.Stage.FLUSH_TOTAL, flushStart);
+            if (PortalPerfStats.isEnabled()) {
+                PortalPerfStats.publishFrame();
             }
         }
     }

--- a/src/client/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCache.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCache.java
@@ -195,14 +195,11 @@ public final class SotoExteriorMeshCache {
         for (SotoGhostExterior.RenderableGhostEntity ghost : ghosts) {
             Entity entity = ghost.entity();
             LerpedPose pose = ghost.pose();
-            entity.setYRot(pose.yaw());
-            entity.setXRot(pose.pitch());
-            if (entity instanceof LivingEntity living) {
-                snapLivingYaw(living, pose.yaw());
-            }
+            applyLerpedPoseForExtract(entity, pose);
             try {
                 ensureGhostEntityId(entity);
-                EntityRenderState entityState = entityDispatcher.extractEntity(entity, tickDelta);
+                // tickDelta 0: pose is already packet-lerped; avoid a second vanilla interp.
+                EntityRenderState entityState = entityDispatcher.extractEntity(entity, 0.0f);
                 if (entityState == null) {
                     continue;
                 }
@@ -228,6 +225,21 @@ public final class SotoExteriorMeshCache {
             entity.getId();
         } catch (IllegalStateException missingId) {
             entity.setId(NEXT_FALLBACK_ENTITY_ID.getAndIncrement());
+        }
+    }
+
+    /**
+     * Snaps the ghost entity to the packet-lerped pose before {@code extractEntity},
+     * so baked render state matches submit translation.
+     */
+    static void applyLerpedPoseForExtract(Entity entity, LerpedPose pose) {
+        if (entity == null || pose == null) {
+            return;
+        }
+        entity.snapTo(pose.x(), pose.y(), pose.z(), pose.yaw(), pose.pitch());
+        entity.setDeltaMovement(0.0, 0.0, 0.0);
+        if (entity instanceof LivingEntity living) {
+            snapLivingYaw(living, pose.yaw());
         }
     }
 

--- a/src/client/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCache.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCache.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.render.soto;
 
 import com.adamkali.dwm.render.boti.BotiEntityMotion.LerpedPose;
+import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostExterior;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
@@ -16,11 +17,13 @@ import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.client.renderer.entity.EntityRenderDispatcher;
 import net.minecraft.client.renderer.entity.state.EntityRenderState;
+import net.minecraft.client.renderer.entity.state.ItemEntityRenderState;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.BlockPos;
 import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.phys.Vec3;
 
@@ -184,6 +187,8 @@ public final class SotoExteriorMeshCache {
                 || !SotoGhostExterior.hasEntities(kind, tardisId)) {
             return 0;
         }
+        float partialTick = resolvePartialTick(client, tickDelta);
+        PortalPerfStats.notePartialTick(partialTick);
         EntityRenderDispatcher entityDispatcher = client.getEntityRenderDispatcher();
         if (camera != null) {
             entityDispatcher.prepare(camera, client.player);
@@ -198,10 +203,17 @@ public final class SotoExteriorMeshCache {
             applyLerpedPoseForExtract(entity, pose);
             try {
                 ensureGhostEntityId(entity);
-                // tickDelta 0: pose is already packet-lerped; avoid a second vanilla interp.
-                EntityRenderState entityState = entityDispatcher.extractEntity(entity, 0.0f);
+                // Fresh END_MAIN partial: age-based anims (item bob/spin) need current partial ticks.
+                EntityRenderState entityState = entityDispatcher.extractEntity(entity, partialTick);
                 if (entityState == null) {
                     continue;
+                }
+                if (entity instanceof ItemEntity
+                        && entityState instanceof ItemEntityRenderState itemState) {
+                    // Wall-clock age + locked bob phase (duplicate spawns recreate ItemEntity with new bobOffs).
+                    itemState.ageInTicks = ghost.animAgeInTicks();
+                    itemState.bobOffset = ghost.bobOffset();
+                    PortalPerfStats.noteItemAgeInTicks(itemState.ageInTicks);
                 }
                 entityState.lightCoords = FULLBRIGHT;
                 entityDispatcher.submit(
@@ -220,6 +232,16 @@ public final class SotoExteriorMeshCache {
         return submitted;
     }
 
+    /**
+     * Prefer the live game-time partial tick at FBO draw time; fall back to the scheduled scene value.
+     */
+    static float resolvePartialTick(Minecraft client, float fallbackTickDelta) {
+        if (client == null || client.getDeltaTracker() == null) {
+            return fallbackTickDelta;
+        }
+        return client.getDeltaTracker().getGameTimeDeltaPartialTick(false);
+    }
+
     private static void ensureGhostEntityId(Entity entity) {
         try {
             entity.getId();
@@ -229,17 +251,31 @@ public final class SotoExteriorMeshCache {
     }
 
     /**
+     * True when packet yaw/pitch should drive extract (living locomotion).
+     * Items spin/bob from age + partialTick — packet rotation would fight that.
+     */
+    static boolean shouldApplyPacketRotation(Entity entity) {
+        return entity != null && !(entity instanceof ItemEntity);
+    }
+
+    /**
      * Snaps the ghost entity to the packet-lerped pose before {@code extractEntity},
      * so baked render state matches submit translation.
+     * {@link ItemEntity}: position only (preserve yaw/pitch for age-based spin).
      */
     static void applyLerpedPoseForExtract(Entity entity, LerpedPose pose) {
         if (entity == null || pose == null) {
             return;
         }
-        entity.snapTo(pose.x(), pose.y(), pose.z(), pose.yaw(), pose.pitch());
-        entity.setDeltaMovement(0.0, 0.0, 0.0);
-        if (entity instanceof LivingEntity living) {
-            snapLivingYaw(living, pose.yaw());
+        if (shouldApplyPacketRotation(entity)) {
+            entity.snapTo(pose.x(), pose.y(), pose.z(), pose.yaw(), pose.pitch());
+            entity.setDeltaMovement(0.0, 0.0, 0.0);
+            if (entity instanceof LivingEntity living) {
+                snapLivingYaw(living, pose.yaw());
+            }
+        } else {
+            entity.snapTo(pose.x(), pose.y(), pose.z(), entity.getYRot(), entity.getXRot());
+            entity.setDeltaMovement(0.0, 0.0, 0.0);
         }
     }
 

--- a/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
@@ -92,28 +92,27 @@ public final class SotoPortalContent implements PortalContent {
         context.bindTarget();
         GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(atmosphere);
         try {
-            context.bindTarget();
             SotoGhostMeshCache.drawLayer(
                     PortalStreamKind.SOTO,
                     id,
                     hitch.viewMatrix(),
-                    SotoGhostMeshCache.TerrainPass.OPAQUE
+                    SotoGhostMeshCache.TerrainPass.OPAQUE,
+                    hitch
             );
-            context.bindTarget();
             SotoGhostMeshCache.drawLayer(
                     PortalStreamKind.SOTO,
                     id,
                     hitch.viewMatrix(),
-                    SotoGhostMeshCache.TerrainPass.CUTOUT
+                    SotoGhostMeshCache.TerrainPass.CUTOUT,
+                    hitch
             );
-            context.bindTarget();
             SotoGhostMeshCache.drawLayer(
                     PortalStreamKind.SOTO,
                     id,
                     hitch.viewMatrix(),
-                    SotoGhostMeshCache.TerrainPass.TRANSLUCENT
+                    SotoGhostMeshCache.TerrainPass.TRANSLUCENT,
+                    hitch
             );
-            context.bindTarget();
             try {
                 PortalFeatureFlush featureFlush = context.featureFlush();
                 if (featureFlush != null) {

--- a/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.render.portal.PortalCameraTransform;
 import com.adamkali.dwm.render.portal.PortalContent;
 import com.adamkali.dwm.render.portal.PortalContentContext;
 import com.adamkali.dwm.render.portal.PortalFeatureFlush;
+import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostExterior;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostMeshCache;
@@ -88,10 +89,13 @@ public final class SotoPortalContent implements PortalContent {
         PortalAtmosphere portal = PortalSceneStore.getAtmosphere(PortalStreamKind.SOTO, id);
         SotoAtmosphere atmosphere = portal != null ? SotoAtmosphere.fromPortal(portal) : SotoAtmosphere.DEFAULT;
 
+        long skyStart = PortalPerfStats.begin();
         SotoSkyFogRenderer.renderPortalSky(sceneMatrices, null, atmosphere);
         context.bindTarget();
         GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(atmosphere);
+        PortalPerfStats.end(PortalPerfStats.Stage.SKY_FOG, skyStart);
         try {
+            long opaqueStart = PortalPerfStats.begin();
             SotoGhostMeshCache.drawLayer(
                     PortalStreamKind.SOTO,
                     id,
@@ -99,6 +103,9 @@ public final class SotoPortalContent implements PortalContent {
                     SotoGhostMeshCache.TerrainPass.OPAQUE,
                     hitch
             );
+            PortalPerfStats.end(PortalPerfStats.Stage.TERRAIN_OPAQUE, opaqueStart);
+
+            long cutoutStart = PortalPerfStats.begin();
             SotoGhostMeshCache.drawLayer(
                     PortalStreamKind.SOTO,
                     id,
@@ -106,6 +113,9 @@ public final class SotoPortalContent implements PortalContent {
                     SotoGhostMeshCache.TerrainPass.CUTOUT,
                     hitch
             );
+            PortalPerfStats.end(PortalPerfStats.Stage.TERRAIN_CUTOUT, cutoutStart);
+
+            long translucentStart = PortalPerfStats.begin();
             SotoGhostMeshCache.drawLayer(
                     PortalStreamKind.SOTO,
                     id,
@@ -113,6 +123,9 @@ public final class SotoPortalContent implements PortalContent {
                     SotoGhostMeshCache.TerrainPass.TRANSLUCENT,
                     hitch
             );
+            PortalPerfStats.end(PortalPerfStats.Stage.TERRAIN_TRANSLUCENT, translucentStart);
+
+            long featuresStart = PortalPerfStats.begin();
             try {
                 PortalFeatureFlush featureFlush = context.featureFlush();
                 if (featureFlush != null) {
@@ -149,6 +162,8 @@ public final class SotoPortalContent implements PortalContent {
                     }
                 }
             } catch (Throwable ignored) {
+            } finally {
+                PortalPerfStats.end(PortalPerfStats.Stage.GHOST_FEATURES, featuresStart);
             }
         } finally {
             SotoSkyFogRenderer.restoreFog(previousFog);

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -7,6 +7,7 @@ import com.adamkali.dwm.render.boti.BotiEntityMotion;
 import com.adamkali.dwm.render.boti.BotiEntityMotion.EntityInterpState;
 import com.adamkali.dwm.render.boti.BotiEntityMotion.LerpedPose;
 import com.adamkali.dwm.render.portal.PortalFrameCache;
+import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.tardis.boti.BotiEntitySample;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
@@ -44,6 +45,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -148,8 +150,23 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         SotoGhostExterior ghost = getOrCreate(kind, payload.tardisId());
         ghost.footprintOrigin = payload.footprintOrigin();
         long key = ChunkPos.pack(payload.chunkX(), payload.chunkZ());
-        Map<BlockPos, BlockState> previousBlocks = ghost.chunkBlocks.put(key, new HashMap<>(payload.toBlockMap()));
-        Map<BlockPos, CompoundTag> previousBes = ghost.chunkBlockEntities.put(key, new HashMap<>(payload.toBlockEntityMap()));
+        Map<BlockPos, BlockState> newBlocks = new HashMap<>(payload.toBlockMap());
+        Map<BlockPos, CompoundTag> newBes = new HashMap<>(payload.toBlockEntityMap());
+        Map<BlockPos, BlockState> previousBlocks = ghost.chunkBlocks.get(key);
+        Map<BlockPos, CompoundTag> previousBes = ghost.chunkBlockEntities.get(key);
+        boolean contentUnchanged = chunkContentUnchanged(previousBlocks, newBlocks, previousBes, newBes);
+        boolean hasDrawable = SotoGhostMeshCache.hasDrawableChunk(
+                kind, payload.tardisId(), payload.chunkX(), payload.chunkZ()
+        );
+        if (contentUnchanged && hasDrawable) {
+            // Keep maps current (cheap) but skip tessellation / pass-batch rebuild.
+            ghost.chunkBlocks.put(key, newBlocks);
+            ghost.chunkBlockEntities.put(key, newBes);
+            PortalPerfStats.noteBakeSkip();
+            return;
+        }
+        previousBlocks = ghost.chunkBlocks.put(key, newBlocks);
+        previousBes = ghost.chunkBlockEntities.put(key, newBes);
         if (previousBlocks != null) {
             for (BlockPos pos : previousBlocks.keySet()) {
                 ghost.blocksByRel.remove(pos);
@@ -160,9 +177,27 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
                 ghost.blockEntitiesByRel.remove(pos);
             }
         }
-        ghost.blocksByRel.putAll(payload.toBlockMap());
-        ghost.blockEntitiesByRel.putAll(payload.toBlockEntityMap());
+        ghost.blocksByRel.putAll(newBlocks);
+        ghost.blockEntitiesByRel.putAll(newBes);
         SotoGhostMeshCache.onChunkApplied(kind, payload.tardisId(), payload.chunkX(), payload.chunkZ(), ghost);
+    }
+
+    /**
+     * True when block + block-entity maps are equal (including both null/empty).
+     * Package-visible for unit tests.
+     */
+    static boolean chunkContentUnchanged(
+            Map<BlockPos, BlockState> previousBlocks,
+            Map<BlockPos, BlockState> newBlocks,
+            Map<BlockPos, CompoundTag> previousBes,
+            Map<BlockPos, CompoundTag> newBes
+    ) {
+        return Objects.equals(emptyToNull(previousBlocks), emptyToNull(newBlocks))
+                && Objects.equals(emptyToNull(previousBes), emptyToNull(newBes));
+    }
+
+    private static <K, V> Map<K, V> emptyToNull(Map<K, V> map) {
+        return map == null || map.isEmpty() ? null : map;
     }
 
     public static void unloadChunk(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ) {

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -125,18 +125,23 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         List<RenderableGhostEntity> result = new ArrayList<>(ghost.entities.size());
         for (Map.Entry<UUID, GhostEntity> entry : ghost.entities.entrySet()) {
             GhostEntity ghostEntity = entry.getValue();
-            if (ghostEntity.entity == null || ghostEntity.interp == null) {
+            if (ghostEntity.interp == null) {
                 continue;
             }
             LerpedPose pose = BotiEntityMotion.lerpPose(ghostEntity.interp, nowMs, ENTITY_UPDATE_INTERVAL_MS);
-            LerpedPose previousPose = ghostEntity.lastPublishedPose;
-            if (previousPose != null) {
-                double dx = pose.x() - previousPose.x();
-                double dy = pose.y() - previousPose.y();
-                double dz = pose.z() - previousPose.z();
-                PortalPerfStats.notePoseDelta(Math.sqrt(dx * dx + dy * dy + dz * dz));
+            // Stats only: once-per-frame baseline lives in PortalPerfStats (not on GhostEntity),
+            // so repeated getRenderableEntities calls in one flush cannot corrupt inter-frame deltas.
+            PortalPerfStats.noteLerpedPose(
+                    kind,
+                    tardisId,
+                    entry.getKey(),
+                    pose.x(),
+                    pose.y(),
+                    pose.z()
+            );
+            if (ghostEntity.entity == null) {
+                continue;
             }
-            ghostEntity.lastPublishedPose = pose;
             float animAge = animAgeInTicks(ghostEntity.animStartMs, nowMs);
             result.add(new RenderableGhostEntity(
                     ghostEntity.entity,
@@ -187,9 +192,6 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
                 : nextInterpForUpdate(previous.entity, previous.interp, relX, relY, relZ, yaw, pitch, receiveTimeMs);
         Entity entity = previous == null ? null : previous.entity;
         GhostEntity stored = new GhostEntity(entity, next, animStartMsPreserved(previous, receiveTimeMs), previous != null ? previous.bobOffset : 0.0f);
-        if (previous != null) {
-            stored.lastPublishedPose = previous.lastPublishedPose;
-        }
         ghost.entities.put(entityUuid, stored);
     }
 
@@ -222,12 +224,14 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
                 ITEM_BOB_OFFSETS.remove(entityUuid);
             }
         }
+        PortalPerfStats.clearPoseTracking(kind, tardisId);
         SotoGhostMeshCache.invalidate(kind, tardisId);
     }
 
     public static void invalidateAll() {
         BY_KEY.clear();
         ITEM_BOB_OFFSETS.clear();
+        PortalPerfStats.clearAllPoseTracking();
         SotoGhostMeshCache.invalidateAll();
     }
 
@@ -347,7 +351,6 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
                     previous.animStartMs,
                     previous.bobOffset
             );
-            stored.lastPublishedPose = previous.lastPublishedPose;
             ghost.entities.put(payload.entityUuid(), stored);
             return;
         }
@@ -413,7 +416,6 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             living.yHeadRotO = payload.headYaw();
         }
         GhostEntity stored = new GhostEntity(entity, next, previous.animStartMs, previous.bobOffset);
-        stored.lastPublishedPose = previous.lastPublishedPose;
         ghost.entities.put(payload.entityUuid(), stored);
     }
 
@@ -477,6 +479,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             return;
         }
         ghost.entities.remove(entityUuid);
+        PortalPerfStats.clearPoseTracking(kind, tardisId, entityUuid);
     }
 
     public PortalStreamKind kind() {
@@ -682,7 +685,6 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         final long animStartMs;
         /** Stable item bob/spin phase; survives duplicate spawn packets that recreate ItemEntity. */
         final float bobOffset;
-        LerpedPose lastPublishedPose;
 
         GhostEntity(Entity entity, EntityInterpState interp, long animStartMs, float bobOffset) {
             this.entity = entity;

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -6,6 +6,7 @@ import com.adamkali.dwm.network.SyncPortalEntityUpdateS2CPayload;
 import com.adamkali.dwm.render.boti.BotiEntityMotion;
 import com.adamkali.dwm.render.boti.BotiEntityMotion.EntityInterpState;
 import com.adamkali.dwm.render.boti.BotiEntityMotion.LerpedPose;
+import com.adamkali.dwm.render.portal.PortalFrameCache;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.tardis.boti.BotiEntitySample;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
@@ -134,6 +135,9 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
     public static void clientTick() {
         for (SotoGhostExterior ghost : BY_KEY.values()) {
             ghost.tickEntities();
+            if (ghost.entityCount() > 0) {
+                PortalFrameCache.markDirty(ghost.kind, ghost.tardisId);
+            }
         }
     }
 

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -104,18 +104,87 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
      * Entities with packet-lerped poses for smooth portal rendering.
      */
     public static List<RenderableGhostEntity> getRenderableEntities(PortalStreamKind kind, UUID tardisId) {
+        return getRenderableEntities(kind, tardisId, Util.getMillis());
+    }
+
+    /**
+     * Same as {@link #getRenderableEntities(PortalStreamKind, UUID)} with a fixed clock (tests / deterministic lerp).
+     */
+    public static List<RenderableGhostEntity> getRenderableEntities(
+            PortalStreamKind kind,
+            UUID tardisId,
+            long nowMs
+    ) {
         SotoGhostExterior ghost = get(kind, tardisId);
         if (ghost == null || ghost.entities.isEmpty()) {
             return List.of();
         }
-        long now = Util.getMillis();
         List<RenderableGhostEntity> result = new ArrayList<>(ghost.entities.size());
         for (GhostEntity ghostEntity : ghost.entities.values()) {
             if (ghostEntity.entity == null || ghostEntity.interp == null) {
                 continue;
             }
-            LerpedPose pose = BotiEntityMotion.lerpPose(ghostEntity.interp, now, ENTITY_UPDATE_INTERVAL_MS);
+            LerpedPose pose = BotiEntityMotion.lerpPose(ghostEntity.interp, nowMs, ENTITY_UPDATE_INTERVAL_MS);
             result.add(new RenderableGhostEntity(ghostEntity.entity, pose));
+        }
+        return List.copyOf(result);
+    }
+
+    /**
+     * Test helper: stores interp without a live entity so pose sampling can be asserted headlessly.
+     */
+    static void putInterpForTest(
+            PortalStreamKind kind,
+            UUID tardisId,
+            UUID entityUuid,
+            EntityInterpState interp
+    ) {
+        if (kind == null || tardisId == null || entityUuid == null || interp == null) {
+            return;
+        }
+        getOrCreate(kind, tardisId).entities.put(entityUuid, new GhostEntity(null, interp));
+    }
+
+    /**
+     * Test helper: advances stored interp the same way {@link #applyEntityUpdate} does (no position snap).
+     */
+    static void advanceInterpForTest(
+            PortalStreamKind kind,
+            UUID tardisId,
+            UUID entityUuid,
+            float relX,
+            float relY,
+            float relZ,
+            float yaw,
+            float pitch,
+            long receiveTimeMs
+    ) {
+        SotoGhostExterior ghost = get(kind, tardisId);
+        if (ghost == null || entityUuid == null) {
+            return;
+        }
+        GhostEntity previous = ghost.entities.get(entityUuid);
+        EntityInterpState next = previous == null || previous.interp == null
+                ? EntityInterpState.identity(relX, relY, relZ, yaw, pitch, receiveTimeMs)
+                : previous.interp.advanceTo(relX, relY, relZ, yaw, pitch, receiveTimeMs);
+        Entity entity = previous == null ? null : previous.entity;
+        ghost.entities.put(entityUuid, new GhostEntity(entity, next));
+    }
+
+    /**
+     * Test helper: lerped poses for all ghosts at {@code nowMs} (includes interp-only test entries).
+     */
+    static List<LerpedPose> sampleLerpedPosesForTest(PortalStreamKind kind, UUID tardisId, long nowMs) {
+        SotoGhostExterior ghost = get(kind, tardisId);
+        if (ghost == null || ghost.entities.isEmpty()) {
+            return List.of();
+        }
+        List<LerpedPose> result = new ArrayList<>(ghost.entities.size());
+        for (GhostEntity ghostEntity : ghost.entities.values()) {
+            if (ghostEntity.interp == null) {
+                continue;
+            }
+            result.add(BotiEntityMotion.lerpPose(ghostEntity.interp, nowMs, ENTITY_UPDATE_INTERVAL_MS));
         }
         return List.copyOf(result);
     }
@@ -270,17 +339,12 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         if (entity instanceof LivingEntity living) {
             float speed = BotiEntityMotion.limbSpeed(next.fromX(), next.fromZ(), next.toX(), next.toZ());
             living.walkAnimation.update(speed, 0.4f, living.isBaby() ? 3.0f : 1.0f);
+            // Head/body only — position is packet-lerped at render time (avoid snap-to-target vs extract mismatch).
+            living.setYBodyRot(payload.bodyYaw());
+            living.setYHeadRot(payload.headYaw());
+            living.yBodyRotO = payload.bodyYaw();
+            living.yHeadRotO = payload.headYaw();
         }
-        ghost.snapEntityPose(
-                entity,
-                payload.relX(),
-                payload.relY(),
-                payload.relZ(),
-                payload.yaw(),
-                payload.pitch(),
-                payload.headYaw(),
-                payload.bodyYaw()
-        );
         ghost.entities.put(payload.entityUuid(), new GhostEntity(entity, next));
     }
 

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -28,6 +28,7 @@ import net.minecraft.world.entity.EntitySpawnReason;
 import net.minecraft.world.entity.EntitySpawnRequest;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.CardinalLighting;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ColorResolver;
@@ -65,6 +66,8 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
     private static final AtomicInteger NEXT_GHOST_ENTITY_ID = new AtomicInteger(1_000_000);
 
     private static final Map<PortalSceneStore.SceneKey, SotoGhostExterior> BY_KEY = new ConcurrentHashMap<>();
+    /** Survives remove+respawn flaps so item bob/spin phase does not reset. */
+    private static final Map<UUID, Float> ITEM_BOB_OFFSETS = new ConcurrentHashMap<>();
 
     private final PortalStreamKind kind;
     private final UUID tardisId;
@@ -120,12 +123,27 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             return List.of();
         }
         List<RenderableGhostEntity> result = new ArrayList<>(ghost.entities.size());
-        for (GhostEntity ghostEntity : ghost.entities.values()) {
+        for (Map.Entry<UUID, GhostEntity> entry : ghost.entities.entrySet()) {
+            GhostEntity ghostEntity = entry.getValue();
             if (ghostEntity.entity == null || ghostEntity.interp == null) {
                 continue;
             }
             LerpedPose pose = BotiEntityMotion.lerpPose(ghostEntity.interp, nowMs, ENTITY_UPDATE_INTERVAL_MS);
-            result.add(new RenderableGhostEntity(ghostEntity.entity, pose));
+            LerpedPose previousPose = ghostEntity.lastPublishedPose;
+            if (previousPose != null) {
+                double dx = pose.x() - previousPose.x();
+                double dy = pose.y() - previousPose.y();
+                double dz = pose.z() - previousPose.z();
+                PortalPerfStats.notePoseDelta(Math.sqrt(dx * dx + dy * dy + dz * dz));
+            }
+            ghostEntity.lastPublishedPose = pose;
+            float animAge = animAgeInTicks(ghostEntity.animStartMs, nowMs);
+            result.add(new RenderableGhostEntity(
+                    ghostEntity.entity,
+                    pose,
+                    animAge,
+                    ghostEntity.bobOffset
+            ));
         }
         return List.copyOf(result);
     }
@@ -142,7 +160,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         if (kind == null || tardisId == null || entityUuid == null || interp == null) {
             return;
         }
-        getOrCreate(kind, tardisId).entities.put(entityUuid, new GhostEntity(null, interp));
+        getOrCreate(kind, tardisId).entities.put(entityUuid, new GhostEntity(null, interp, interp.receiveTimeMs(), 0.0f));
     }
 
     /**
@@ -166,9 +184,13 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         GhostEntity previous = ghost.entities.get(entityUuid);
         EntityInterpState next = previous == null || previous.interp == null
                 ? EntityInterpState.identity(relX, relY, relZ, yaw, pitch, receiveTimeMs)
-                : previous.interp.advanceTo(relX, relY, relZ, yaw, pitch, receiveTimeMs);
+                : nextInterpForUpdate(previous.entity, previous.interp, relX, relY, relZ, yaw, pitch, receiveTimeMs);
         Entity entity = previous == null ? null : previous.entity;
-        ghost.entities.put(entityUuid, new GhostEntity(entity, next));
+        GhostEntity stored = new GhostEntity(entity, next, animStartMsPreserved(previous, receiveTimeMs), previous != null ? previous.bobOffset : 0.0f);
+        if (previous != null) {
+            stored.lastPublishedPose = previous.lastPublishedPose;
+        }
+        ghost.entities.put(entityUuid, stored);
     }
 
     /**
@@ -194,12 +216,18 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             return;
         }
         PortalSceneStore.SceneKey key = new PortalSceneStore.SceneKey(kind, tardisId);
-        BY_KEY.remove(key);
+        SotoGhostExterior removed = BY_KEY.remove(key);
+        if (removed != null) {
+            for (UUID entityUuid : removed.entities.keySet()) {
+                ITEM_BOB_OFFSETS.remove(entityUuid);
+            }
+        }
         SotoGhostMeshCache.invalidate(kind, tardisId);
     }
 
     public static void invalidateAll() {
         BY_KEY.clear();
+        ITEM_BOB_OFFSETS.clear();
         SotoGhostMeshCache.invalidateAll();
     }
 
@@ -295,11 +323,38 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             return;
         }
         SotoGhostExterior ghost = getOrCreate(kind, payload.tardisId());
+        GhostEntity previous = ghost.entities.get(payload.entityUuid());
+        long now = Util.getMillis();
+        // Duplicate spawn for an existing ghost: reuse the entity so ItemEntity.bobOffs stays stable.
+        if (previous != null && previous.entity != null) {
+            Entity entity = previous.entity;
+            EntityInterpState interp = EntityInterpState.identity(
+                    payload.relX(), payload.relY(), payload.relZ(), payload.yaw(), payload.pitch(), now
+            );
+            ghost.snapEntityPose(
+                    entity,
+                    payload.relX(),
+                    payload.relY(),
+                    payload.relZ(),
+                    payload.yaw(),
+                    payload.pitch(),
+                    payload.headYaw(),
+                    payload.bodyYaw()
+            );
+            GhostEntity stored = new GhostEntity(
+                    entity,
+                    interp,
+                    previous.animStartMs,
+                    previous.bobOffset
+            );
+            stored.lastPublishedPose = previous.lastPublishedPose;
+            ghost.entities.put(payload.entityUuid(), stored);
+            return;
+        }
         Entity entity = ghost.createEntity(payload);
         if (entity == null) {
             return;
         }
-        long now = Util.getMillis();
         EntityInterpState interp = EntityInterpState.identity(
                 payload.relX(), payload.relY(), payload.relZ(), payload.yaw(), payload.pitch(), now
         );
@@ -313,7 +368,12 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
                 payload.headYaw(),
                 payload.bodyYaw()
         );
-        ghost.entities.put(payload.entityUuid(), new GhostEntity(entity, interp));
+        float bobOffset = entity instanceof ItemEntity item
+                ? ITEM_BOB_OFFSETS.computeIfAbsent(payload.entityUuid(), id -> item.bobOffs)
+                : 0.0f;
+        long animStartMs = animStartMsForNew(entity, now);
+        GhostEntity stored = new GhostEntity(entity, interp, animStartMs, bobOffset);
+        ghost.entities.put(payload.entityUuid(), stored);
     }
 
     public static void applyEntityUpdate(PortalStreamKind kind, SyncPortalEntityUpdateS2CPayload payload) {
@@ -332,8 +392,15 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         EntityInterpState next = previous.interp == null
                 ? EntityInterpState.identity(
                         payload.relX(), payload.relY(), payload.relZ(), payload.yaw(), payload.pitch(), now)
-                : previous.interp.advanceTo(
-                        payload.relX(), payload.relY(), payload.relZ(), payload.yaw(), payload.pitch(), now);
+                : nextInterpForUpdate(
+                        previous.entity,
+                        previous.interp,
+                        payload.relX(),
+                        payload.relY(),
+                        payload.relZ(),
+                        payload.yaw(),
+                        payload.pitch(),
+                        now);
 
         Entity entity = previous.entity;
         if (entity instanceof LivingEntity living) {
@@ -345,7 +412,63 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             living.yBodyRotO = payload.bodyYaw();
             living.yHeadRotO = payload.headYaw();
         }
-        ghost.entities.put(payload.entityUuid(), new GhostEntity(entity, next));
+        GhostEntity stored = new GhostEntity(entity, next, previous.animStartMs, previous.bobOffset);
+        stored.lastPublishedPose = previous.lastPublishedPose;
+        ghost.entities.put(payload.entityUuid(), stored);
+    }
+
+    /**
+     * Items hold pose without micro-lerp (age-based bob/spin); others advance over the update interval.
+     * Package-visible for tests.
+     */
+    static EntityInterpState nextInterpForUpdate(
+            Entity entity,
+            EntityInterpState previous,
+            float relX,
+            float relY,
+            float relZ,
+            float yaw,
+            float pitch,
+            long now
+    ) {
+        if (previous == null) {
+            PortalPerfStats.noteIdentityInterp();
+            return EntityInterpState.identity(relX, relY, relZ, yaw, pitch, now);
+        }
+        if (usesIdentityInterp(entity)) {
+            PortalPerfStats.noteIdentityInterp();
+            return EntityInterpState.identity(relX, relY, relZ, yaw, pitch, now);
+        }
+        PortalPerfStats.noteAdvanceInterp();
+        return previous.advanceTo(relX, relY, relZ, yaw, pitch, now);
+    }
+
+    /** Package-visible: item ghosts skip packet position lerp. */
+    static boolean usesIdentityInterp(Entity entity) {
+        return entity instanceof ItemEntity;
+    }
+
+    /**
+     * Wall-clock animation age in ticks (50ms). Independent of {@link Entity#tickCount}, which does not
+     * advance for ghosts unless they are in {@link ClientLevel}'s ticker.
+     */
+    static float animAgeInTicks(long animStartMs, long nowMs) {
+        if (animStartMs <= 0L || nowMs <= animStartMs) {
+            return 0.0f;
+        }
+        return (nowMs - animStartMs) / 50.0f;
+    }
+
+    static long animStartMsForNew(Entity entity, long nowMs) {
+        if (entity instanceof ItemEntity item) {
+            int age = Math.max(0, item.getAge());
+            return nowMs - (long) age * 50L;
+        }
+        return nowMs;
+    }
+
+    private static long animStartMsPreserved(GhostEntity previous, long nowMs) {
+        return previous != null && previous.animStartMs > 0L ? previous.animStartMs : nowMs;
     }
 
     public static void removeEntity(PortalStreamKind kind, UUID tardisId, UUID entityUuid) {
@@ -425,6 +548,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
 
     /**
      * Advances animation age only. Position is packet-driven + render-lerped (no velocity integrate).
+     * Also mirrors age onto {@link Entity#tickCount} so extract-based anims stay coherent if used.
      */
     private void tickEntities() {
         for (GhostEntity ghostEntity : entities.values()) {
@@ -432,7 +556,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             if (entity == null) {
                 continue;
             }
-            entity.tickCount++;
+            entity.tickCount = Math.max(entity.tickCount + 1, (int) animAgeInTicks(ghostEntity.animStartMs, Util.getMillis()));
         }
     }
 
@@ -549,9 +673,22 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         return 15;
     }
 
-    public record RenderableGhostEntity(Entity entity, LerpedPose pose) {
+    public record RenderableGhostEntity(Entity entity, LerpedPose pose, float animAgeInTicks, float bobOffset) {
     }
 
-    private record GhostEntity(Entity entity, EntityInterpState interp) {
+    private static final class GhostEntity {
+        final Entity entity;
+        final EntityInterpState interp;
+        final long animStartMs;
+        /** Stable item bob/spin phase; survives duplicate spawn packets that recreate ItemEntity. */
+        final float bobOffset;
+        LerpedPose lastPublishedPose;
+
+        GhostEntity(Entity entity, EntityInterpState interp, long animStartMs, float bobOffset) {
+            this.entity = entity;
+            this.interp = interp;
+            this.animStartMs = animStartMs;
+            this.bobOffset = bobOffset;
+        }
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostHitchCull.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostHitchCull.java
@@ -1,0 +1,151 @@
+package com.adamkali.dwm.render.soto.ghost;
+
+import org.joml.Matrix4f;
+import org.joml.Vector3f;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Pure hitch-camera visibility tests for ghost chunk columns.
+ * Prefers under-culling: only drops columns clearly behind or far outside a wide frustum.
+ *
+ * <p>Portal stream {@code chunkX/Z} are world section coords, but hitch eye/view and mesh
+ * vertices are footprint-relative — convert with {@code footprintOrigin} before testing.
+ */
+public final class SotoGhostHitchCull {
+    /** Matches {@link SotoGhostExterior} vertical range (relative Y after origin subtract). */
+    public static final int MIN_Y = -64;
+    public static final int MAX_Y = 320;
+
+    /**
+     * View-space +Z behind the camera (JOML lookAt looks down -Z). Chunks with all corners
+     * farther behind than this margin are culled.
+     */
+    static final float BEHIND_MARGIN = 8.0f;
+
+    /**
+     * Generous |x|/(-z) limit (~68° half-angle with slack). Vertical FOV is not applied:
+     * ghost columns span full world height, so Y-corner tests would over-cull.
+     */
+    static final float WIDE_FRUSTUM_TAN = 2.5f;
+
+    private SotoGhostHitchCull() {
+    }
+
+    /**
+     * Returns true when the chunk column may contribute pixels for the hitch camera.
+     * Null hitch inputs keep the chunk (under-cull / safe fallback).
+     *
+     * @param footprintOrigin world min corner of the ghost footprint; null treated as {@link BlockPos#ZERO}
+     */
+    public static boolean isChunkVisibleToHitch(
+            int chunkX,
+            int chunkZ,
+            BlockPos footprintOrigin,
+            Vec3 eyeRelative,
+            Vec3 lookDirection,
+            Matrix4f viewMatrix
+    ) {
+        if (eyeRelative == null || lookDirection == null) {
+            return true;
+        }
+        float[] aabb = relativeChunkAabb(chunkX, chunkZ, footprintOrigin);
+        if (viewMatrix != null) {
+            return isChunkVisibleInView(aabb[0], aabb[1], aabb[2], aabb[3], viewMatrix);
+        }
+        return isChunkVisibleInForwardHalfSpace(aabb[0], aabb[1], aabb[2], aabb[3], eyeRelative, lookDirection);
+    }
+
+    /**
+     * World chunk column → footprint-relative XZ AABB: {@code [minX, maxX, minZ, maxZ]}.
+     */
+    static float[] relativeChunkAabb(int chunkX, int chunkZ, BlockPos footprintOrigin) {
+        int originX = footprintOrigin == null ? 0 : footprintOrigin.getX();
+        int originZ = footprintOrigin == null ? 0 : footprintOrigin.getZ();
+        float minX = (chunkX << 4) - originX;
+        float minZ = (chunkZ << 4) - originZ;
+        return new float[]{minX, minX + 16.0f, minZ, minZ + 16.0f};
+    }
+
+    static boolean isChunkVisibleInView(
+            float minX,
+            float maxX,
+            float minZ,
+            float maxZ,
+            Matrix4f viewMatrix
+    ) {
+        float minY = MIN_Y;
+        float maxY = MAX_Y;
+
+        boolean anyInFront = false;
+        boolean anyInWideFrustum = false;
+        Vector3f scratch = new Vector3f();
+        for (int xi = 0; xi < 2; xi++) {
+            float x = xi == 0 ? minX : maxX;
+            for (int yi = 0; yi < 2; yi++) {
+                float y = yi == 0 ? minY : maxY;
+                for (int zi = 0; zi < 2; zi++) {
+                    float z = zi == 0 ? minZ : maxZ;
+                    viewMatrix.transformPosition(x, y, z, scratch);
+                    if (scratch.z <= BEHIND_MARGIN) {
+                        anyInFront = true;
+                        float negZ = Math.max(-scratch.z, 0.1f);
+                        if (Math.abs(scratch.x) <= negZ * WIDE_FRUSTUM_TAN) {
+                            anyInWideFrustum = true;
+                        }
+                    }
+                }
+            }
+        }
+        return anyInFront && anyInWideFrustum;
+    }
+
+    /** Test helper using already-relative chunk section coords (origin = ZERO). */
+    static boolean isChunkVisibleInView(int chunkX, int chunkZ, Matrix4f viewMatrix) {
+        float[] aabb = relativeChunkAabb(chunkX, chunkZ, BlockPos.ZERO);
+        return isChunkVisibleInView(aabb[0], aabb[1], aabb[2], aabb[3], viewMatrix);
+    }
+
+    static boolean isChunkVisibleInForwardHalfSpace(
+            float minX,
+            float maxX,
+            float minZ,
+            float maxZ,
+            Vec3 eyeRelative,
+            Vec3 lookDirection
+    ) {
+        Vec3 look = lookDirection.normalize();
+
+        double maxDot = Double.NEGATIVE_INFINITY;
+        for (int xi = 0; xi < 2; xi++) {
+            double x = xi == 0 ? minX : maxX;
+            for (int yi = 0; yi < 2; yi++) {
+                double y = yi == 0 ? MIN_Y : MAX_Y;
+                for (int zi = 0; zi < 2; zi++) {
+                    double z = zi == 0 ? minZ : maxZ;
+                    double dx = x - eyeRelative.x;
+                    double dy = y - eyeRelative.y;
+                    double dz = z - eyeRelative.z;
+                    double dot = dx * look.x + dy * look.y + dz * look.z;
+                    if (dot > maxDot) {
+                        maxDot = dot;
+                    }
+                }
+            }
+        }
+        // Culled only when the entire AABB is clearly behind the hitch plane.
+        return maxDot >= -BEHIND_MARGIN;
+    }
+
+    /** Test helper using already-relative chunk section coords (origin = ZERO). */
+    static boolean isChunkVisibleInForwardHalfSpace(
+            int chunkX,
+            int chunkZ,
+            Vec3 eyeRelative,
+            Vec3 lookDirection
+    ) {
+        float[] aabb = relativeChunkAabb(chunkX, chunkZ, BlockPos.ZERO);
+        return isChunkVisibleInForwardHalfSpace(aabb[0], aabb[1], aabb[2], aabb[3], eyeRelative, lookDirection);
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.render.soto.ghost;
 
+import com.adamkali.dwm.render.portal.PortalCameraTransform;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.mojang.blaze3d.IndexType;
@@ -25,10 +26,12 @@ import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import org.joml.Matrix4f;
 import org.joml.Matrix4fStack;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
@@ -37,23 +40,23 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Per-chunk GPU meshes baked from {@link SotoGhostExterior} on chunk apply.
+ * Per-chunk CPU meshes baked from {@link SotoGhostExterior} on chunk apply, drawn via
+ * hitch-culled pass-level GPU batches (one draw per {@link TerrainPass}).
  * Keyed by (PortalStreamKind, UUID) so BOTI and SOTO share the same mesh infrastructure.
  */
 public final class SotoGhostMeshCache {
     private static final int FULLBRIGHT = LightCoordsUtil.FULL_BRIGHT;
+    private static final int QUAD_VERTEX_STRIDE = 4;
+    private static final int QUAD_INDEX_STRIDE = 6;
 
     private static final Map<PortalSceneStore.SceneKey, Map<Long, ChunkMesh>> MESHES = new ConcurrentHashMap<>();
+    private static final Map<PortalSceneStore.SceneKey, PassBatchState> PASS_BATCHES = new ConcurrentHashMap<>();
 
     private SotoGhostMeshCache() {
     }
 
     public static boolean hasMeshes(PortalStreamKind kind, UUID tardisId) {
-        if (kind == null || tardisId == null) {
-            return false;
-        }
-        Map<Long, ChunkMesh> byChunk = MESHES.get(new PortalSceneStore.SceneKey(kind, tardisId));
-        return byChunk != null && !byChunk.isEmpty();
+        return meshChunkCount(kind, tardisId) > 0;
     }
 
     public static int meshChunkCount(PortalStreamKind kind, UUID tardisId) {
@@ -61,7 +64,16 @@ public final class SotoGhostMeshCache {
             return 0;
         }
         Map<Long, ChunkMesh> byChunk = MESHES.get(new PortalSceneStore.SceneKey(kind, tardisId));
-        return byChunk == null ? 0 : byChunk.size();
+        if (byChunk == null || byChunk.isEmpty()) {
+            return 0;
+        }
+        int count = 0;
+        for (ChunkMesh mesh : byChunk.values()) {
+            if (mesh != null && mesh.isDrawable()) {
+                count++;
+            }
+        }
+        return count;
     }
 
     public static void onChunkApplied(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ, SotoGhostExterior ghost) {
@@ -80,6 +92,7 @@ public final class SotoGhostMeshCache {
         if (baked.isEmpty()) {
             byChunk.remove(key, baked);
         }
+        markPassBatchesDirty(sceneKey);
     }
 
     public static void onChunkUnloaded(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ) {
@@ -98,6 +111,7 @@ public final class SotoGhostMeshCache {
         if (byChunk.isEmpty()) {
             MESHES.remove(sceneKey, byChunk);
         }
+        markPassBatchesDirty(sceneKey);
     }
 
     public static void invalidate(PortalStreamKind kind, UUID tardisId) {
@@ -106,23 +120,32 @@ public final class SotoGhostMeshCache {
         }
         PortalSceneStore.SceneKey sceneKey = new PortalSceneStore.SceneKey(kind, tardisId);
         Map<Long, ChunkMesh> byChunk = MESHES.remove(sceneKey);
-        if (byChunk == null) {
-            return;
+        if (byChunk != null) {
+            for (ChunkMesh mesh : byChunk.values()) {
+                mesh.close();
+            }
+            byChunk.clear();
         }
-        for (ChunkMesh mesh : byChunk.values()) {
-            mesh.close();
+        PassBatchState batches = PASS_BATCHES.remove(sceneKey);
+        if (batches != null) {
+            batches.close();
         }
-        byChunk.clear();
     }
 
     public static void invalidateAll() {
         for (PortalSceneStore.SceneKey key : List.copyOf(MESHES.keySet())) {
             invalidate(key.kind(), key.tardisId());
         }
+        for (PortalSceneStore.SceneKey key : List.copyOf(PASS_BATCHES.keySet())) {
+            PassBatchState batches = PASS_BATCHES.remove(key);
+            if (batches != null) {
+                batches.close();
+            }
+        }
     }
 
     /**
-     * Test helper: records a chunk as having a drawable mesh without requiring a GPU bake.
+     * Test helper: records a chunk as having drawable mesh without requiring a GPU bake.
      */
     public static void markChunkMeshForTest(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ) {
         if (kind == null || tardisId == null) {
@@ -131,38 +154,96 @@ public final class SotoGhostMeshCache {
         PortalSceneStore.SceneKey sceneKey = new PortalSceneStore.SceneKey(kind, tardisId);
         long key = ChunkPos.pack(chunkX, chunkZ);
         Map<Long, ChunkMesh> byChunk = MESHES.computeIfAbsent(sceneKey, ignored -> new ConcurrentHashMap<>());
-        ChunkMesh previous = byChunk.put(key, ChunkMesh.MARKER);
-        if (previous != null && previous != ChunkMesh.MARKER) {
+        ChunkMesh previous = byChunk.put(key, ChunkMesh.TEST_DRAWABLE);
+        if (previous != null && previous != ChunkMesh.TEST_DRAWABLE && previous != ChunkMesh.MARKER) {
             previous.close();
         }
+        markPassBatchesDirty(sceneKey);
     }
 
     /**
-     * Draws one terrain pass across every chunk, preserving opaque → cutout → translucent order.
+     * Test helper: records a non-drawable MARKER entry (must not satisfy {@link #hasMeshes}).
      */
-    public static void drawLayer(PortalStreamKind kind, UUID tardisId, Matrix4f viewMatrix, TerrainPass pass) {
+    public static void markChunkMarkerForTest(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ) {
+        if (kind == null || tardisId == null) {
+            return;
+        }
+        PortalSceneStore.SceneKey sceneKey = new PortalSceneStore.SceneKey(kind, tardisId);
+        long key = ChunkPos.pack(chunkX, chunkZ);
+        Map<Long, ChunkMesh> byChunk = MESHES.computeIfAbsent(sceneKey, ignored -> new ConcurrentHashMap<>());
+        ChunkMesh previous = byChunk.put(key, ChunkMesh.MARKER);
+        if (previous != null && previous != ChunkMesh.MARKER && previous != ChunkMesh.TEST_DRAWABLE) {
+            previous.close();
+        }
+        markPassBatchesDirty(sceneKey);
+    }
+
+    /** Test helper: whether pass batches need rebuild for this scene. */
+    public static boolean arePassBatchesDirtyForTest(PortalStreamKind kind, UUID tardisId) {
+        if (kind == null || tardisId == null) {
+            return false;
+        }
+        PassBatchState state = PASS_BATCHES.get(new PortalSceneStore.SceneKey(kind, tardisId));
+        return state == null || state.dirty;
+    }
+
+    /**
+     * Draws one terrain pass as a single GPU batch (opaque → cutout → translucent order preserved
+     * by the caller issuing three draws).
+     */
+    public static void drawLayer(
+            PortalStreamKind kind,
+            UUID tardisId,
+            Matrix4f viewMatrix,
+            TerrainPass pass,
+            PortalCameraTransform.Result hitch
+    ) {
         if (kind == null || tardisId == null || viewMatrix == null || pass == null) {
             return;
         }
-        Map<Long, ChunkMesh> byChunk = MESHES.get(new PortalSceneStore.SceneKey(kind, tardisId));
+        PortalSceneStore.SceneKey sceneKey = new PortalSceneStore.SceneKey(kind, tardisId);
+        Map<Long, ChunkMesh> byChunk = MESHES.get(sceneKey);
         if (byChunk == null || byChunk.isEmpty()) {
+            return;
+        }
+        PassBatchState batches = ensurePassBatches(sceneKey, byChunk, hitch);
+        LayerBuffer batch = batches.buffer(pass);
+        if (batch == null) {
             return;
         }
         Matrix4fStack modelViewStack = RenderSystem.getModelViewStack();
         modelViewStack.pushMatrix();
         modelViewStack.set(viewMatrix);
         try {
-            List<Long> chunkKeys = new ArrayList<>(byChunk.keySet());
-            chunkKeys.sort(Long::compare);
-            for (Long chunkKey : chunkKeys) {
-                ChunkMesh mesh = byChunk.get(chunkKey);
-                if (mesh != null) {
-                    mesh.draw(pass);
-                }
-            }
+            batch.draw();
         } finally {
             modelViewStack.popMatrix();
         }
+    }
+
+    private static void markPassBatchesDirty(PortalSceneStore.SceneKey sceneKey) {
+        PassBatchState state = PASS_BATCHES.get(sceneKey);
+        if (state != null) {
+            state.dirty = true;
+        } else {
+            PASS_BATCHES.put(sceneKey, new PassBatchState());
+        }
+    }
+
+    private static PassBatchState ensurePassBatches(
+            PortalSceneStore.SceneKey sceneKey,
+            Map<Long, ChunkMesh> byChunk,
+            PortalCameraTransform.Result hitch
+    ) {
+        PassBatchState state = PASS_BATCHES.computeIfAbsent(sceneKey, ignored -> new PassBatchState());
+        HitchSignature signature = HitchSignature.from(hitch);
+        if (!state.dirty && signature.equals(state.hitchSignature)) {
+            return state;
+        }
+        SotoGhostExterior ghost = SotoGhostExterior.get(sceneKey.kind(), sceneKey.tardisId());
+        BlockPos footprintOrigin = ghost != null ? ghost.footprintOrigin() : BlockPos.ZERO;
+        state.rebuild(byChunk, hitch, signature, footprintOrigin);
+        return state;
     }
 
     private static ChunkMesh bakeChunk(Map<BlockPos, BlockState> blocks, SotoGhostExterior ghost) {
@@ -223,7 +304,7 @@ public final class SotoGhostMeshCache {
                 );
             }
 
-            List<LayerBuffer> uploaded = new ArrayList<>();
+            List<CpuLayer> uploaded = new ArrayList<>();
             for (ChunkSectionLayer layer : ChunkSectionLayer.values()) {
                 BufferBuilder builder = builders.get(layer);
                 if (builder == null) {
@@ -234,9 +315,9 @@ public final class SotoGhostMeshCache {
                     continue;
                 }
                 try {
-                    LayerBuffer layerBuffer = uploadLayer(layer, meshData);
-                    if (layerBuffer != null) {
-                        uploaded.add(layerBuffer);
+                    CpuLayer cpuLayer = CpuLayer.fromMesh(layer, meshData);
+                    if (cpuLayer != null) {
+                        uploaded.add(cpuLayer);
                     }
                 } finally {
                     meshData.close();
@@ -278,83 +359,266 @@ public final class SotoGhostMeshCache {
         builder.putBlockBakedQuad(x, y, z, quad, instance);
     }
 
-    private static LayerBuffer uploadLayer(ChunkSectionLayer layer, MeshData meshData) {
-        MeshData.DrawState drawState = meshData.drawState();
-        if (drawState.vertexCount() <= 0 || drawState.indexCount() <= 0) {
-            return null;
-        }
-        ByteBuffer vertexBytes = meshData.vertexBuffer();
-        if (vertexBytes == null || !vertexBytes.hasRemaining()) {
-            return null;
-        }
-        GpuBuffer vertexBuffer = RenderSystem.getDevice().createBuffer(
-                () -> "dwm_soto_" + layer.label(),
-                GpuBuffer.USAGE_VERTEX | GpuBuffer.USAGE_COPY_DST,
-                vertexBytes
-        );
-        GpuBuffer indexBuffer = null;
-        ByteBuffer indexBytes = meshData.indexBuffer();
-        if (indexBytes != null && indexBytes.hasRemaining()) {
-            indexBuffer = RenderSystem.getDevice().createBuffer(
-                    () -> "dwm_soto_idx_" + layer.label(),
-                    GpuBuffer.USAGE_INDEX | GpuBuffer.USAGE_COPY_DST,
-                    indexBytes
-            );
-        }
-        return new LayerBuffer(
-                TerrainPass.forSectionLayer(layer),
-                layer,
-                vertexBuffer,
-                indexBuffer,
-                drawState.indexType(),
-                drawState.indexCount()
-        );
+    private static byte[] copyBytes(ByteBuffer buffer) {
+        ByteBuffer duplicate = buffer.duplicate();
+        byte[] bytes = new byte[duplicate.remaining()];
+        duplicate.get(bytes);
+        return bytes;
     }
 
-    private static final class ChunkMesh implements AutoCloseable {
-        static final ChunkMesh EMPTY = new ChunkMesh(List.of(), false);
-        static final ChunkMesh MARKER = new ChunkMesh(List.of(), true);
-
-        private final List<LayerBuffer> layers;
-        private final boolean marker;
-        private boolean closed;
-
-        private ChunkMesh(List<LayerBuffer> layers) {
-            this(layers, false);
+    private static void appendSequentialQuadIndices(ByteBuffer dest, IndexType type, int vertexBase, int vertexCount) {
+        int quadCount = vertexCount / QUAD_VERTEX_STRIDE;
+        for (int q = 0; q < quadCount; q++) {
+            int i = vertexBase + q * QUAD_VERTEX_STRIDE;
+            putIndex(dest, type, i);
+            putIndex(dest, type, i + 1);
+            putIndex(dest, type, i + 2);
+            putIndex(dest, type, i + 2);
+            putIndex(dest, type, i + 3);
+            putIndex(dest, type, i);
         }
+    }
 
-        private ChunkMesh(List<LayerBuffer> layers, boolean marker) {
-            this.layers = List.copyOf(layers);
-            this.marker = marker;
+    private static void appendRemappedIndices(
+            ByteBuffer dest,
+            IndexType outType,
+            byte[] srcIndices,
+            IndexType srcType,
+            int indexCount,
+            int vertexBase
+    ) {
+        ByteBuffer src = ByteBuffer.wrap(srcIndices).order(ByteOrder.nativeOrder());
+        for (int i = 0; i < indexCount; i++) {
+            int value = srcType == IndexType.INT ? src.getInt() : Short.toUnsignedInt(src.getShort());
+            putIndex(dest, outType, value + vertexBase);
         }
+    }
 
-        boolean isEmpty() {
-            return !marker && layers.isEmpty();
+    private static void putIndex(ByteBuffer dest, IndexType type, int value) {
+        if (type == IndexType.INT) {
+            dest.putInt(value);
+        } else {
+            dest.putShort((short) value);
         }
+    }
 
-        int draw(TerrainPass pass) {
-            if (closed || isEmpty() || marker || pass == null) {
-                return 0;
+    private static LayerBuffer uploadMerged(TerrainPass pass, ChunkSectionLayer sectionLayer, List<CpuLayer> parts) {
+        if (parts == null || parts.isEmpty()) {
+            return null;
+        }
+        int totalVertexBytes = 0;
+        int totalVertices = 0;
+        int totalIndices = 0;
+        for (CpuLayer part : parts) {
+            totalVertexBytes += part.vertexBytes().length;
+            totalVertices += part.vertexCount();
+            if (part.indexBytes() != null) {
+                totalIndices += part.indexCount();
+            } else {
+                totalIndices += (part.vertexCount() / QUAD_VERTEX_STRIDE) * QUAD_INDEX_STRIDE;
             }
-            int drawn = 0;
-            for (LayerBuffer layerBuffer : layers) {
-                if (layerBuffer.pass() == pass) {
-                    layerBuffer.draw();
-                    drawn++;
+        }
+        if (totalVertices <= 0 || totalIndices <= 0 || totalVertexBytes <= 0) {
+            return null;
+        }
+
+        IndexType outType = IndexType.least(totalVertices);
+        ByteBuffer mergedVertices = ByteBuffer.allocateDirect(totalVertexBytes).order(ByteOrder.nativeOrder());
+        ByteBuffer mergedIndices = ByteBuffer.allocateDirect(totalIndices * outType.bytes).order(ByteOrder.nativeOrder());
+        int vertexBase = 0;
+        for (CpuLayer part : parts) {
+            mergedVertices.put(part.vertexBytes());
+            if (part.indexBytes() != null) {
+                appendRemappedIndices(
+                        mergedIndices,
+                        outType,
+                        part.indexBytes(),
+                        part.indexType(),
+                        part.indexCount(),
+                        vertexBase
+                );
+            } else {
+                appendSequentialQuadIndices(mergedIndices, outType, vertexBase, part.vertexCount());
+            }
+            vertexBase += part.vertexCount();
+        }
+        mergedVertices.flip();
+        mergedIndices.flip();
+
+        GpuBuffer vertexBuffer = RenderSystem.getDevice().createBuffer(
+                () -> "dwm_soto_pass_" + pass.name().toLowerCase(),
+                GpuBuffer.USAGE_VERTEX | GpuBuffer.USAGE_COPY_DST,
+                mergedVertices
+        );
+        GpuBuffer indexBuffer = RenderSystem.getDevice().createBuffer(
+                () -> "dwm_soto_pass_idx_" + pass.name().toLowerCase(),
+                GpuBuffer.USAGE_INDEX | GpuBuffer.USAGE_COPY_DST,
+                mergedIndices
+        );
+        return new LayerBuffer(pass, sectionLayer, vertexBuffer, indexBuffer, outType, totalIndices);
+    }
+
+    private record HitchSignature(double eyeX, double eyeY, double eyeZ, double lookX, double lookY, double lookZ) {
+        static HitchSignature from(PortalCameraTransform.Result hitch) {
+            if (hitch == null) {
+                return new HitchSignature(Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN, Double.NaN);
+            }
+            Vec3 eye = hitch.eyeRelative();
+            Vec3 look = hitch.lookDirection();
+            return new HitchSignature(eye.x, eye.y, eye.z, look.x, look.y, look.z);
+        }
+    }
+
+    private static final class PassBatchState implements AutoCloseable {
+        private final EnumMap<TerrainPass, LayerBuffer> batches = new EnumMap<>(TerrainPass.class);
+        private boolean dirty = true;
+        private HitchSignature hitchSignature;
+
+        LayerBuffer buffer(TerrainPass pass) {
+            return batches.get(pass);
+        }
+
+        void rebuild(
+                Map<Long, ChunkMesh> byChunk,
+                PortalCameraTransform.Result hitch,
+                HitchSignature signature,
+                BlockPos footprintOrigin
+        ) {
+            closeBatches();
+            EnumMap<TerrainPass, List<CpuLayer>> byPass = new EnumMap<>(TerrainPass.class);
+            EnumMap<TerrainPass, ChunkSectionLayer> sectionForPass = new EnumMap<>(TerrainPass.class);
+
+            List<Long> chunkKeys = new ArrayList<>(byChunk.keySet());
+            chunkKeys.sort(Long::compare);
+            Matrix4f viewMatrix = hitch != null ? hitch.viewMatrix() : null;
+            Vec3 eye = hitch != null ? hitch.eyeRelative() : null;
+            Vec3 look = hitch != null ? hitch.lookDirection() : null;
+            BlockPos origin = footprintOrigin == null ? BlockPos.ZERO : footprintOrigin;
+
+            for (Long chunkKey : chunkKeys) {
+                ChunkMesh mesh = byChunk.get(chunkKey);
+                if (mesh == null || !mesh.isDrawable() || mesh.layers.isEmpty()) {
+                    continue;
+                }
+                int chunkX = ChunkPos.getX(chunkKey);
+                int chunkZ = ChunkPos.getZ(chunkKey);
+                if (!SotoGhostHitchCull.isChunkVisibleToHitch(chunkX, chunkZ, origin, eye, look, viewMatrix)) {
+                    continue;
+                }
+                for (CpuLayer layer : mesh.layers) {
+                    TerrainPass pass = layer.pass();
+                    byPass.computeIfAbsent(pass, ignored -> new ArrayList<>()).add(layer);
+                    sectionForPass.putIfAbsent(pass, layer.sectionLayer());
                 }
             }
-            return drawn;
+
+            for (TerrainPass pass : TerrainPass.values()) {
+                List<CpuLayer> parts = byPass.get(pass);
+                if (parts == null || parts.isEmpty()) {
+                    continue;
+                }
+                LayerBuffer merged = uploadMerged(pass, sectionForPass.get(pass), parts);
+                if (merged != null) {
+                    batches.put(pass, merged);
+                }
+            }
+            dirty = false;
+            hitchSignature = signature;
+        }
+
+        private void closeBatches() {
+            for (LayerBuffer buffer : batches.values()) {
+                buffer.close();
+            }
+            batches.clear();
         }
 
         @Override
         public void close() {
-            if (closed || this == EMPTY || this == MARKER) {
+            closeBatches();
+            dirty = true;
+            hitchSignature = null;
+        }
+    }
+
+    private static final class ChunkMesh implements AutoCloseable {
+        static final ChunkMesh EMPTY = new ChunkMesh(List.of(), Kind.EMPTY);
+        static final ChunkMesh MARKER = new ChunkMesh(List.of(), Kind.MARKER);
+        static final ChunkMesh TEST_DRAWABLE = new ChunkMesh(List.of(), Kind.TEST_DRAWABLE);
+
+        private enum Kind {
+            EMPTY,
+            MARKER,
+            TEST_DRAWABLE,
+            REAL
+        }
+
+        private final List<CpuLayer> layers;
+        private final Kind kind;
+        private boolean closed;
+
+        private ChunkMesh(List<CpuLayer> layers) {
+            this(layers, Kind.REAL);
+        }
+
+        private ChunkMesh(List<CpuLayer> layers, Kind kind) {
+            this.layers = List.copyOf(layers);
+            this.kind = kind;
+        }
+
+        boolean isEmpty() {
+            return kind == Kind.EMPTY || (kind == Kind.REAL && layers.isEmpty());
+        }
+
+        boolean isDrawable() {
+            if (closed) {
+                return false;
+            }
+            return kind == Kind.TEST_DRAWABLE || (kind == Kind.REAL && !layers.isEmpty());
+        }
+
+        @Override
+        public void close() {
+            if (closed || kind != Kind.REAL) {
                 return;
             }
             closed = true;
-            for (LayerBuffer layerBuffer : layers) {
-                layerBuffer.close();
+        }
+    }
+
+    private record CpuLayer(
+            TerrainPass pass,
+            ChunkSectionLayer sectionLayer,
+            byte[] vertexBytes,
+            byte[] indexBytes,
+            IndexType indexType,
+            int indexCount,
+            int vertexCount
+    ) {
+        static CpuLayer fromMesh(ChunkSectionLayer layer, MeshData meshData) {
+            MeshData.DrawState drawState = meshData.drawState();
+            if (drawState.vertexCount() <= 0 || drawState.indexCount() <= 0) {
+                return null;
             }
+            ByteBuffer vertexBytes = meshData.vertexBuffer();
+            if (vertexBytes == null || !vertexBytes.hasRemaining()) {
+                return null;
+            }
+            byte[] vertices = copyBytes(vertexBytes);
+            byte[] indices = null;
+            ByteBuffer indexBytes = meshData.indexBuffer();
+            if (indexBytes != null && indexBytes.hasRemaining()) {
+                indices = copyBytes(indexBytes);
+            }
+            return new CpuLayer(
+                    TerrainPass.forSectionLayer(layer),
+                    layer,
+                    vertices,
+                    indices,
+                    drawState.indexType(),
+                    drawState.indexCount(),
+                    drawState.vertexCount()
+            );
         }
     }
 

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.render.soto.ghost;
 
 import com.adamkali.dwm.render.portal.PortalCameraTransform;
+import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.mojang.blaze3d.IndexType;
@@ -83,7 +84,9 @@ public final class SotoGhostMeshCache {
         PortalSceneStore.SceneKey sceneKey = new PortalSceneStore.SceneKey(kind, tardisId);
         long key = ChunkPos.pack(chunkX, chunkZ);
         Map<BlockPos, BlockState> blocks = ghost.blocksInChunk(key);
+        long bakeStart = PortalPerfStats.begin();
         ChunkMesh baked = bakeChunk(blocks, ghost);
+        PortalPerfStats.noteMeshBake(bakeStart >= 0L ? System.nanoTime() - bakeStart : 0L);
         Map<Long, ChunkMesh> byChunk = MESHES.computeIfAbsent(sceneKey, ignored -> new ConcurrentHashMap<>());
         ChunkMesh previous = byChunk.put(key, baked);
         if (previous != null) {
@@ -242,7 +245,9 @@ public final class SotoGhostMeshCache {
         }
         SotoGhostExterior ghost = SotoGhostExterior.get(sceneKey.kind(), sceneKey.tardisId());
         BlockPos footprintOrigin = ghost != null ? ghost.footprintOrigin() : BlockPos.ZERO;
+        long rebuildStart = PortalPerfStats.begin();
         state.rebuild(byChunk, hitch, signature, footprintOrigin);
+        PortalPerfStats.end(PortalPerfStats.Stage.PASS_BATCH_REBUILD, rebuildStart);
         return state;
     }
 
@@ -495,6 +500,8 @@ public final class SotoGhostMeshCache {
             Vec3 look = hitch != null ? hitch.lookDirection() : null;
             BlockPos origin = footprintOrigin == null ? BlockPos.ZERO : footprintOrigin;
 
+            int kept = 0;
+            int culled = 0;
             for (Long chunkKey : chunkKeys) {
                 ChunkMesh mesh = byChunk.get(chunkKey);
                 if (mesh == null || !mesh.isDrawable() || mesh.layers.isEmpty()) {
@@ -503,14 +510,17 @@ public final class SotoGhostMeshCache {
                 int chunkX = ChunkPos.getX(chunkKey);
                 int chunkZ = ChunkPos.getZ(chunkKey);
                 if (!SotoGhostHitchCull.isChunkVisibleToHitch(chunkX, chunkZ, origin, eye, look, viewMatrix)) {
+                    culled++;
                     continue;
                 }
+                kept++;
                 for (CpuLayer layer : mesh.layers) {
                     TerrainPass pass = layer.pass();
                     byPass.computeIfAbsent(pass, ignored -> new ArrayList<>()).add(layer);
                     sectionForPass.putIfAbsent(pass, layer.sectionLayer());
                 }
             }
+            PortalPerfStats.setCullCounts(kept, culled);
 
             for (TerrainPass pass : TerrainPass.values()) {
                 List<CpuLayer> parts = byPass.get(pass);

--- a/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
+++ b/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
@@ -77,6 +77,19 @@ public final class SotoGhostMeshCache {
         return count;
     }
 
+    /** True when a drawable (non-MARKER) mesh exists for this chunk column. */
+    public static boolean hasDrawableChunk(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ) {
+        if (kind == null || tardisId == null) {
+            return false;
+        }
+        Map<Long, ChunkMesh> byChunk = MESHES.get(new PortalSceneStore.SceneKey(kind, tardisId));
+        if (byChunk == null) {
+            return false;
+        }
+        ChunkMesh mesh = byChunk.get(ChunkPos.pack(chunkX, chunkZ));
+        return mesh != null && mesh.isDrawable();
+    }
+
     public static void onChunkApplied(PortalStreamKind kind, UUID tardisId, int chunkX, int chunkZ, SotoGhostExterior ghost) {
         if (kind == null || tardisId == null || ghost == null) {
             return;

--- a/src/main/generated/assets/dwm/lang/en_us.json
+++ b/src/main/generated/assets/dwm/lang/en_us.json
@@ -82,6 +82,8 @@
   "dwm.config.option.chameleon_gui": "Enable Chameleon GUI",
   "dwm.config.option.enable_door_portals": "Door portals (BOTI / SOTO)",
   "dwm.config.option.enable_door_portals.tooltip": "Show doorway previews through open exterior and interior doors using the shared portal renderer. Disabled on Fabulous graphics or when order-independent transparency is on.",
+  "dwm.config.option.show_portal_perf_debug": "Portal performance debug HUD",
+  "dwm.config.option.show_portal_perf_debug.tooltip": "Show an F3-style on-screen overlay with shared portal pipeline stage timings (BOTI and SOTO). Enable only while profiling.",
   "dwm.console.biome_selected": "Biome: %s",
   "dwm.console.biome_selector": "Biome selector",
   "dwm.console.biome_unavailable": "No biomes available for this dimension",

--- a/src/main/java/com/adamkali/dwm/config/DWMConfig.java
+++ b/src/main/java/com/adamkali/dwm/config/DWMConfig.java
@@ -20,6 +20,12 @@ public class DWMConfig {
      */
     public static final ConfigKey<Boolean> ENABLE_DOOR_PORTALS = new ConfigKey<>("enableDoorPortals", true);
 
+    /**
+     * Client F3-style HUD overlay with shared portal pipeline stage timings (BOTI + SOTO).
+     * Default off — enable only while profiling.
+     */
+    public static final ConfigKey<Boolean> SHOW_PORTAL_PERF_DEBUG = new ConfigKey<>("showPortalPerfDebug", false);
+
     /** Legacy keys migrated into {@link #ENABLE_DOOR_PORTALS} on load. */
     static final String LEGACY_ENABLE_BOTI = "enableBoti";
     static final String LEGACY_ENABLE_SOTO = "enableSoto";

--- a/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
+++ b/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
@@ -285,6 +285,8 @@ public class DWMLanguageProvider extends FabricLanguageProvider {
         t.add("dwm.config.option.chameleon_gui", "Enable Chameleon GUI");
         t.add("dwm.config.option.enable_door_portals", "Door portals (BOTI / SOTO)");
         t.add("dwm.config.option.enable_door_portals.tooltip", "Show doorway previews through open exterior and interior doors using the shared portal renderer. Disabled on Fabulous graphics or when order-independent transparency is on.");
+        t.add("dwm.config.option.show_portal_perf_debug", "Portal performance debug HUD");
+        t.add("dwm.config.option.show_portal_perf_debug.tooltip", "Show an F3-style on-screen overlay with shared portal pipeline stage timings (BOTI and SOTO). Enable only while profiling.");
         t.add("dwm.config.category.experimental", "Experimental");
     }
 

--- a/src/main/java/com/adamkali/dwm/network/DWMPacketIds.java
+++ b/src/main/java/com/adamkali/dwm/network/DWMPacketIds.java
@@ -22,6 +22,7 @@ public class DWMPacketIds {
     public static final Identifier SYNC_PORTAL_ENTITY_SPAWN_PACKET_ID = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sync_portal_entity_spawn");
     public static final Identifier SYNC_PORTAL_ENTITY_UPDATE_PACKET_ID = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sync_portal_entity_update");
     public static final Identifier SYNC_PORTAL_ENTITY_REMOVE_PACKET_ID = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sync_portal_entity_remove");
+    public static final Identifier SYNC_PORTAL_PERF_PACKET_ID = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sync_portal_perf");
 
     public static final Identifier TRAVEL_AUDIO_PACKET_ID = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "travel_audio");
 }

--- a/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
+++ b/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
@@ -34,6 +34,7 @@ public class ServerPayloadTypeRegistry {
         PayloadTypeRegistry.clientboundPlay().register(SyncPortalEntitySpawnS2CPayload.ID, SyncPortalEntitySpawnS2CPayload.CODEC);
         PayloadTypeRegistry.clientboundPlay().register(SyncPortalEntityUpdateS2CPayload.ID, SyncPortalEntityUpdateS2CPayload.CODEC);
         PayloadTypeRegistry.clientboundPlay().register(SyncPortalEntityRemoveS2CPayload.ID, SyncPortalEntityRemoveS2CPayload.CODEC);
+        PayloadTypeRegistry.clientboundPlay().register(SyncPortalPerfS2CPayload.ID, SyncPortalPerfS2CPayload.CODEC);
         PayloadTypeRegistry.clientboundPlay().register(TravelAudioS2CPayload.ID, TravelAudioS2CPayload.CODEC);
 
         PayloadTypeRegistry.serverboundPlay().register(UpdateTardisChameleonC2SPayload.ID, UpdateTardisChameleonC2SPayload.CODEC);

--- a/src/main/java/com/adamkali/dwm/network/SyncPortalPerfS2CPayload.java
+++ b/src/main/java/com/adamkali/dwm/network/SyncPortalPerfS2CPayload.java
@@ -1,0 +1,111 @@
+package com.adamkali.dwm.network;
+
+import com.adamkali.dwm.tardis.portal.PortalStreamPerfStats;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+
+/**
+ * ~1 Hz S2C snapshot of server MSPT + portal stream sync counters for the portal perf debugger.
+ */
+public record SyncPortalPerfS2CPayload(
+        float msptMs,
+        float flushMetaMs,
+        float flushSotoMs,
+        float flushBotiMs,
+        float syncEntitiesMs,
+        float syncFlushMs,
+        int entitySpawns,
+        int entityUpdates,
+        int entityRemoves,
+        int chunkPackets,
+        int metaPackets,
+        int chunkSamples,
+        int entitiesScanned,
+        int fullResyncs,
+        int viewers,
+        int activeStreams,
+        int serverTick
+) implements CustomPacketPayload {
+    public static final CustomPacketPayload.Type<SyncPortalPerfS2CPayload> ID =
+            new CustomPacketPayload.Type<>(DWMPacketIds.SYNC_PORTAL_PERF_PACKET_ID);
+
+    public static final StreamCodec<RegistryFriendlyByteBuf, SyncPortalPerfS2CPayload> CODEC =
+            StreamCodec.ofMember(SyncPortalPerfS2CPayload::encode, SyncPortalPerfS2CPayload::decode);
+
+    public static SyncPortalPerfS2CPayload fromSnapshot(PortalStreamPerfStats.Snapshot snap) {
+        if (snap == null || !snap.isPresent()) {
+            return new SyncPortalPerfS2CPayload(
+                    Float.NaN, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+            );
+        }
+        return new SyncPortalPerfS2CPayload(
+                (float) snap.msptMs(),
+                (float) snap.flushMetaMs(),
+                (float) snap.flushSotoMs(),
+                (float) snap.flushBotiMs(),
+                (float) snap.syncEntitiesMs(),
+                (float) snap.syncFlushMs(),
+                snap.entitySpawns(),
+                snap.entityUpdates(),
+                snap.entityRemoves(),
+                snap.chunkPackets(),
+                snap.metaPackets(),
+                snap.chunkSamples(),
+                snap.entitiesScanned(),
+                snap.fullResyncs(),
+                snap.viewers(),
+                snap.activeStreams(),
+                snap.serverTick()
+        );
+    }
+
+    private static void encode(SyncPortalPerfS2CPayload payload, RegistryFriendlyByteBuf buf) {
+        buf.writeFloat(payload.msptMs);
+        buf.writeFloat(payload.flushMetaMs);
+        buf.writeFloat(payload.flushSotoMs);
+        buf.writeFloat(payload.flushBotiMs);
+        buf.writeFloat(payload.syncEntitiesMs);
+        buf.writeFloat(payload.syncFlushMs);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.entitySpawns);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.entityUpdates);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.entityRemoves);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.chunkPackets);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.metaPackets);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.chunkSamples);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.entitiesScanned);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.fullResyncs);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.viewers);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.activeStreams);
+        ByteBufCodecs.VAR_INT.encode(buf, payload.serverTick);
+    }
+
+    private static SyncPortalPerfS2CPayload decode(RegistryFriendlyByteBuf buf) {
+        return new SyncPortalPerfS2CPayload(
+                buf.readFloat(),
+                buf.readFloat(),
+                buf.readFloat(),
+                buf.readFloat(),
+                buf.readFloat(),
+                buf.readFloat(),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf)
+        );
+    }
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return ID;
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamPerfStats.java
+++ b/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamPerfStats.java
@@ -1,0 +1,307 @@
+package com.adamkali.dwm.tardis.portal;
+
+import com.adamkali.dwm.config.DWMConfig;
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Config-gated server-side portal stream diagnostics.
+ * Accumulates per-tick counters/phase timings and publishes a ~1 Hz {@link Snapshot}.
+ */
+public final class PortalStreamPerfStats {
+    public static final int PUBLISH_INTERVAL_TICKS = 20;
+
+    private static long flushMetaNs;
+    private static long flushSotoNs;
+    private static long flushBotiNs;
+    private static long syncEntitiesNs;
+    private static int entitySpawns;
+    private static int entityUpdates;
+    private static int entityRemoves;
+    private static int chunkPackets;
+    private static int metaPackets;
+    private static int chunkSamples;
+    private static int entitiesScanned;
+    private static int fullResyncs;
+    private static int maxViewers;
+    private static int maxActiveStreams;
+    private static int streamsThisTick;
+    private static double lastMsptMs;
+    private static int lastServerTick;
+
+    private static volatile Snapshot published = Snapshot.IDLE;
+
+    private PortalStreamPerfStats() {
+    }
+
+    public static boolean isEnabled() {
+        return DWMConfig.getBoolean(DWMConfig.SHOW_PORTAL_PERF_DEBUG);
+    }
+
+    /** Returns {@code System.nanoTime()} when enabled, else {@code -1}. */
+    public static long begin() {
+        return isEnabled() ? System.nanoTime() : -1L;
+    }
+
+    public static void beginTick(MinecraftServer server) {
+        if (!isEnabled() || server == null) {
+            return;
+        }
+        streamsThisTick = 0;
+        lastMsptMs = server.getAverageTickTimeNanos() / 1_000_000.0;
+        lastServerTick = server.getTickCount();
+    }
+
+    /** Fold this tick's active-stream count into the window max. Call once at end of tick. */
+    public static void endTick() {
+        if (!isEnabled()) {
+            return;
+        }
+        if (streamsThisTick > maxActiveStreams) {
+            maxActiveStreams = streamsThisTick;
+        }
+    }
+
+    public static void endFlushMeta(long startNs) {
+        addPhaseNs(startNs, Phase.FLUSH_META);
+    }
+
+    public static void endFlushSoto(long startNs) {
+        addPhaseNs(startNs, Phase.FLUSH_SOTO);
+    }
+
+    public static void endFlushBoti(long startNs) {
+        addPhaseNs(startNs, Phase.FLUSH_BOTI);
+    }
+
+    public static void endSyncEntities(long startNs) {
+        addPhaseNs(startNs, Phase.SYNC_ENTITIES);
+    }
+
+    public static void noteEntitySpawn() {
+        if (isEnabled()) {
+            entitySpawns++;
+        }
+    }
+
+    public static void noteEntityUpdate() {
+        if (isEnabled()) {
+            entityUpdates++;
+        }
+    }
+
+    public static void noteEntityRemove() {
+        if (isEnabled()) {
+            entityRemoves++;
+        }
+    }
+
+    public static void noteChunkPacket() {
+        if (isEnabled()) {
+            chunkPackets++;
+        }
+    }
+
+    public static void noteMetaPacket() {
+        if (isEnabled()) {
+            metaPackets++;
+        }
+    }
+
+    public static void noteChunkSample() {
+        if (isEnabled()) {
+            chunkSamples++;
+        }
+    }
+
+    public static void noteEntitiesScanned(int count) {
+        if (isEnabled() && count > 0) {
+            entitiesScanned += count;
+        }
+    }
+
+    public static void noteFullResync() {
+        if (isEnabled()) {
+            fullResyncs++;
+        }
+    }
+
+    public static void noteStreamViewers(int viewerCount) {
+        if (!isEnabled() || viewerCount <= 0) {
+            return;
+        }
+        streamsThisTick++;
+        if (viewerCount > maxViewers) {
+            maxViewers = viewerCount;
+        }
+    }
+
+    /**
+     * Every {@link #PUBLISH_INTERVAL_TICKS} ticks, builds a window snapshot and resets accumulators.
+     *
+     * @return published snapshot when a publish occurred; otherwise {@code null}
+     */
+    public static Snapshot maybePublish(int tickCounter) {
+        if (!isEnabled() || tickCounter % PUBLISH_INTERVAL_TICKS != 0) {
+            return null;
+        }
+        Snapshot snap = buildSnapshot();
+        published = snap;
+        resetWindow();
+        return snap;
+    }
+
+    public static Snapshot snapshot() {
+        return published;
+    }
+
+    /** Pure helper for tests: convert accumulated window fields into a snapshot. */
+    static Snapshot buildSnapshotPure(
+            double msptMs,
+            long flushMetaNsValue,
+            long flushSotoNsValue,
+            long flushBotiNsValue,
+            long syncEntitiesNsValue,
+            int entitySpawnsValue,
+            int entityUpdatesValue,
+            int entityRemovesValue,
+            int chunkPacketsValue,
+            int metaPacketsValue,
+            int chunkSamplesValue,
+            int entitiesScannedValue,
+            int fullResyncsValue,
+            int viewersValue,
+            int activeStreamsValue,
+            int serverTick
+    ) {
+        double flushMetaMs = nsToMs(flushMetaNsValue);
+        double flushSotoMs = nsToMs(flushSotoNsValue);
+        double flushBotiMs = nsToMs(flushBotiNsValue);
+        double syncEntitiesMs = nsToMs(syncEntitiesNsValue);
+        return new Snapshot(
+                msptMs,
+                flushMetaMs,
+                flushSotoMs,
+                flushBotiMs,
+                syncEntitiesMs,
+                flushMetaMs + flushSotoMs + flushBotiMs,
+                entitySpawnsValue,
+                entityUpdatesValue,
+                entityRemovesValue,
+                chunkPacketsValue,
+                metaPacketsValue,
+                chunkSamplesValue,
+                entitiesScannedValue,
+                fullResyncsValue,
+                viewersValue,
+                activeStreamsValue,
+                serverTick
+        );
+    }
+
+    static void resetForTests() {
+        resetWindow();
+        lastMsptMs = 0.0;
+        lastServerTick = 0;
+        published = Snapshot.IDLE;
+    }
+
+    public static void clear() {
+        resetForTests();
+    }
+
+    private static Snapshot buildSnapshot() {
+        return buildSnapshotPure(
+                lastMsptMs,
+                flushMetaNs,
+                flushSotoNs,
+                flushBotiNs,
+                syncEntitiesNs,
+                entitySpawns,
+                entityUpdates,
+                entityRemoves,
+                chunkPackets,
+                metaPackets,
+                chunkSamples,
+                entitiesScanned,
+                fullResyncs,
+                maxViewers,
+                maxActiveStreams,
+                lastServerTick
+        );
+    }
+
+    private static void resetWindow() {
+        flushMetaNs = 0L;
+        flushSotoNs = 0L;
+        flushBotiNs = 0L;
+        syncEntitiesNs = 0L;
+        entitySpawns = 0;
+        entityUpdates = 0;
+        entityRemoves = 0;
+        chunkPackets = 0;
+        metaPackets = 0;
+        chunkSamples = 0;
+        entitiesScanned = 0;
+        fullResyncs = 0;
+        maxViewers = 0;
+        maxActiveStreams = 0;
+        streamsThisTick = 0;
+    }
+
+    private static void addPhaseNs(long startNs, Phase phase) {
+        if (startNs < 0L || !isEnabled()) {
+            return;
+        }
+        long elapsed = System.nanoTime() - startNs;
+        if (elapsed <= 0L) {
+            return;
+        }
+        switch (phase) {
+            case FLUSH_META -> flushMetaNs += elapsed;
+            case FLUSH_SOTO -> flushSotoNs += elapsed;
+            case FLUSH_BOTI -> flushBotiNs += elapsed;
+            case SYNC_ENTITIES -> syncEntitiesNs += elapsed;
+        }
+    }
+
+    static double nsToMs(long ns) {
+        return ns / 1_000_000.0;
+    }
+
+    private enum Phase {
+        FLUSH_META,
+        FLUSH_SOTO,
+        FLUSH_BOTI,
+        SYNC_ENTITIES
+    }
+
+    public record Snapshot(
+            double msptMs,
+            double flushMetaMs,
+            double flushSotoMs,
+            double flushBotiMs,
+            double syncEntitiesMs,
+            double syncFlushMs,
+            int entitySpawns,
+            int entityUpdates,
+            int entityRemoves,
+            int chunkPackets,
+            int metaPackets,
+            int chunkSamples,
+            int entitiesScanned,
+            int fullResyncs,
+            int viewers,
+            int activeStreams,
+            int serverTick
+    ) {
+        public static final Snapshot IDLE = new Snapshot(
+                Double.NaN,
+                0.0, 0.0, 0.0, 0.0, 0.0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        );
+
+        public boolean isPresent() {
+            return !Double.isNaN(msptMs);
+        }
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -5,6 +5,7 @@ import com.adamkali.dwm.network.SyncPortalEntityRemoveS2CPayload;
 import com.adamkali.dwm.network.SyncPortalEntitySpawnS2CPayload;
 import com.adamkali.dwm.network.SyncPortalEntityUpdateS2CPayload;
 import com.adamkali.dwm.network.SyncPortalMetaS2CPayload;
+import com.adamkali.dwm.network.SyncPortalPerfS2CPayload;
 import com.adamkali.dwm.network.UnloadPortalChunkS2CPayload;
 import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.boti.BotiPlotIndex;
@@ -56,6 +57,7 @@ public final class PortalStreamSyncService {
     private static final Map<StreamKey, Integer> LEAVE_GRACE = new ConcurrentHashMap<>();
     private static final Set<UUID> META_DIRTY = ConcurrentHashMap.newKeySet();
     private static final Map<UUID, Integer> META_REVISIONS = new ConcurrentHashMap<>();
+    private static final Set<ServerPlayer> TICK_VIEWERS = ConcurrentHashMap.newKeySet();
     private static int tickCounter;
 
     private PortalStreamSyncService() {
@@ -88,8 +90,10 @@ public final class PortalStreamSyncService {
         LEAVE_GRACE.clear();
         META_DIRTY.clear();
         META_REVISIONS.clear();
+        TICK_VIEWERS.clear();
         SotoExteriorIndex.clear();
         BotiPlotIndex.clear();
+        PortalStreamPerfStats.clear();
         tickCounter = 0;
     }
 
@@ -150,10 +154,38 @@ public final class PortalStreamSyncService {
 
     private static void onEndTick(MinecraftServer server) {
         tickCounter++;
+        TICK_VIEWERS.clear();
+        boolean diag = PortalStreamPerfStats.isEnabled();
+        if (diag) {
+            PortalStreamPerfStats.beginTick(server);
+        }
         markShellAnimatingDirty();
+        long metaStart = PortalStreamPerfStats.begin();
         flushMeta(server);
+        PortalStreamPerfStats.endFlushMeta(metaStart);
+        long sotoStart = PortalStreamPerfStats.begin();
         flushStreams(server, PortalStreamKind.SOTO);
+        PortalStreamPerfStats.endFlushSoto(sotoStart);
+        long botiStart = PortalStreamPerfStats.begin();
         flushStreams(server, PortalStreamKind.BOTI);
+        PortalStreamPerfStats.endFlushBoti(botiStart);
+        if (diag) {
+            PortalStreamPerfStats.endTick();
+            maybeSendPerfDiag(server);
+        }
+    }
+
+    private static void maybeSendPerfDiag(MinecraftServer server) {
+        PortalStreamPerfStats.Snapshot snap = PortalStreamPerfStats.maybePublish(tickCounter);
+        if (snap == null || !snap.isPresent() || TICK_VIEWERS.isEmpty()) {
+            return;
+        }
+        SyncPortalPerfS2CPayload payload = SyncPortalPerfS2CPayload.fromSnapshot(snap);
+        for (ServerPlayer viewer : Set.copyOf(TICK_VIEWERS)) {
+            if (viewer != null && !viewer.hasDisconnected()) {
+                ServerPlayNetworking.send(viewer, payload);
+            }
+        }
     }
 
     private static void markShellAnimatingDirty() {
@@ -201,6 +233,7 @@ public final class PortalStreamSyncService {
                 );
                 for (ServerPlayer viewer : viewers) {
                     ServerPlayNetworking.send(viewer, payload);
+                    PortalStreamPerfStats.noteMetaPacket();
                 }
             }
         }
@@ -220,6 +253,8 @@ public final class PortalStreamSyncService {
                 continue;
             }
             active.add(tardisId);
+            TICK_VIEWERS.addAll(viewers);
+            PortalStreamPerfStats.noteStreamViewers(viewers.size());
             LEAVE_GRACE.remove(streamKey);
             SceneContext ctx = resolveScene(server, kind, tardisId);
             if (ctx == null) {
@@ -279,6 +314,7 @@ public final class PortalStreamSyncService {
                     ServerPlayNetworking.send(player, new SyncPortalEntityRemoveS2CPayload(
                             streamKey.kind, streamKey.tardisId, entityId
                     ));
+                    PortalStreamPerfStats.noteEntityRemove();
                 }
             }
             SENT_CHUNKS.remove(key);
@@ -323,6 +359,7 @@ public final class PortalStreamSyncService {
         ServerPlayNetworking.send(player, SyncPortalMetaS2CPayload.of(
                 ctx.kind(), ctx.tardisId(), revision, ctx.shell(), ctx.atmosphere()
         ));
+        PortalStreamPerfStats.noteMetaPacket();
     }
 
     private static void sendFullChunks(ServerPlayer player, SceneContext ctx) {
@@ -332,13 +369,16 @@ public final class PortalStreamSyncService {
         for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
                 PortalStreamSample sample = ctx.sampleChunk(cx, cz);
+                PortalStreamPerfStats.noteChunkSample();
                 ServerPlayNetworking.send(
                         player,
                         SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
                 );
+                PortalStreamPerfStats.noteChunkPacket();
                 sent.add(ChunkPos.pack(cx, cz));
             }
         }
+        PortalStreamPerfStats.noteFullResync();
         TRACKED_ENTITIES.put(key, ConcurrentHashMap.newKeySet());
         syncEntities(player, ctx);
     }
@@ -368,10 +408,12 @@ public final class PortalStreamSyncService {
             int cx = ChunkPos.getX(packed);
             int cz = ChunkPos.getZ(packed);
             PortalStreamSample sample = ctx.sampleChunk(cx, cz);
+            PortalStreamPerfStats.noteChunkSample();
             ServerPlayNetworking.send(
                     player,
                     SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
             );
+            PortalStreamPerfStats.noteChunkPacket();
             sent.add(packed);
         }
     }
@@ -393,17 +435,21 @@ public final class PortalStreamSyncService {
             int cx = ChunkPos.getX(packed);
             int cz = ChunkPos.getZ(packed);
             PortalStreamSample sample = ctx.sampleChunk(cx, cz);
+            PortalStreamPerfStats.noteChunkSample();
             ServerPlayNetworking.send(
                     player,
                     SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
             );
+            PortalStreamPerfStats.noteChunkPacket();
         }
     }
 
     private static void syncEntities(ServerPlayer player, SceneContext ctx) {
+        long syncStart = PortalStreamPerfStats.begin();
         ViewerKey key = new ViewerKey(ctx.kind(), ctx.tardisId(), player.getUUID());
         Set<UUID> tracked = TRACKED_ENTITIES.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
         List<Entity> live = ctx.collectEntities();
+        PortalStreamPerfStats.noteEntitiesScanned(live.size());
         Set<UUID> liveIds = new HashSet<>();
         for (Entity entity : live) {
             if (BotiInteriorSampler.captureEntityNbt(entity) == null
@@ -416,6 +462,7 @@ public final class PortalStreamSyncService {
                         player,
                         SyncPortalEntityUpdateS2CPayload.fromEntity(ctx.kind(), ctx.tardisId(), entity, ctx.footprintOrigin())
                 );
+                PortalStreamPerfStats.noteEntityUpdate();
             } else {
                 SyncPortalEntitySpawnS2CPayload spawn =
                         SyncPortalEntitySpawnS2CPayload.fromEntity(ctx.kind(), ctx.tardisId(), entity, ctx.footprintOrigin());
@@ -423,6 +470,7 @@ public final class PortalStreamSyncService {
                     continue;
                 }
                 ServerPlayNetworking.send(player, spawn);
+                PortalStreamPerfStats.noteEntitySpawn();
                 tracked.add(entity.getUUID());
             }
         }
@@ -430,8 +478,10 @@ public final class PortalStreamSyncService {
             if (!liveIds.contains(id)) {
                 tracked.remove(id);
                 ServerPlayNetworking.send(player, new SyncPortalEntityRemoveS2CPayload(ctx.kind(), ctx.tardisId(), id));
+                PortalStreamPerfStats.noteEntityRemove();
             }
         }
+        PortalStreamPerfStats.endSyncEntities(syncStart);
     }
 
     private static void keepAlive(SceneContext ctx) {

--- a/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -142,6 +142,12 @@ public final class PortalStreamSyncService {
         StreamKey streamKey = new StreamKey(kind, tardisId);
         SUBSCRIBERS.computeIfAbsent(streamKey, id -> ConcurrentHashMap.newKeySet()).add(player.getUUID());
         LEAVE_GRACE.remove(streamKey);
+        ViewerKey viewerKey = new ViewerKey(kind, tardisId, player.getUUID());
+        Set<Long> alreadySent = SENT_CHUNKS.get(viewerKey);
+        boolean alreadyStreaming = alreadySent != null && !alreadySent.isEmpty();
+        if (alreadyStreaming) {
+            return true;
+        }
         sendMeta(player, ctx);
         sendFullChunks(player, ctx);
         return true;

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalFrameCacheTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalFrameCacheTest.java
@@ -1,0 +1,119 @@
+package com.adamkali.dwm.render.portal;
+
+import com.adamkali.dwm.tardis.portal.PortalStreamKind;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalFrameCacheTest {
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        PortalFrameCache.resetForTests();
+    }
+
+    @Test
+    void unknownKey_isDirtyByDefault() {
+        PortalKey key = PortalKey.soto(UUID.randomUUID());
+        assertTrue(PortalFrameCache.isDirty(key));
+        assertFalse(PortalFrameCache.wasLastWriter(key));
+        assertNull(PortalFrameCache.lastWriter());
+    }
+
+    @Test
+    void clearDirty_afterNoteRendered_allowsSkipEligibility() {
+        PortalKey key = PortalKey.soto(UUID.randomUUID());
+        PortalFrameCache.noteRendered(key);
+        PortalFrameCache.clearDirty(key);
+
+        assertFalse(PortalFrameCache.isDirty(key));
+        assertTrue(PortalFrameCache.wasLastWriter(key));
+    }
+
+    @Test
+    void otherKeyRender_dirtiesPreviousWriter() {
+        UUID id = UUID.randomUUID();
+        PortalKey soto = PortalKey.soto(id);
+        PortalKey boti = PortalKey.boti(id);
+
+        PortalFrameCache.noteRendered(soto);
+        PortalFrameCache.clearDirty(soto);
+        assertFalse(PortalFrameCache.isDirty(soto));
+
+        PortalKey previous = PortalFrameCache.noteRendered(boti);
+        PortalFrameCache.clearDirty(boti);
+
+        assertEquals(soto, previous);
+        assertTrue(PortalFrameCache.isDirty(soto));
+        assertFalse(PortalFrameCache.isDirty(boti));
+        assertTrue(PortalFrameCache.wasLastWriter(boti));
+        assertFalse(PortalFrameCache.wasLastWriter(soto));
+    }
+
+    @Test
+    void overwrittenReadyKeys_marksOthersDirty() {
+        PortalKey soto = PortalKey.soto(UUID.randomUUID());
+        PortalKey boti = PortalKey.boti(UUID.randomUUID());
+        Set<PortalKey> ready = new HashSet<>();
+        ready.add(soto);
+        ready.add(boti);
+        PortalFrameCache.clearDirty(soto);
+        PortalFrameCache.clearDirty(boti);
+
+        Set<PortalKey> overwritten = PortalFrameCache.overwrittenReadyKeys(soto, ready);
+
+        assertTrue(overwritten.contains(boti));
+        assertFalse(overwritten.contains(soto));
+        assertTrue(PortalFrameCache.isDirty(boti));
+        assertFalse(PortalFrameCache.isDirty(soto));
+    }
+
+    @Test
+    void markDirty_streamKind_mapsToPortalKey() {
+        UUID id = UUID.randomUUID();
+        PortalFrameCache.noteRendered(PortalKey.soto(id));
+        PortalFrameCache.clearDirty(PortalKey.soto(id));
+
+        PortalFrameCache.markDirty(PortalStreamKind.SOTO, id);
+
+        assertTrue(PortalFrameCache.isDirty(PortalKey.soto(id)));
+        assertTrue(PortalFrameCache.isDirty(PortalFrameCache.toPortalKey(PortalStreamKind.SOTO, id)));
+    }
+
+    @Test
+    void invalidateForResize_clearsCleanAndLastWriter() {
+        PortalKey key = PortalKey.boti(UUID.randomUUID());
+        PortalFrameCache.noteRendered(key);
+        PortalFrameCache.clearDirty(key);
+
+        PortalFrameCache.invalidateForResize();
+
+        assertTrue(PortalFrameCache.isDirty(key));
+        assertNull(PortalFrameCache.lastWriter());
+        assertFalse(PortalFrameCache.wasLastWriter(key));
+    }
+
+    @Test
+    void markAllDirty_resetsSkipState() {
+        PortalKey a = PortalKey.soto(UUID.randomUUID());
+        PortalKey b = PortalKey.boti(UUID.randomUUID());
+        PortalFrameCache.noteRendered(a);
+        PortalFrameCache.clearDirty(a);
+        PortalFrameCache.clearDirty(b);
+
+        PortalFrameCache.markAllDirty();
+
+        assertTrue(PortalFrameCache.isDirty(a));
+        assertTrue(PortalFrameCache.isDirty(b));
+        assertNull(PortalFrameCache.lastWriter());
+    }
+}

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
@@ -40,7 +40,13 @@ class PortalPerfDebugLogTest {
                 60,
                 0.25,
                 1.5,
-                PortalPerfStats.Stage.TERRAIN_OPAQUE
+                PortalPerfStats.Stage.TERRAIN_OPAQUE,
+                1.2,
+                0.015,
+                0.42f,
+                12.4f,
+                0.5,
+                0.8
         );
 
         String line = PortalPerfDebugLog.formatLine(1_700_000_000_000L, snap);
@@ -58,6 +64,12 @@ class PortalPerfDebugLogTest {
         assertTrue(line.contains("\"cullCulled\":17"));
         assertTrue(line.contains("\"avgBakeCount\":0.2500"));
         assertTrue(line.contains("\"avgBakeSkipCount\":1.5000"));
+        assertTrue(line.contains("\"avgEntityUpdates\":1.2000"));
+        assertTrue(line.contains("\"maxPoseDelta\":0.0150"));
+        assertTrue(line.contains("\"partialTickUsed\":0.4200"));
+        assertTrue(line.contains("\"itemAgeInTicks\":12.4000"));
+        assertTrue(line.contains("\"avgIdentityInterp\":0.5000"));
+        assertTrue(line.contains("\"avgAdvanceInterp\":0.8000"));
     }
 
     @Test

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
@@ -39,6 +39,7 @@ class PortalPerfDebugLogTest {
                 2.1,
                 60,
                 0.25,
+                1.5,
                 PortalPerfStats.Stage.TERRAIN_OPAQUE
         );
 
@@ -55,6 +56,8 @@ class PortalPerfDebugLogTest {
         assertTrue(line.contains("\"chunks\":25"));
         assertTrue(line.contains("\"cullKept\":8"));
         assertTrue(line.contains("\"cullCulled\":17"));
+        assertTrue(line.contains("\"avgBakeCount\":0.2500"));
+        assertTrue(line.contains("\"avgBakeSkipCount\":1.5000"));
     }
 
     @Test

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
@@ -42,11 +42,14 @@ class PortalPerfDebugLogTest {
                 1.5,
                 PortalPerfStats.Stage.TERRAIN_OPAQUE,
                 1.2,
+                0.4,
+                0.1,
                 0.015,
                 0.42f,
                 12.4f,
                 0.5,
-                0.8
+                0.8,
+                new PortalPerfStats.ServerDiag(48.5f, 3.25f, 1.1f, 40, 2, 1, 0, 1, 1, 2400)
         );
 
         String line = PortalPerfDebugLog.formatLine(1_700_000_000_000L, snap);
@@ -65,11 +68,19 @@ class PortalPerfDebugLogTest {
         assertTrue(line.contains("\"avgBakeCount\":0.2500"));
         assertTrue(line.contains("\"avgBakeSkipCount\":1.5000"));
         assertTrue(line.contains("\"avgEntityUpdates\":1.2000"));
+        assertTrue(line.contains("\"avgEntitySpawns\":0.4000"));
+        assertTrue(line.contains("\"avgEntityRemoves\":0.1000"));
         assertTrue(line.contains("\"maxPoseDelta\":0.0150"));
         assertTrue(line.contains("\"partialTickUsed\":0.4200"));
         assertTrue(line.contains("\"itemAgeInTicks\":12.4000"));
         assertTrue(line.contains("\"avgIdentityInterp\":0.5000"));
         assertTrue(line.contains("\"avgAdvanceInterp\":0.8000"));
+        assertTrue(line.contains("\"msptMs\":48.5000"));
+        assertTrue(line.contains("\"syncFlushMs\":3.2500"));
+        assertTrue(line.contains("\"srvEntityUpdates\":40"));
+        assertTrue(line.contains("\"srvEntitySpawns\":2"));
+        assertTrue(line.contains("\"srvFullResyncs\":0"));
+        assertTrue(line.contains("\"srvViewers\":1"));
     }
 
     @Test

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfDebugLogTest.java
@@ -1,0 +1,65 @@
+package com.adamkali.dwm.render.portal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.EnumMap;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalPerfDebugLogTest {
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        PortalPerfDebugLog.resetForTests();
+        PortalPerfStats.resetForTests();
+    }
+
+    @Test
+    void formatLine_includesAveragesAndIdentity() {
+        UUID id = UUID.fromString("abcdef01-2345-6789-abcd-ef0123456789");
+        EnumMap<PortalPerfStats.Stage, Double> avg = new EnumMap<>(PortalPerfStats.Stage.class);
+        avg.put(PortalPerfStats.Stage.TERRAIN_OPAQUE, 1.25);
+        avg.put(PortalPerfStats.Stage.MESH_BAKE, 0.5);
+
+        PortalPerfStats.DisplaySnapshot snap = new PortalPerfStats.DisplaySnapshot(
+                PortalKey.soto(id),
+                PortalPerfStats.Outcome.RENDERED,
+                avg,
+                25,
+                24,
+                3,
+                8,
+                17,
+                2.5,
+                2.1,
+                60,
+                0.25,
+                PortalPerfStats.Stage.TERRAIN_OPAQUE
+        );
+
+        String line = PortalPerfDebugLog.formatLine(1_700_000_000_000L, snap);
+        assertTrue(line.startsWith("{"));
+        assertTrue(line.endsWith("}"));
+        assertTrue(line.contains("\"kind\":\"SOTO\""));
+        assertTrue(line.contains("\"tardisId\":\"abcdef01-2345-6789-abcd-ef0123456789\""));
+        assertTrue(line.contains("\"outcome\":\"rendered\""));
+        assertTrue(line.contains("\"avgTotalMs\":2.5000"));
+        assertTrue(line.contains("\"emaTotalMs\":2.1000"));
+        assertTrue(line.contains("\"window\":60"));
+        assertTrue(line.contains("\"opaque\":1.2500"));
+        assertTrue(line.contains("\"chunks\":25"));
+        assertTrue(line.contains("\"cullKept\":8"));
+        assertTrue(line.contains("\"cullCulled\":17"));
+    }
+
+    @Test
+    void resolveLogPathForTest_usesLogsSubdir() {
+        Path path = PortalPerfDebugLog.resolveLogPathForTest(Path.of("/tmp/game"));
+        assertEquals(Path.of("/tmp/game/logs/dwm-portal-perf.jsonl"), path);
+    }
+}

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
@@ -1,0 +1,152 @@
+package com.adamkali.dwm.render.portal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalPerfStatsTest {
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        PortalPerfStats.resetForTests();
+    }
+
+    @Test
+    void updateEma_firstSample_returnsSample() {
+        assertEquals(4.0, PortalPerfStats.updateEma(0.0, 4.0, 0.2), 1e-9);
+    }
+
+    @Test
+    void updateEma_blendsTowardSample() {
+        double ema = PortalPerfStats.updateEma(10.0, 0.0, 0.2);
+        assertEquals(8.0, ema, 1e-9);
+    }
+
+    @Test
+    void nsToMs_convertsNanoseconds() {
+        assertEquals(1.5, PortalPerfStats.nsToMs(1_500_000L), 1e-9);
+    }
+
+    @Test
+    void findMaxStage_prefersLargestTimedStage() {
+        EnumMap<PortalPerfStats.Stage, Long> stages = new EnumMap<>(PortalPerfStats.Stage.class);
+        stages.put(PortalPerfStats.Stage.SKY_FOG, 100_000L);
+        stages.put(PortalPerfStats.Stage.TERRAIN_OPAQUE, 5_000_000L);
+        stages.put(PortalPerfStats.Stage.GHOST_FEATURES, 2_000_000L);
+        assertEquals(PortalPerfStats.Stage.TERRAIN_OPAQUE, PortalPerfStats.findMaxStage(stages));
+    }
+
+    @Test
+    void findMaxAvgStage_prefersLargestAverage() {
+        EnumMap<PortalPerfStats.Stage, Double> avg = new EnumMap<>(PortalPerfStats.Stage.class);
+        avg.put(PortalPerfStats.Stage.SKY_FOG, 0.1);
+        avg.put(PortalPerfStats.Stage.TERRAIN_OPAQUE, 1.5);
+        avg.put(PortalPerfStats.Stage.MESH_BAKE, 0.8);
+        assertEquals(PortalPerfStats.Stage.TERRAIN_OPAQUE, PortalPerfStats.findMaxAvgStage(avg));
+    }
+
+    @Test
+    void windowAverage_meansSamples() {
+        assertEquals(2.0, PortalPerfStats.windowAverage(new double[]{1.0, 2.0, 3.0}, 3), 1e-9);
+        assertEquals(0.0, PortalPerfStats.windowAverage(new double[]{}, 0), 1e-9);
+    }
+
+    @Test
+    void shortId_usesFirstEightChars() {
+        UUID id = UUID.fromString("12345678-1234-1234-1234-123456789abc");
+        assertEquals("12345678", PortalPerfStats.shortId(id));
+    }
+
+    @Test
+    void formatLinesPure_idleWhenNoKey() {
+        List<String> lines = PortalPerfStats.formatLinesPure(PortalPerfStats.DisplaySnapshot.IDLE);
+        assertEquals(1, lines.size());
+        assertEquals("Portal Perf [idle]", lines.getFirst());
+    }
+
+    @Test
+    void formatLinesPure_showsAveragesNotRawFrame() {
+        UUID id = UUID.fromString("abcdef01-2345-6789-abcd-ef0123456789");
+        PortalKey key = PortalKey.soto(id);
+        EnumMap<PortalPerfStats.Stage, Double> avg = new EnumMap<>(PortalPerfStats.Stage.class);
+        avg.put(PortalPerfStats.Stage.FLUSH_TOTAL, 3.0);
+        avg.put(PortalPerfStats.Stage.OFF_MAIN_TOTAL, 2.5);
+        avg.put(PortalPerfStats.Stage.TERRAIN_OPAQUE, 1.2);
+        avg.put(PortalPerfStats.Stage.PASS_BATCH_REBUILD, 0.8);
+
+        PortalPerfStats.DisplaySnapshot snap = new PortalPerfStats.DisplaySnapshot(
+                key,
+                PortalPerfStats.Outcome.RENDERED,
+                avg,
+                25,
+                24,
+                3,
+                8,
+                17,
+                2.5,
+                2.1,
+                60,
+                0.0,
+                PortalPerfStats.Stage.TERRAIN_OPAQUE
+        );
+
+        List<String> lines = PortalPerfStats.formatLinesPure(snap);
+        assertTrue(lines.get(0).contains("SOTO"));
+        assertTrue(lines.get(0).contains("abcdef01"));
+        assertTrue(lines.get(1).contains("avg: 2.50ms"));
+        assertTrue(lines.get(1).contains("ema 2.10"));
+        assertTrue(lines.get(1).contains("n=60"));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("*opaque:")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("cull: 8/17")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("maxAvg: opaque")));
+        assertTrue(lines.stream().noneMatch(line -> line.contains("bake this frame")));
+    }
+
+    @Test
+    void ringBuffer_computesWindowAverageAndHistory() {
+        PortalKey key = PortalKey.soto(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        PortalPerfStats.setIdentityForTest(key, PortalPerfStats.Outcome.RENDERED);
+
+        for (int i = 0; i < 3; i++) {
+            EnumMap<PortalPerfStats.Stage, Double> stages = new EnumMap<>(PortalPerfStats.Stage.class);
+            stages.put(PortalPerfStats.Stage.TERRAIN_OPAQUE, 1.0 + i);
+            stages.put(PortalPerfStats.Stage.OFF_MAIN_TOTAL, 2.0 + i);
+            PortalPerfStats.pushSampleForTest(stages, 2.0 + i, 0);
+        }
+
+        assertEquals(3, PortalPerfStats.historySize());
+        float[] totals = PortalPerfStats.historyTotalsMs();
+        assertEquals(3, totals.length);
+        assertEquals(2.0f, totals[0], 1e-4f);
+        assertEquals(4.0f, totals[2], 1e-4f);
+
+        PortalPerfStats.DisplaySnapshot display = PortalPerfStats.displaySnapshot();
+        assertEquals(3, display.windowCount());
+        assertEquals(3.0, display.avgTotalMs(), 1e-9);
+        assertEquals(2.0, display.avgStageMs().get(PortalPerfStats.Stage.TERRAIN_OPAQUE), 1e-9);
+    }
+
+    @Test
+    void ringBuffer_evictsOldestBeyondHistoryCap() {
+        PortalKey key = PortalKey.boti(UUID.fromString("22222222-2222-2222-2222-222222222222"));
+        PortalPerfStats.setIdentityForTest(key, PortalPerfStats.Outcome.RENDERED);
+
+        for (int i = 0; i < PortalPerfStats.HISTORY_FRAMES + 5; i++) {
+            EnumMap<PortalPerfStats.Stage, Double> stages = new EnumMap<>(PortalPerfStats.Stage.class);
+            stages.put(PortalPerfStats.Stage.OFF_MAIN_TOTAL, (double) i);
+            PortalPerfStats.pushSampleForTest(stages, i, 0);
+        }
+
+        assertEquals(PortalPerfStats.HISTORY_FRAMES, PortalPerfStats.historySize());
+        float[] totals = PortalPerfStats.historyTotalsMs();
+        assertEquals(5.0f, totals[0], 1e-4f);
+        assertEquals(PortalPerfStats.HISTORY_FRAMES + 4.0f, totals[totals.length - 1], 1e-4f);
+    }
+}

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
@@ -94,6 +94,7 @@ class PortalPerfStatsTest {
                 2.1,
                 60,
                 0.0,
+                0.0,
                 PortalPerfStats.Stage.TERRAIN_OPAQUE
         );
 

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
@@ -97,11 +97,14 @@ class PortalPerfStatsTest {
                 0.0,
                 PortalPerfStats.Stage.TERRAIN_OPAQUE,
                 2.0,
+                0.5,
+                0.25,
                 0.05,
                 0.3f,
                 8.0f,
                 1.0,
-                1.5
+                1.5,
+                new PortalPerfStats.ServerDiag(55.0f, 4.0f, 1.5f, 48, 3, 0, 1, 2, 1, 900)
         );
 
         List<String> lines = PortalPerfStats.formatLinesPure(snap);
@@ -113,10 +116,16 @@ class PortalPerfStatsTest {
         assertTrue(lines.stream().anyMatch(line -> line.contains("*opaque:")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("cull: 8/17")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("ent upd: 2.00")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("spawn/rm: 0.50/0.25")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("poseΔ: 0.0500")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("partial: 0.300")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("itemAge: 8.00")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("id/adv: 1.00/1.50")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("srv mspt: 55.0")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("sync: 4.00ms")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("upd: 48")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("spawn: 3")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("resync: 1")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("maxAvg: opaque")));
         assertTrue(lines.stream().noneMatch(line -> line.contains("bake this frame")));
     }

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
@@ -95,7 +95,13 @@ class PortalPerfStatsTest {
                 60,
                 0.0,
                 0.0,
-                PortalPerfStats.Stage.TERRAIN_OPAQUE
+                PortalPerfStats.Stage.TERRAIN_OPAQUE,
+                2.0,
+                0.05,
+                0.3f,
+                8.0f,
+                1.0,
+                1.5
         );
 
         List<String> lines = PortalPerfStats.formatLinesPure(snap);
@@ -106,6 +112,11 @@ class PortalPerfStatsTest {
         assertTrue(lines.get(1).contains("n=60"));
         assertTrue(lines.stream().anyMatch(line -> line.contains("*opaque:")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("cull: 8/17")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("ent upd: 2.00")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("poseΔ: 0.0500")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("partial: 0.300")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("itemAge: 8.00")));
+        assertTrue(lines.stream().anyMatch(line -> line.contains("id/adv: 1.00/1.50")));
         assertTrue(lines.stream().anyMatch(line -> line.contains("maxAvg: opaque")));
         assertTrue(lines.stream().noneMatch(line -> line.contains("bake this frame")));
     }

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalPerfStatsTest.java
@@ -8,6 +8,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.UUID;
 
+import com.adamkali.dwm.tardis.portal.PortalStreamKind;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -169,5 +171,48 @@ class PortalPerfStatsTest {
         float[] totals = PortalPerfStats.historyTotalsMs();
         assertEquals(5.0f, totals[0], 1e-4f);
         assertEquals(PortalPerfStats.HISTORY_FRAMES + 4.0f, totals[totals.length - 1], 1e-4f);
+    }
+
+    @Test
+    void noteLerpedPose_sameFrameReentry_keepsInterFrameBaseline() {
+        PortalPerfStats.setEnabledOverrideForTest(true);
+        UUID tardisId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        UUID entityId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+        // Frame 0 baseline at origin.
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.SOTO, tardisId, entityId, 0.0, 0.0, 0.0);
+        PortalPerfStats.publishFrame();
+        assertEquals(0.0, PortalPerfStats.maxPoseDeltaThisFrameForTest(), 1e-9);
+
+        // First sample this frame: inter-frame delta 10.
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.SOTO, tardisId, entityId, 10.0, 0.0, 0.0);
+        assertEquals(10.0, PortalPerfStats.maxPoseDeltaThisFrameForTest(), 1e-9);
+
+        // Same-frame re-entry with a different pose must not replace the baseline or shrink the max
+        // via a smaller intra-frame step (old GhostEntity.lastPublishedPose bug).
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.SOTO, tardisId, entityId, 12.0, 0.0, 0.0);
+        assertEquals(10.0, PortalPerfStats.maxPoseDeltaThisFrameForTest(), 1e-9);
+
+        PortalPerfStats.publishFrame();
+        // Next frame compares against the first sample (10), not the ignored re-entry (12).
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.SOTO, tardisId, entityId, 20.0, 0.0, 0.0);
+        assertEquals(10.0, PortalPerfStats.maxPoseDeltaThisFrameForTest(), 1e-9);
+    }
+
+    @Test
+    void noteLerpedPose_botiAndSoto_trackIndependently() {
+        PortalPerfStats.setEnabledOverrideForTest(true);
+        UUID tardisId = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        UUID entityId = UUID.fromString("11111111-2222-3333-4444-555555555555");
+
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.BOTI, tardisId, entityId, 0.0, 0.0, 0.0);
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.SOTO, tardisId, entityId, 0.0, 0.0, 0.0);
+        PortalPerfStats.publishFrame();
+
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.BOTI, tardisId, entityId, 5.0, 0.0, 0.0);
+        assertEquals(5.0, PortalPerfStats.maxPoseDeltaThisFrameForTest(), 1e-9);
+        // SOTO still has its own baseline at 0 — an 8-block move must be visible independently.
+        PortalPerfStats.noteLerpedPose(PortalStreamKind.SOTO, tardisId, entityId, 8.0, 0.0, 0.0);
+        assertEquals(8.0, PortalPerfStats.maxPoseDeltaThisFrameForTest(), 1e-9);
     }
 }

--- a/src/test/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCacheTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCacheTest.java
@@ -104,4 +104,14 @@ class SotoExteriorMeshCacheTest {
         assertEquals(TardisChameleonVariant.TT_CAPSULE, SotoExteriorMeshCache.getShellState(id).variant());
         assertTrue(SotoExteriorMeshCache.getShellState(id).isOpen());
     }
+
+    @Test
+    void shouldApplyPacketRotation_rejectsNull() {
+        assertFalse(SotoExteriorMeshCache.shouldApplyPacketRotation(null));
+    }
+
+    @Test
+    void resolvePartialTick_fallsBackWhenClientNull() {
+        assertEquals(0.37f, SotoExteriorMeshCache.resolvePartialTick(null, 0.37f), 1.0e-6f);
+    }
 }

--- a/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
@@ -9,9 +9,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -25,6 +28,7 @@ class SotoGhostExteriorTest {
     @AfterEach
     void tearDown() {
         SotoGhostExterior.invalidateAll();
+        SotoGhostMeshCache.invalidateAll();
     }
 
     @Test
@@ -62,6 +66,55 @@ class SotoGhostExteriorTest {
     }
 
     @Test
+    void chunkContentUnchanged_comparesBlocksAndBes() {
+        BlockPos pos = new BlockPos(1, 2, 3);
+        Map<BlockPos, BlockState> blocksA = Map.of(pos, Blocks.STONE.defaultBlockState());
+        Map<BlockPos, BlockState> blocksB = Map.of(pos, Blocks.STONE.defaultBlockState());
+        Map<BlockPos, BlockState> blocksC = Map.of(pos, Blocks.DIRT.defaultBlockState());
+        Map<BlockPos, CompoundTag> bes = Map.of(pos, new CompoundTag());
+
+        assertTrue(SotoGhostExterior.chunkContentUnchanged(blocksA, blocksB, null, null));
+        assertTrue(SotoGhostExterior.chunkContentUnchanged(null, Map.of(), null, Map.of()));
+        assertFalse(SotoGhostExterior.chunkContentUnchanged(blocksA, blocksC, null, null));
+        assertFalse(SotoGhostExterior.chunkContentUnchanged(blocksA, blocksB, null, bes));
+    }
+
+    @Test
+    void applyChunk_identicalWithDrawableMesh_skipsRebake() {
+        UUID id = UUID.randomUUID();
+        SyncPortalChunkS2CPayload payload = dirtChunk(id, 1, 2, Blocks.DIRT);
+
+        SotoGhostExterior.applyChunk(PortalStreamKind.SOTO, payload);
+        SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 1, 2);
+        assertTrue(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 1, 2));
+
+        // Second identical apply must keep drawable mesh (skip onChunkApplied / bake).
+        SotoGhostExterior.applyChunk(PortalStreamKind.SOTO, payload);
+        assertTrue(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 1, 2));
+        assertEquals(1, SotoGhostMeshCache.meshChunkCount(PortalStreamKind.SOTO, id));
+    }
+
+    @Test
+    void applyChunk_contentChange_replacesDrawableMesh() {
+        UUID id = UUID.randomUUID();
+        SyncPortalChunkS2CPayload dirt = dirtChunk(id, 1, 2, Blocks.DIRT);
+        SyncPortalChunkS2CPayload stone = dirtChunk(id, 1, 2, Blocks.STONE);
+
+        SotoGhostExterior.applyChunk(PortalStreamKind.SOTO, dirt);
+        SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 1, 2);
+        assertTrue(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 1, 2));
+
+        SotoGhostExterior.applyChunk(PortalStreamKind.SOTO, stone);
+        // Real bake in unit tests yields MARKER/empty — drawable test mesh must be replaced.
+        assertFalse(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 1, 2));
+        assertTrue(SotoGhostMeshCache.arePassBatchesDirtyForTest(PortalStreamKind.SOTO, id));
+
+        SotoGhostExterior ghost = SotoGhostExterior.get(PortalStreamKind.SOTO, id);
+        assertNotNull(ghost);
+        assertEquals(Blocks.STONE, ghost.getBlockState(new BlockPos(2, 1, 3)).getBlock());
+    }
+
+    @Test
     void removeEntity_andInvalidateClearState() {
         UUID id = UUID.randomUUID();
         SotoGhostExterior.getOrCreate(PortalStreamKind.SOTO, id);
@@ -70,5 +123,26 @@ class SotoGhostExteriorTest {
         assertFalse(SotoGhostExterior.hasEntities(PortalStreamKind.SOTO, id));
         SotoGhostExterior.invalidate(PortalStreamKind.SOTO, id);
         assertNull(SotoGhostExterior.get(PortalStreamKind.SOTO, id));
+    }
+
+    private static SyncPortalChunkS2CPayload dirtChunk(
+            UUID id,
+            int cx,
+            int cz,
+            net.minecraft.world.level.block.Block block
+    ) {
+        return new SyncPortalChunkS2CPayload(
+                PortalStreamKind.SOTO,
+                id,
+                cx,
+                cz,
+                100,
+                64,
+                200,
+                List.of(new SyncPortalChunkS2CPayload.BlockEntry(
+                        2, 1, 3, BotiRelativePosCodec.stateId(block.defaultBlockState())
+                )),
+                List.of()
+        );
     }
 }

--- a/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
@@ -125,6 +125,40 @@ class SotoGhostExteriorTest {
         assertNull(SotoGhostExterior.get(PortalStreamKind.SOTO, id));
     }
 
+    @Test
+    void entityInterp_advancesLerpedPoseBetweenPackets() {
+        UUID tardisId = UUID.randomUUID();
+        UUID entityUuid = UUID.randomUUID();
+        long t0 = 1_000L;
+
+        SotoGhostExterior.putInterpForTest(
+                PortalStreamKind.SOTO,
+                tardisId,
+                entityUuid,
+                new com.adamkali.dwm.render.boti.BotiEntityMotion.EntityInterpState(
+                        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        0.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                        t0
+                )
+        );
+        SotoGhostExterior.advanceInterpForTest(
+                PortalStreamKind.SOTO, tardisId, entityUuid,
+                10.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+                t0 + SotoGhostExterior.ENTITY_UPDATE_INTERVAL_MS
+        );
+
+        long receive = t0 + SotoGhostExterior.ENTITY_UPDATE_INTERVAL_MS;
+        var atReceive = SotoGhostExterior.sampleLerpedPosesForTest(PortalStreamKind.SOTO, tardisId, receive);
+        var atMid = SotoGhostExterior.sampleLerpedPosesForTest(
+                PortalStreamKind.SOTO, tardisId, receive + SotoGhostExterior.ENTITY_UPDATE_INTERVAL_MS / 2
+        );
+
+        assertEquals(1, atReceive.size());
+        assertEquals(1, atMid.size());
+        assertEquals(0.0, atReceive.getFirst().x(), 1.0e-4);
+        assertEquals(5.0, atMid.getFirst().x(), 1.0e-4);
+    }
+
     private static SyncPortalChunkS2CPayload dirtChunk(
             UUID id,
             int cx,

--- a/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
@@ -159,6 +159,45 @@ class SotoGhostExteriorTest {
         assertEquals(5.0, atMid.getFirst().x(), 1.0e-4);
     }
 
+    @Test
+    void usesIdentityInterp_onlyForItemEntities() {
+        assertFalse(SotoGhostExterior.usesIdentityInterp(null));
+    }
+
+    @Test
+    void animAgeInTicks_growsWithWallClock() {
+        long start = 1_000L;
+        assertEquals(0.0f, SotoGhostExterior.animAgeInTicks(start, start), 1.0e-4f);
+        assertEquals(2.0f, SotoGhostExterior.animAgeInTicks(start, start + 100L), 1.0e-4f);
+        assertEquals(20.0f, SotoGhostExterior.animAgeInTicks(start, start + 1_000L), 1.0e-4f);
+        assertTrue(SotoGhostExterior.animAgeInTicks(start, start + 50_000L) > 2.0f);
+    }
+
+    @Test
+    void nextInterpForUpdate_nullEntity_advances() {
+        var previous = com.adamkali.dwm.render.boti.BotiEntityMotion.EntityInterpState.identity(
+                0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1_000L
+        );
+        var next = SotoGhostExterior.nextInterpForUpdate(
+                null, previous, 10.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1_100L
+        );
+        assertEquals(0.0f, next.fromX(), 1.0e-4f);
+        assertEquals(10.0f, next.toX(), 1.0e-4f);
+        assertEquals(1_100L, next.receiveTimeMs());
+    }
+
+    @Test
+    void nextInterpForUpdate_nullPrevious_usesIdentity() {
+        var next = SotoGhostExterior.nextInterpForUpdate(
+                null, null, 3.0f, 1.0f, 2.0f, 45.0f, 10.0f, 2_000L
+        );
+        assertEquals(3.0f, next.fromX(), 1.0e-4f);
+        assertEquals(3.0f, next.toX(), 1.0e-4f);
+        assertEquals(1.0f, next.fromY(), 1.0e-4f);
+        assertEquals(1.0f, next.toY(), 1.0e-4f);
+        assertEquals(2_000L, next.receiveTimeMs());
+    }
+
     private static SyncPortalChunkS2CPayload dirtChunk(
             UUID id,
             int cx,

--- a/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostHitchCullTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostHitchCullTest.java
@@ -1,0 +1,92 @@
+package com.adamkali.dwm.render.soto.ghost;
+
+import org.joml.Matrix4f;
+import org.junit.jupiter.api.Test;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SotoGhostHitchCullTest {
+
+    @Test
+    void forwardHalfSpace_keepsChunkInFront() {
+        Vec3 eye = new Vec3(8.0, 64.0, 8.0);
+        Vec3 look = new Vec3(0.0, 0.0, 1.0);
+        assertTrue(SotoGhostHitchCull.isChunkVisibleInForwardHalfSpace(0, 2, eye, look));
+    }
+
+    @Test
+    void forwardHalfSpace_cullsChunkClearlyBehind() {
+        Vec3 eye = new Vec3(8.0, 64.0, 8.0);
+        Vec3 look = new Vec3(0.0, 0.0, 1.0);
+        assertFalse(SotoGhostHitchCull.isChunkVisibleInForwardHalfSpace(0, -3, eye, look));
+    }
+
+    @Test
+    void forwardHalfSpace_keepsNearPlaneChunkWithMargin() {
+        Vec3 eye = new Vec3(8.0, 64.0, 8.0);
+        Vec3 look = new Vec3(0.0, 0.0, 1.0);
+        // Chunk immediately behind the eye but within BEHIND_MARGIN should stay.
+        assertTrue(SotoGhostHitchCull.isChunkVisibleInForwardHalfSpace(0, 0, eye, look));
+    }
+
+    @Test
+    void viewFrustum_keepsChunkAlongLookAxis() {
+        Vec3 eye = new Vec3(8.0, 64.0, 8.0);
+        Vec3 look = new Vec3(0.0, 0.0, 1.0);
+        Matrix4f view = new Matrix4f().lookAt(
+                (float) eye.x, (float) eye.y, (float) eye.z,
+                (float) (eye.x + look.x), (float) (eye.y + look.y), (float) (eye.z + look.z),
+                0.0f, 1.0f, 0.0f
+        );
+        assertTrue(SotoGhostHitchCull.isChunkVisibleInView(0, 2, view));
+        assertTrue(SotoGhostHitchCull.isChunkVisibleToHitch(0, 2, BlockPos.ZERO, eye, look, view));
+    }
+
+    @Test
+    void viewFrustum_cullsChunkBehindCamera() {
+        Vec3 eye = new Vec3(8.0, 64.0, 8.0);
+        Vec3 look = new Vec3(0.0, 0.0, 1.0);
+        Matrix4f view = new Matrix4f().lookAt(
+                (float) eye.x, (float) eye.y, (float) eye.z,
+                (float) (eye.x + look.x), (float) (eye.y + look.y), (float) (eye.z + look.z),
+                0.0f, 1.0f, 0.0f
+        );
+        assertFalse(SotoGhostHitchCull.isChunkVisibleInView(0, -4, view));
+        assertFalse(SotoGhostHitchCull.isChunkVisibleToHitch(0, -4, BlockPos.ZERO, eye, look, view));
+    }
+
+    @Test
+    void nullHitchInputs_underCullKeepChunk() {
+        assertTrue(SotoGhostHitchCull.isChunkVisibleToHitch(1, 1, BlockPos.ZERO, null, null, null));
+        assertTrue(SotoGhostHitchCull.isChunkVisibleToHitch(
+                1, 1, BlockPos.ZERO, new Vec3(0, 0, 0), null, null
+        ));
+    }
+
+    @Test
+    void worldChunkKeys_convertViaFootprintOrigin_beforeCull() {
+        // Matches production: world section keys + relative hitch eye.
+        BlockPos origin = new BlockPos(-5, 63, -101);
+        Vec3 eye = new Vec3(5.5, 1.75, 6.5);
+        Vec3 look = new Vec3(0.0, 0.0, 1.0);
+        Matrix4f view = new Matrix4f().lookAt(
+                (float) eye.x, (float) eye.y, (float) eye.z,
+                (float) (eye.x + look.x), (float) (eye.y + look.y), (float) (eye.z + look.z),
+                0.0f, 1.0f, 0.0f
+        );
+
+        // World chunk (0, -6) → relative Z ≈ [5, 21], in front of the door hitch.
+        float[] aabb = SotoGhostHitchCull.relativeChunkAabb(0, -6, origin);
+        assertEquals(5.0f, aabb[0], 1e-4);
+        assertEquals(21.0f, aabb[1], 1e-4);
+        assertEquals(5.0f, aabb[2], 1e-4);
+        assertEquals(21.0f, aabb[3], 1e-4);
+
+        assertTrue(SotoGhostHitchCull.isChunkVisibleToHitch(0, -6, origin, eye, look, view));
+        // Without footprint conversion the same world key is far behind the relative camera.
+        assertFalse(SotoGhostHitchCull.isChunkVisibleToHitch(0, -6, BlockPos.ZERO, eye, look, view));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCacheTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCacheTest.java
@@ -88,6 +88,18 @@ class SotoGhostMeshCacheTest {
     }
 
     @Test
+    void hasDrawableChunk_trueOnlyForDrawableMesh() {
+        UUID id = UUID.randomUUID();
+        assertFalse(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 0, 0));
+
+        SotoGhostMeshCache.markChunkMarkerForTest(PortalStreamKind.SOTO, id, 0, 0);
+        assertFalse(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 0, 0));
+
+        SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 0, 0);
+        assertTrue(SotoGhostMeshCache.hasDrawableChunk(PortalStreamKind.SOTO, id, 0, 0));
+    }
+
+    @Test
     void invalidateAll_clearsAllMeshes() {
         UUID a = UUID.randomUUID();
         UUID b = UUID.randomUUID();

--- a/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCacheTest.java
+++ b/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCacheTest.java
@@ -42,6 +42,18 @@ class SotoGhostMeshCacheTest {
     }
 
     @Test
+    void markerOnly_doesNotCountAsDrawableMesh() {
+        UUID id = UUID.randomUUID();
+        SotoGhostMeshCache.markChunkMarkerForTest(PortalStreamKind.SOTO, id, 0, 0);
+        assertFalse(SotoGhostMeshCache.hasMeshes(PortalStreamKind.SOTO, id));
+        assertEquals(0, SotoGhostMeshCache.meshChunkCount(PortalStreamKind.SOTO, id));
+
+        SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 1, 1);
+        assertTrue(SotoGhostMeshCache.hasMeshes(PortalStreamKind.SOTO, id));
+        assertEquals(1, SotoGhostMeshCache.meshChunkCount(PortalStreamKind.SOTO, id));
+    }
+
+    @Test
     void unloadChunk_clearsMeshMarker() {
         UUID id = UUID.randomUUID();
         SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 3, 4);
@@ -84,5 +96,22 @@ class SotoGhostMeshCacheTest {
         SotoGhostMeshCache.invalidateAll();
         assertFalse(SotoGhostMeshCache.hasMeshes(PortalStreamKind.SOTO, a));
         assertFalse(SotoGhostMeshCache.hasMeshes(PortalStreamKind.BOTI, b));
+    }
+
+    @Test
+    void passBatches_markedDirtyOnMeshLifecycle() {
+        UUID id = UUID.randomUUID();
+        assertTrue(SotoGhostMeshCache.arePassBatchesDirtyForTest(PortalStreamKind.SOTO, id));
+
+        SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 0, 0);
+        assertTrue(SotoGhostMeshCache.arePassBatchesDirtyForTest(PortalStreamKind.SOTO, id));
+
+        SotoGhostMeshCache.onChunkUnloaded(PortalStreamKind.SOTO, id, 0, 0);
+        assertTrue(SotoGhostMeshCache.arePassBatchesDirtyForTest(PortalStreamKind.SOTO, id));
+
+        SotoGhostMeshCache.markChunkMeshForTest(PortalStreamKind.SOTO, id, 2, 2);
+        SotoGhostMeshCache.invalidate(PortalStreamKind.SOTO, id);
+        assertTrue(SotoGhostMeshCache.arePassBatchesDirtyForTest(PortalStreamKind.SOTO, id));
+        assertFalse(SotoGhostMeshCache.hasMeshes(PortalStreamKind.SOTO, id));
     }
 }

--- a/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamPerfStatsTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamPerfStatsTest.java
@@ -1,0 +1,68 @@
+package com.adamkali.dwm.tardis.portal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalStreamPerfStatsTest {
+    @BeforeEach
+    @AfterEach
+    void reset() {
+        PortalStreamPerfStats.resetForTests();
+    }
+
+    @Test
+    void nsToMs_convertsNanoseconds() {
+        assertEquals(2.5, PortalStreamPerfStats.nsToMs(2_500_000L), 1e-9);
+    }
+
+    @Test
+    void buildSnapshotPure_sumsFlushPhasesAndPreservesCounters() {
+        PortalStreamPerfStats.Snapshot snap = PortalStreamPerfStats.buildSnapshotPure(
+                62.5,
+                1_000_000L,
+                2_000_000L,
+                500_000L,
+                750_000L,
+                3,
+                40,
+                1,
+                12,
+                2,
+                12,
+                55,
+                1,
+                2,
+                1,
+                1200
+        );
+
+        assertTrue(snap.isPresent());
+        assertEquals(62.5, snap.msptMs(), 1e-9);
+        assertEquals(1.0, snap.flushMetaMs(), 1e-9);
+        assertEquals(2.0, snap.flushSotoMs(), 1e-9);
+        assertEquals(0.5, snap.flushBotiMs(), 1e-9);
+        assertEquals(0.75, snap.syncEntitiesMs(), 1e-9);
+        assertEquals(3.5, snap.syncFlushMs(), 1e-9);
+        assertEquals(3, snap.entitySpawns());
+        assertEquals(40, snap.entityUpdates());
+        assertEquals(1, snap.entityRemoves());
+        assertEquals(12, snap.chunkPackets());
+        assertEquals(2, snap.metaPackets());
+        assertEquals(12, snap.chunkSamples());
+        assertEquals(55, snap.entitiesScanned());
+        assertEquals(1, snap.fullResyncs());
+        assertEquals(2, snap.viewers());
+        assertEquals(1, snap.activeStreams());
+        assertEquals(1200, snap.serverTick());
+    }
+
+    @Test
+    void idleSnapshot_isNotPresent() {
+        assertFalse(PortalStreamPerfStats.Snapshot.IDLE.isPresent());
+    }
+}


### PR DESCRIPTION
## Why this matters

- SOTO/BOTI door portals were redrawing too much terrain and FBO work per frame, which hurt client FPS when doors were open.
- Operators and developers needed a reliable way to measure portal cost (client + server) without guessing from frame time alone.

## Proposed Implementation

- Batch ghost terrain draws and hitch-cull chunks so only visible portal terrain is submitted.
- Skip full-window FBO redraw when the hitch scene is clean / meshes are not ready.
- Add config-gated portal perf debug HUD, JSONL session log, and server→client perf diagnostics payload.
- Stabilize SOTO ghost item bob/spin across spawn churn; tighten portal request re-arming and stream handling.
- Cover new cull/cache/perf helpers with unit tests.

## Problems Encountered / Decisions Made

- BOTI content now waits on ghost meshes (same spirit as SOTO) before committing to a full FBO pass; blueprint fallback still covers the not-ready case.
- Perf overlay and JSONL logging are off by default behind `show_portal_perf_debug` so shipping builds stay quiet unless opted in.

Made with [Cursor](https://cursor.com)