### PR TITLE
fix(tardis): require door-column clearance when landing

### DIFF
--- a/docs/feature-tardis-block.md
+++ b/docs/feature-tardis-block.md
@@ -25,6 +25,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 - `TardisBlockEntity` stores `interiorEntrance` / `interiorGenerated`.
 - Exterior return coordinates stored on `TardisDataModel` for exit teleports.
 - Collision entry when the exterior door is open (`doorSwing >= 0.9`); exit via open interior doors.
+- Landing search requires replaceable space in the door-facing column (feet + head), not only the shell cell.
 - Single config toggle `enableDoorPortals` (default on) via Mod Menu / Cloth Config; legacy `enableBoti` / `enableSoto` migrate on load.
 - Interior doors use an invisible block + dedicated BER (`TardisClassicInteriorDoorModel`) with swing animation.
 - Materialisation lever travel: first pull dematerialises the exterior; after a short hold the TARDIS enters `IN_FLIGHT`; a second pull materialises at the destination resolved from the active `DestinationMode`.

--- a/src/main/java/com/adamkali/dwm/gametest/TardisLandingGameTests.java
+++ b/src/main/java/com/adamkali/dwm/gametest/TardisLandingGameTests.java
@@ -1,0 +1,62 @@
+package com.adamkali.dwm.gametest;
+
+import com.adamkali.dwm.tardis.logic.LandingSiteLogic;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.level.block.Blocks;
+
+public class TardisLandingGameTests {
+    private static final Direction DOOR_FACING = Direction.NORTH;
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void isValidLanding_acceptsOpenDoorColumn(GameTestHelper context) {
+        BlockPos shellRel = new BlockPos(2, 2, 2);
+        placeShellPad(context, shellRel);
+        // Door column (north of shell) left as air from empty structure.
+
+        BlockPos shellAbs = context.absolutePos(shellRel);
+        if (!LandingSiteLogic.isValidLanding(context.getLevel(), shellAbs, DOOR_FACING)) {
+            throw new AssertionError("Expected valid landing with replaceable door column");
+        }
+        context.succeed();
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void isValidLanding_rejectsBlockedDoorFeet(GameTestHelper context) {
+        BlockPos shellRel = new BlockPos(2, 2, 2);
+        placeShellPad(context, shellRel);
+        BlockPos doorRel = shellRel.relative(DOOR_FACING);
+        context.setBlock(doorRel, Blocks.STONE);
+
+        BlockPos shellAbs = context.absolutePos(shellRel);
+        if (LandingSiteLogic.isValidLanding(context.getLevel(), shellAbs, DOOR_FACING)) {
+            throw new AssertionError("Expected invalid landing when door feet are blocked");
+        }
+        context.succeed();
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void isValidLanding_rejectsBlockedDoorHead(GameTestHelper context) {
+        BlockPos shellRel = new BlockPos(2, 2, 2);
+        placeShellPad(context, shellRel);
+        BlockPos doorHeadRel = shellRel.relative(DOOR_FACING).above();
+        context.setBlock(doorHeadRel, Blocks.STONE);
+
+        BlockPos shellAbs = context.absolutePos(shellRel);
+        if (LandingSiteLogic.isValidLanding(context.getLevel(), shellAbs, DOOR_FACING)) {
+            throw new AssertionError("Expected invalid landing when door head is blocked");
+        }
+        context.succeed();
+    }
+
+    private static void placeShellPad(GameTestHelper context, BlockPos shellRel) {
+        context.setBlock(shellRel.below(), Blocks.STONE);
+        context.setBlock(shellRel, Blocks.AIR);
+        context.setBlock(shellRel.above(), Blocks.AIR);
+        BlockPos doorRel = shellRel.relative(DOOR_FACING);
+        context.setBlock(doorRel, Blocks.AIR);
+        context.setBlock(doorRel.above(), Blocks.AIR);
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/logic/LandingSiteLogic.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/LandingSiteLogic.java
@@ -51,9 +51,10 @@ public final class LandingSiteLogic {
             ServerLevel world,
             ResourceKey<Biome> biome,
             BlockPos searchOrigin,
-            int radius
+            int radius,
+            Direction doorFacing
     ) {
-        if (world == null || biome == null || searchOrigin == null) {
+        if (world == null || biome == null || searchOrigin == null || doorFacing == null) {
             return Optional.empty();
         }
         Pair<BlockPos, Holder<Biome>> located = world.findClosestBiome3d(
@@ -71,8 +72,8 @@ public final class LandingSiteLogic {
         world.getChunk(biomePos);
         int topY = world.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, biomePos.getX(), biomePos.getZ());
         BlockPos landing = new BlockPos(biomePos.getX(), topY, biomePos.getZ());
-        if (!isValidLanding(world, landing)) {
-            return findNearbyValidLanding(world, biomePos.getX(), biomePos.getZ());
+        if (!isValidLanding(world, landing, doorFacing)) {
+            return findNearbyValidLanding(world, biomePos.getX(), biomePos.getZ(), doorFacing);
         }
         return Optional.of(landing);
     }
@@ -81,21 +82,33 @@ public final class LandingSiteLogic {
      * Tries {@code target} if valid; otherwise spirals nearby for a valid shell cell.
      * Used for waypoint exact-coordinate landings.
      */
-    public static Optional<BlockPos> findLandingAtOrNearby(ServerLevel world, BlockPos target) {
-        if (world == null || target == null) {
+    public static Optional<BlockPos> findLandingAtOrNearby(
+            ServerLevel world,
+            BlockPos target,
+            Direction doorFacing
+    ) {
+        if (world == null || target == null || doorFacing == null) {
             return Optional.empty();
         }
         world.getChunk(target);
-        if (isValidLanding(world, target)) {
+        if (isValidLanding(world, target, doorFacing)) {
             return Optional.of(target);
         }
-        return findNearbyValidLanding(world, target.getX(), target.getZ());
+        return findNearbyValidLanding(world, target.getX(), target.getZ(), doorFacing);
     }
 
     /**
      * Tries a small spiral of columns around {@code originX/Z} after the chunk is loaded.
      */
-    public static Optional<BlockPos> findNearbyValidLanding(ServerLevel world, int originX, int originZ) {
+    public static Optional<BlockPos> findNearbyValidLanding(
+            ServerLevel world,
+            int originX,
+            int originZ,
+            Direction doorFacing
+    ) {
+        if (world == null || doorFacing == null) {
+            return Optional.empty();
+        }
         for (int radius = 1; radius <= 8; radius++) {
             for (int dx = -radius; dx <= radius; dx++) {
                 for (int dz = -radius; dz <= radius; dz++) {
@@ -107,7 +120,7 @@ public final class LandingSiteLogic {
                     world.getChunk(x >> 4, z >> 4);
                     int topY = world.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z);
                     BlockPos candidate = new BlockPos(x, topY, z);
-                    if (isValidLanding(world, candidate)) {
+                    if (isValidLanding(world, candidate, doorFacing)) {
                         return Optional.of(candidate);
                     }
                 }
@@ -119,16 +132,21 @@ public final class LandingSiteLogic {
     public static Optional<BlockPos> findLanding(
             ServerLevel world,
             ResourceKey<Biome> biome,
-            BlockPos searchOrigin
+            BlockPos searchOrigin,
+            Direction doorFacing
     ) {
-        return findLanding(world, biome, searchOrigin, DEFAULT_SEARCH_RADIUS);
+        return findLanding(world, biome, searchOrigin, DEFAULT_SEARCH_RADIUS, doorFacing);
     }
 
     /**
      * Surface landing near {@code searchOrigin} without biome filtering (untagged / modded dims).
      */
-    public static Optional<BlockPos> findSurfaceLanding(ServerLevel world, BlockPos searchOrigin) {
-        if (world == null || searchOrigin == null) {
+    public static Optional<BlockPos> findSurfaceLanding(
+            ServerLevel world,
+            BlockPos searchOrigin,
+            Direction doorFacing
+    ) {
+        if (world == null || searchOrigin == null || doorFacing == null) {
             return Optional.empty();
         }
         world.getChunk(searchOrigin);
@@ -138,17 +156,18 @@ public final class LandingSiteLogic {
                 searchOrigin.getZ()
         );
         BlockPos landing = new BlockPos(searchOrigin.getX(), topY, searchOrigin.getZ());
-        if (isValidLanding(world, landing)) {
+        if (isValidLanding(world, landing, doorFacing)) {
             return Optional.of(landing);
         }
-        return findNearbyValidLanding(world, searchOrigin.getX(), searchOrigin.getZ());
+        return findNearbyValidLanding(world, searchOrigin.getX(), searchOrigin.getZ(), doorFacing);
     }
 
     /**
-     * Shell needs a solid floor under {@code pos} and replaceable space at {@code pos} and above.
+     * Shell needs a solid floor under {@code pos}, replaceable space at {@code pos} and above,
+     * and replaceable space in the door-facing column (feet + head) used by exit teleport.
      */
-    public static boolean isValidLanding(LevelReader world, BlockPos pos) {
-        if (world == null || pos == null || world.isOutsideBuildHeight(pos)) {
+    public static boolean isValidLanding(LevelReader world, BlockPos pos, Direction doorFacing) {
+        if (world == null || pos == null || doorFacing == null || world.isOutsideBuildHeight(pos)) {
             return false;
         }
         BlockState below = world.getBlockState(pos.below());
@@ -157,6 +176,23 @@ public final class LandingSiteLogic {
         }
         BlockState feet = world.getBlockState(pos);
         BlockState head = world.getBlockState(pos.above());
-        return (feet.isAir() || feet.canBeReplaced()) && (head.isAir() || head.canBeReplaced());
+        if (!isReplaceable(feet) || !isReplaceable(head)) {
+            return false;
+        }
+
+        BlockPos door = pos.relative(doorFacing);
+        if (world.isOutsideBuildHeight(door) || world.isOutsideBuildHeight(door.above())) {
+            return false;
+        }
+        if (world instanceof ServerLevel serverLevel) {
+            serverLevel.getChunk(door);
+        }
+        BlockState doorFeet = world.getBlockState(door);
+        BlockState doorHead = world.getBlockState(door.above());
+        return isReplaceable(doorFeet) && isReplaceable(doorHead);
+    }
+
+    private static boolean isReplaceable(BlockState state) {
+        return state.isAir() || state.canBeReplaced();
     }
 }

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.TardisBlock;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.sound.DWMSounds;
+import com.adamkali.dwm.tardis.TardisExteriorFacing;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.DestinationMode;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
@@ -14,6 +15,7 @@ import com.adamkali.dwm.tardis.soto.SotoExteriorIndex;
 import com.adamkali.dwm.tardis.portal.PortalStreamSyncService;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
@@ -220,6 +222,10 @@ public final class TardisTravelService {
         ServerLevel destinationWorld;
         BlockPos landing;
         int facingRotation = snapshot.facingRotation();
+        if (mode == DestinationMode.WAYPOINT) {
+            facingRotation = model.travelDestinationRotation;
+        }
+        Direction doorFacing = TardisExteriorFacing.doorDirection(facingRotation);
 
         if (mode == DestinationMode.PLAYER) {
             Optional<ServerPlayer> target = PlayerLocatorLogic.resolve(server, model.travelTargetPlayerUuid);
@@ -230,7 +236,8 @@ public final class TardisTravelService {
             }
             ServerPlayer player = target.get();
             destinationWorld = (ServerLevel) player.level();
-            Optional<BlockPos> resolved = resolvePlayerLanding(destinationWorld, player.blockPosition());
+            Optional<BlockPos> resolved = resolvePlayerLanding(
+                    destinationWorld, player.blockPosition(), doorFacing);
             if (resolved.isEmpty()) {
                 lastMaterialiseFailureReason = FAIL_INVALID_LANDING;
                 return InteractionResult.FAIL;
@@ -243,15 +250,12 @@ public final class TardisTravelService {
                 return InteractionResult.FAIL;
             }
             BlockPos oldPos = new BlockPos(model.exteriorX, model.exteriorY, model.exteriorZ);
-            Optional<BlockPos> resolved = resolveLanding(destinationWorld, model, oldPos);
+            Optional<BlockPos> resolved = resolveLanding(destinationWorld, model, oldPos, doorFacing);
             if (resolved.isEmpty() && mode == DestinationMode.WAYPOINT) {
                 lastMaterialiseFailureReason = FAIL_INVALID_LANDING;
                 return InteractionResult.FAIL;
             }
             landing = resolved.orElse(oldPos);
-            if (mode == DestinationMode.WAYPOINT) {
-                facingRotation = model.travelDestinationRotation;
-            }
         }
 
         placeShell(destinationWorld, landing, snapshot, facingRotation);
@@ -476,25 +480,31 @@ public final class TardisTravelService {
     private static Optional<BlockPos> resolveLanding(
             ServerLevel world,
             TardisDataModel model,
-            BlockPos searchOrigin
+            BlockPos searchOrigin,
+            Direction doorFacing
     ) {
         DestinationMode mode = effectiveTravelMode(model);
         if (mode == DestinationMode.WAYPOINT) {
             return waypointTargetFromSnapshot(model)
-                    .flatMap(target -> LandingSiteLogic.findLandingAtOrNearby(world, target));
+                    .flatMap(target -> LandingSiteLogic.findLandingAtOrNearby(world, target, doorFacing));
         }
         Optional<ResourceKey<Biome>> biome = LandingSiteLogic.parseBiome(model.travelDestinationBiome);
         if (biome.isPresent()) {
-            Optional<BlockPos> landing = LandingSiteLogic.findLanding(world, biome.get(), searchOrigin);
+            Optional<BlockPos> landing = LandingSiteLogic.findLanding(
+                    world, biome.get(), searchOrigin, doorFacing);
             if (landing.isPresent()) {
                 return landing;
             }
         }
-        return LandingSiteLogic.findSurfaceLanding(world, searchOrigin);
+        return LandingSiteLogic.findSurfaceLanding(world, searchOrigin, doorFacing);
     }
 
-    private static Optional<BlockPos> resolvePlayerLanding(ServerLevel world, BlockPos playerPos) {
-        return LandingSiteLogic.findLandingAtOrNearby(world, playerPos);
+    private static Optional<BlockPos> resolvePlayerLanding(
+            ServerLevel world,
+            BlockPos playerPos,
+            Direction doorFacing
+    ) {
+        return LandingSiteLogic.findLandingAtOrNearby(world, playerPos, doorFacing);
     }
 
     /**

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,6 +29,7 @@
     "fabric-gametest": [
       "com.adamkali.dwm.gametest.TardisDoorGameTests",
       "com.adamkali.dwm.gametest.TardisInteriorGameTests",
+      "com.adamkali.dwm.gametest.TardisLandingGameTests",
       "com.adamkali.dwm.gametest.AshWoodFamilyGameTests",
       "com.adamkali.dwm.gametest.DarkAshWoodFamilyGameTests",
       "com.adamkali.dwm.gametest.CardinalWoodFamilyGameTests",


### PR DESCRIPTION
## Why this matters

- Landing only validated the shell cell, so a blocked door-facing column (common on badlands terraces) dumped exiting players into solid blocks and bounced them back inside.

## Proposed Implementation

- `LandingSiteLogic.isValidLanding` also requires replaceable space in the door-facing column at feet and head.
- Door facing is resolved before search (including waypoint rotation) and threaded through every landing helper.
- GameTests cover open, blocked-feet, and blocked-head door columns.

## Problems Encountered / Decisions Made

- Reused the existing air-or-`canBeReplaced` rule instead of a stricter isAir-only check, so plants and other replaceable blocks still count as valid exit space.

Made with [Cursor](https://cursor.com)