### PR TITLE
feat(ci): publish release JARs to CurseForge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,23 @@ jobs:
               encoding="utf-8",
           )
 
+          curseforge_data = {
+              "changelog": changelog_body,
+              "changelogType": "markdown",
+              "displayName": version,
+              "gameVersionNames": [minecraft_version, "Fabric", "Client", "Server"],
+              "releaseType": "release",
+              "relations": {
+                  "projects": [
+                      {"slug": "fabric-api", "type": "requiredDependency"},
+                  ],
+              },
+          }
+          Path("curseforge-data.json").write_text(
+              json.dumps(curseforge_data, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
               out.write(f"minecraft_version={minecraft_version}\n")
               out.write(f"release_version={version}\n")
@@ -174,6 +191,33 @@ jobs:
           echo "modrinth_version_url=${VERSION_URL}" >> "$GITHUB_OUTPUT"
           echo "Published Modrinth version: ${VERSION_URL}"
 
+      - name: Publish to CurseForge
+        id: curseforge
+        env:
+          CURSEFORGE_TOKEN: ${{ secrets.CURSEFORGE_TOKEN }}
+          MOD_VERSION: ${{ steps.version.outputs.mod_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${CURSEFORGE_TOKEN:-}" ]; then
+            echo "CURSEFORGE_TOKEN secret is not set" >&2
+            exit 1
+          fi
+          JAR="build/libs/dwm-${MOD_VERSION}.jar"
+          if [ ! -f "$JAR" ]; then
+            echo "Missing build artifact: $JAR" >&2
+            exit 1
+          fi
+          RESPONSE=$(curl -fsS -X POST "https://minecraft.curseforge.com/api/projects/355957/upload-file" \
+            -H "X-Api-Token: ${CURSEFORGE_TOKEN}" \
+            -F "metadata=<curseforge-data.json" \
+            -F "file=@${JAR}")
+          echo "$RESPONSE" | tee curseforge-response.json
+          FILE_ID=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$RESPONSE")
+          FILE_URL="https://www.curseforge.com/minecraft/mc-mods/the-doctor-who-mod/files/${FILE_ID}"
+          echo "curseforge_file_id=${FILE_ID}" >> "$GITHUB_OUTPUT"
+          echo "curseforge_file_url=${FILE_URL}" >> "$GITHUB_OUTPUT"
+          echo "Published CurseForge file: ${FILE_URL}"
+
       - name: Announce on Discord
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
@@ -181,6 +225,7 @@ jobs:
           MINECRAFT_VERSION: ${{ steps.notes.outputs.minecraft_version }}
           SUMMARY: ${{ steps.notes.outputs.summary }}
           MODRINTH_VERSION_URL: ${{ steps.modrinth.outputs.modrinth_version_url }}
+          CURSEFORGE_FILE_URL: ${{ steps.curseforge.outputs.curseforge_file_url }}
         run: |
           set -euo pipefail
           if [ -z "${DISCORD_WEBHOOK_URL:-}" ]; then
@@ -195,6 +240,7 @@ jobs:
           minecraft_version = os.environ["MINECRAFT_VERSION"]
           summary = os.environ["SUMMARY"].strip()
           modrinth_url = os.environ["MODRINTH_VERSION_URL"]
+          curseforge_url = os.environ["CURSEFORGE_FILE_URL"]
           if not summary:
               raise SystemExit("Release summary is empty")
 
@@ -209,6 +255,10 @@ jobs:
                       "url": modrinth_url,
                       "description": summary,
                       "color": 1911355,
+                      "fields": [
+                          {"name": "Modrinth", "value": f"[Download]({modrinth_url})", "inline": True},
+                          {"name": "CurseForge", "value": f"[Download]({curseforge_url})", "inline": True},
+                      ],
                       "footer": {"text": f"Fabric · Minecraft {minecraft_version}"},
                       "thumbnail": {
                           "url": "https://cdn.modrinth.com/data/CY3ponKT/03858742885c853698edb03ac20d719e38575f8e_96.webp"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,8 +83,8 @@
 - CI runs on GitHub Actions ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)); CircleCI is retired.
 - Releases are intentional git tags `v{minecraft}-{mod}` — see [docs/release-policy.md](docs/release-policy.md).
 - Do not bump `mod_version` or `version.json` promos except when cutting a release; use `./gradlew syncVersionJson` at cut time.
-- The release workflow publishes the GitHub Release, Modrinth version, and Discord `#releases` announcement from `version.json` (`summary` + changelog lists). Requires `MODRINTH_TOKEN` and `DISCORD_WEBHOOK_URL` secrets.
-- Modrinth project listing fields live in `metadata/` (`modrinth.json` + `modrinth-body.md`); sync them with the manual **Sync Modrinth Project** workflow (`PROJECT_WRITE` on `MODRINTH_TOKEN`).
+- The release workflow publishes the GitHub Release, Modrinth version, CurseForge file, and Discord `#releases` announcement from `version.json` (`summary` + changelog lists). Requires `MODRINTH_TOKEN`, `CURSEFORGE_TOKEN`, and `DISCORD_WEBHOOK_URL` secrets.
+- Modrinth project listing fields live in `metadata/` (`modrinth.json` + `modrinth-body.md`); sync them with the manual **Sync Modrinth Project** workflow (`PROJECT_WRITE` on `MODRINTH_TOKEN`). CurseForge listing (description/categories) has no official PATCH API — edit by hand on CurseForge.
 
 ## Change Scope & Safety
 - Keep unrelated files untouched.

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ This folder documents implemented player-facing features for The Doctor Who Mod 
 - [Differentiation Strategy](./differentiation-strategy.md)
 
 ## Releases
-- [Release Policy](./release-policy.md) (cadence, versioning, Modrinth + Discord checklist, CI)
+- [Release Policy](./release-policy.md) (cadence, versioning, Modrinth + CurseForge + Discord checklist, CI)
 
 ## Scope Notes
 - These docs describe behavior currently implemented in this repository.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -2,7 +2,7 @@
 
 See also: [Docs Index](./index.md), [Branding Guidelines](./branding-guidelines.md)
 
-This document defines when we cut a release, what “enough” means, how versions are named, and the distribution checklist (GitHub, Modrinth, Discord).
+This document defines when we cut a release, what “enough” means, how versions are named, and the distribution checklist (GitHub, Modrinth, CurseForge, Discord).
 
 ## Cadence (hybrid)
 
@@ -24,14 +24,14 @@ Example: `v1.21.4-1.2.0` → Minecraft `1.21.4`, mod `1.2.0`.
 | --- | --- |
 | `minecraft_version` | [`gradle.properties`](../gradle.properties) |
 | `mod_version` | [`gradle.properties`](../gradle.properties) (SemVer piece only) |
-| Player changelog + promos | [`version.json`](../version.json) (source for GitHub Release notes, Modrinth changelog, and Discord) |
+| Player changelog + promos | [`version.json`](../version.json) (source for GitHub Release notes, Modrinth/CurseForge changelogs, and Discord) |
 
 Each per-version entry under `version.json` → `{minecraft_version}` → `{mod_version}` includes:
 
 | Field | Purpose |
 | --- | --- |
-| `summary` | Short player-facing blurb (required, non-blank). Leads the GitHub Release body and Modrinth changelog; used as the Discord embed description. |
-| `added` / `changed` / `removed` | Detailed changelog bullets for GitHub and Modrinth. |
+| `summary` | Short player-facing blurb (required, non-blank). Leads the GitHub Release body and Modrinth/CurseForge changelogs; used as the Discord embed description. |
+| `added` / `changed` / `removed` | Detailed changelog bullets for GitHub, Modrinth, and CurseForge. |
 
 ### SemVer meaning for `mod_version`
 
@@ -78,9 +78,9 @@ Ship a patch immediately for:
 
 ## Source of truth
 
-- **[`version.json`](../version.json)** is the only release-notes and promo channel (GitHub Release body, Modrinth changelog, Discord summary).
+- **[`version.json`](../version.json)** is the only release-notes and promo channel (GitHub Release body, Modrinth/CurseForge changelogs, Discord summary).
 - Do not maintain a separate changelog file; dual ledgers drift.
-- **[`metadata/`](../metadata/)** is the source of truth for the Modrinth **project listing** (`description`, long-form `body`, categories, Discord URL). Edit those files, then run the **Sync Modrinth Project** workflow; listing updates are manual and are not part of the tag Release workflow.
+- **[`metadata/`](../metadata/)** is the source of truth for the Modrinth **project listing** (`description`, long-form `body`, categories, Discord URL). Edit those files, then run the **Sync Modrinth Project** workflow; listing updates are manual and are not part of the tag Release workflow. CurseForge has no official listing PATCH API — update the CurseForge project page description and categories by hand when they change.
 
 ## Distribution checklist
 
@@ -91,13 +91,15 @@ Ship a patch immediately for:
 5. Confirm the **Release** GitHub Actions workflow succeeds:
    - GitHub Release with remapped JAR (+ sources JAR) and notes from `version.json` (`summary` + detailed lists)
    - Modrinth version upload (Fabric + Minecraft from the tag; Fabric API dependency)
-   - Discord `#releases` embed (summary + Modrinth link)
+   - CurseForge file upload (project `355957`; Fabric + Client/Server + Minecraft from the tag; Fabric API required dependency)
+   - Discord `#releases` embed (summary + Modrinth and CurseForge links)
 
 ### Required GitHub Actions secrets
 
 | Secret | Purpose |
 | --- | --- |
 | `MODRINTH_TOKEN` | Modrinth personal access token with `VERSION_CREATE` (Release) and `PROJECT_WRITE` (Sync Modrinth Project) |
+| `CURSEFORGE_TOKEN` | CurseForge authors upload token ([API Tokens](https://console.curseforge.com/#/api-tokens)); account must be able to upload to project `355957` |
 | `DISCORD_WEBHOOK_URL` | Incoming webhook for Discord `#releases` |
 
 ## CI overview
@@ -106,7 +108,7 @@ Ship a patch immediately for:
 | --- | --- | --- |
 | [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) | `pull_request`, push to `main` | `./gradlew build` (compile + unit tests + version sync check) |
 | [`.github/workflows/create-release-tag.yml`](../.github/workflows/create-release-tag.yml) | `workflow_dispatch` | Create and push `v*` tag from `version.json` `promos.latest` if missing; then dispatch Release |
-| [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*`, or `workflow_dispatch` | Build; publish GitHub Release, Modrinth version, and Discord announcement from `version.json` |
-| [`.github/workflows/sync-modrinth-project.yml`](../.github/workflows/sync-modrinth-project.yml) | `workflow_dispatch` | PATCH Modrinth project listing from [`metadata/`](../metadata/) |
+| [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*`, or `workflow_dispatch` | Build; publish GitHub Release, Modrinth version, CurseForge file, and Discord announcement from `version.json` |
+| [`.github/workflows/sync-modrinth-project.yml`](../.github/workflows/sync-modrinth-project.yml) | `workflow_dispatch` | PATCH Modrinth project listing from [`metadata/`](../metadata/) (Modrinth only; CurseForge listing stays manual) |
 
 CircleCI is retired; do not add draft GitHub releases on every `main` merge.


### PR DESCRIPTION
## Why this matters

- Tag releases already go to GitHub, Modrinth, and Discord; CurseForge players were left on a manual upload path for [the-doctor-who-mod](https://www.curseforge.com/minecraft/mc-mods/the-doctor-who-mod).

## Proposed Implementation

- Extend `.github/workflows/release.yml` to write `curseforge-data.json` from the same `version.json` changelog used for Modrinth, then upload the remapped JAR to CurseForge project `355957` with Fabric + Client/Server + Minecraft via `gameVersionNames`.
- Include CurseForge and Modrinth download links on the Discord release embed.
- Document `CURSEFORGE_TOKEN` and the CurseForge distribution step in `docs/release-policy.md` and `AGENTS.md`; listing sync remains Modrinth-only (no CurseForge PATCH API).

## Problems Encountered / Decisions Made

- CurseForge has no official project-listing PATCH API, so `sync-modrinth-project.yml` was left unchanged and CurseForge description/categories stay manual.
- Requires a new GitHub Actions secret `CURSEFORGE_TOKEN` before the next tag, or Release will fail closed.


Made with [Cursor](https://cursor.com)