### PR TITLE
feat(gallifrey): decorate biomes with Gallifrey plants

### DIFF
--- a/docs/feature-gallifrey-dimension.md
+++ b/docs/feature-gallifrey-dimension.md
@@ -8,13 +8,14 @@ Give TARDIS travel a unique destination world built from Gallifrey builder block
 ## Player Outcomes
 - Reach Gallifrey via the First Doctor console planet locator (or debug `/execute in dwm:gallifrey run tp @s ~ 128 ~`).
 - Cycle Gallifrey biomes on the biome dial before materialising.
-- Explore terrain surfaced with Gallifrey grass, dirt, sand, orange sand, and stone, with Ash / Dark Ash / Cardinal trees in forested biomes.
+- Explore terrain surfaced with Gallifrey grass, dirt, sand, orange sand, and stone, with Ash / Dark Ash / Cardinal trees in forested biomes and Gallifrey decorative plants in the wild.
 
 ## Implemented Now
 - Dimension `dwm:gallifrey` (noise overworld-style generator, overworld-like dimension type).
 - Biomes: `dwm:gallifrey_plains`, `dwm:gallifrey_forest`, `dwm:gallifrey_wastes`, `dwm:gallifrey_badlands` (tag `#dwm:is_gallifrey`).
 - Surface rules use Gallifrey grass / dirt / coarse dirt / sand / sandstone / orange sand / orange sandstone / stone (wastes stay Gallifrey-sand; badlands use orange sand).
 - Placed tree features for Ash (sparse plains + denser forest), Dark Ash, and Cardinal in forest.
+- Plant decoration: Flower of Remembrance / Moonlight Bloom mix on plains (denser) and forest (sparser); Saccharine Cane columns on wastes and badlands (no water requirement).
 - Archive colormap and cloud textures imported under `assets/dwm/textures/` for future tinting/sky work; grass block uses pre-colored deep-red textures.
 - TARDIS `BiomeSelectorLogic` maps `dwm:gallifrey` to `#dwm:is_gallifrey`.
 
@@ -25,11 +26,10 @@ Give TARDIS travel a unique destination world built from Gallifrey builder block
 4. Debug without a TARDIS: `/execute in dwm:gallifrey run tp @s ~ 128 ~`.
 
 ## Known Constraints
-- No Gallifrey decorative plants yet (see building feature follow-ups).
 - Cloud texture is imported but not wired through custom dimension effects; sky/fog use biome colors and overworld dimension effects.
 - Villages and Gallifrey mobs are follow-on tickets (DWM-041–043).
 
 ## Future Opportunities (Planned)
 - Wire colormaps for tinted grass/foliage if decorative plants need biome tinting.
 - Custom dimension effects for Gallifrey clouds/sky.
-- Plants, villages, and fauna.
+- Villages and fauna.

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_badlands.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_badlands.json
@@ -75,7 +75,8 @@
       "minecraft:spring_lava"
     ],
     [
-      "minecraft:glow_lichen"
+      "minecraft:glow_lichen",
+      "dwm:saccharine_cane_badlands"
     ],
     [
       "minecraft:freeze_top_layer"

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_forest.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_forest.json
@@ -78,7 +78,8 @@
       "minecraft:glow_lichen",
       "dwm:ash_forest",
       "dwm:dark_ash_forest",
-      "dwm:cardinal_forest"
+      "dwm:cardinal_forest",
+      "dwm:gallifrey_flowers_forest"
     ],
     [
       "minecraft:freeze_top_layer"

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_plains.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_plains.json
@@ -76,7 +76,8 @@
     ],
     [
       "minecraft:glow_lichen",
-      "dwm:ash_plains"
+      "dwm:ash_plains",
+      "dwm:gallifrey_flowers_plains"
     ],
     [
       "minecraft:freeze_top_layer"

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_wastes.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_wastes.json
@@ -75,7 +75,8 @@
       "minecraft:spring_lava"
     ],
     [
-      "minecraft:glow_lichen"
+      "minecraft:glow_lichen",
+      "dwm:saccharine_cane_wastes"
     ],
     [
       "minecraft:freeze_top_layer"

--- a/src/main/generated/data/dwm/worldgen/configured_feature/gallifrey_flowers.json
+++ b/src/main/generated/data/dwm/worldgen/configured_feature/gallifrey_flowers.json
@@ -1,0 +1,22 @@
+{
+  "type": "minecraft:simple_block",
+  "config": {
+    "to_place": {
+      "type": "minecraft:weighted_state_provider",
+      "entries": [
+        {
+          "data": {
+            "Name": "dwm:flower_of_remembrance"
+          },
+          "weight": 2
+        },
+        {
+          "data": {
+            "Name": "dwm:moonlight_bloom"
+          },
+          "weight": 1
+        }
+      ]
+    }
+  }
+}

--- a/src/main/generated/data/dwm/worldgen/configured_feature/saccharine_cane.json
+++ b/src/main/generated/data/dwm/worldgen/configured_feature/saccharine_cane.json
@@ -1,0 +1,26 @@
+{
+  "type": "minecraft:block_column",
+  "config": {
+    "allowed_placement": {
+      "type": "minecraft:matching_block_tag",
+      "tag": "minecraft:air"
+    },
+    "direction": "up",
+    "layers": [
+      {
+        "height": {
+          "type": "minecraft:biased_to_bottom",
+          "max_inclusive": 4,
+          "min_inclusive": 2
+        },
+        "provider": {
+          "type": "minecraft:simple_state_provider",
+          "state": {
+            "Name": "dwm:saccharine_cane"
+          }
+        }
+      }
+    ],
+    "prioritize_tip": false
+  }
+}

--- a/src/main/generated/data/dwm/worldgen/placed_feature/gallifrey_flowers_forest.json
+++ b/src/main/generated/data/dwm/worldgen/placed_feature/gallifrey_flowers_forest.json
@@ -1,0 +1,45 @@
+{
+  "feature": "dwm:gallifrey_flowers",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 32
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:biome"
+    },
+    {
+      "type": "minecraft:count",
+      "count": 64
+    },
+    {
+      "type": "minecraft:random_offset",
+      "xz_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 7,
+        "min": -7,
+        "plateau": 0
+      },
+      "y_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 3,
+        "min": -3,
+        "plateau": 0
+      }
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:matching_block_tag",
+        "tag": "minecraft:air"
+      }
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/worldgen/placed_feature/gallifrey_flowers_plains.json
+++ b/src/main/generated/data/dwm/worldgen/placed_feature/gallifrey_flowers_plains.json
@@ -1,0 +1,45 @@
+{
+  "feature": "dwm:gallifrey_flowers",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 16
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:biome"
+    },
+    {
+      "type": "minecraft:count",
+      "count": 64
+    },
+    {
+      "type": "minecraft:random_offset",
+      "xz_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 7,
+        "min": -7,
+        "plateau": 0
+      },
+      "y_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 3,
+        "min": -3,
+        "plateau": 0
+      }
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:matching_block_tag",
+        "tag": "minecraft:air"
+      }
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/worldgen/placed_feature/saccharine_cane_badlands.json
+++ b/src/main/generated/data/dwm/worldgen/placed_feature/saccharine_cane_badlands.json
@@ -1,0 +1,73 @@
+{
+  "feature": "dwm:saccharine_cane",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 5
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:biome"
+    },
+    {
+      "type": "minecraft:count",
+      "count": 20
+    },
+    {
+      "type": "minecraft:random_offset",
+      "xz_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 4,
+        "min": -4,
+        "plateau": 0
+      },
+      "y_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 0,
+        "min": 0,
+        "plateau": 0
+      }
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:all_of",
+        "predicates": [
+          {
+            "type": "minecraft:matching_block_tag",
+            "tag": "minecraft:air"
+          },
+          {
+            "type": "minecraft:any_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "minecraft:dirt"
+              },
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "minecraft:sand"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/generated/data/dwm/worldgen/placed_feature/saccharine_cane_wastes.json
+++ b/src/main/generated/data/dwm/worldgen/placed_feature/saccharine_cane_wastes.json
@@ -1,0 +1,73 @@
+{
+  "feature": "dwm:saccharine_cane",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 4
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "MOTION_BLOCKING"
+    },
+    {
+      "type": "minecraft:biome"
+    },
+    {
+      "type": "minecraft:count",
+      "count": 20
+    },
+    {
+      "type": "minecraft:random_offset",
+      "xz_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 4,
+        "min": -4,
+        "plateau": 0
+      },
+      "y_spread": {
+        "type": "minecraft:trapezoid",
+        "max": 0,
+        "min": 0,
+        "plateau": 0
+      }
+    },
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:all_of",
+        "predicates": [
+          {
+            "type": "minecraft:matching_block_tag",
+            "tag": "minecraft:air"
+          },
+          {
+            "type": "minecraft:any_of",
+            "predicates": [
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "minecraft:dirt"
+              },
+              {
+                "type": "minecraft:matching_block_tag",
+                "offset": [
+                  0,
+                  -1,
+                  0
+                ],
+                "tag": "minecraft:sand"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/java/com/adamkali/dwm/world/DWMBiomeBootstrap.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMBiomeBootstrap.java
@@ -50,6 +50,7 @@ public final class DWMBiomeBootstrap {
         BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder(features, carvers);
         addBasicFeatures(generation);
         generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.ASH_PLAINS);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.GALLIFREY_FLOWERS_PLAINS);
 
         return buildBiome(true, 0.9F, 0.3F, spawns, generation);
     }
@@ -66,6 +67,7 @@ public final class DWMBiomeBootstrap {
         generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.ASH_FOREST);
         generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.DARK_ASH_FOREST);
         generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.CARDINAL_FOREST);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.GALLIFREY_FLOWERS_FOREST);
 
         return buildBiome(true, 0.85F, 0.6F, spawns, generation);
     }
@@ -79,6 +81,7 @@ public final class DWMBiomeBootstrap {
 
         BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder(features, carvers);
         addBasicFeatures(generation);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.SACCHARINE_CANE_WASTES);
 
         return buildBiome(false, 1.2F, 0.0F, spawns, generation);
     }
@@ -92,6 +95,7 @@ public final class DWMBiomeBootstrap {
 
         BiomeGenerationSettings.Builder generation = new BiomeGenerationSettings.Builder(features, carvers);
         addBasicFeatures(generation);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.SACCHARINE_CANE_BADLANDS);
 
         return buildBiome(false, 1.2F, 0.0F, spawns, generation);
     }

--- a/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatureBootstrap.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatureBootstrap.java
@@ -4,15 +4,20 @@ import com.adamkali.dwm.block.DWMBlocks;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.util.random.WeightedList;
+import net.minecraft.util.valueproviders.BiasedToBottomInt;
 import net.minecraft.util.valueproviders.ConstantInt;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
+import net.minecraft.world.level.levelgen.feature.configurations.BlockColumnConfiguration;
+import net.minecraft.world.level.levelgen.feature.configurations.SimpleBlockConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.levelgen.feature.featuresize.TwoLayersFeatureSize;
 import net.minecraft.world.level.levelgen.feature.foliageplacers.BlobFoliagePlacer;
 import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
+import net.minecraft.world.level.levelgen.feature.stateproviders.WeightedStateProvider;
 import net.minecraft.world.level.levelgen.feature.trunkplacers.StraightTrunkPlacer;
 
 public final class DWMConfiguredFeatureBootstrap {
@@ -23,6 +28,28 @@ public final class DWMConfiguredFeatureBootstrap {
         registerTree(registerable, DWMConfiguredFeatures.ASH, DWMBlocks.ASH_LOG, DWMBlocks.ASH_LEAVES);
         registerTree(registerable, DWMConfiguredFeatures.DARK_ASH, DWMBlocks.DARK_ASH_LOG, DWMBlocks.DARK_ASH_LEAVES);
         registerTree(registerable, DWMConfiguredFeatures.CARDINAL, DWMBlocks.CARDINAL_LOG, DWMBlocks.CARDINAL_LEAVES);
+
+        WeightedList.Builder<BlockState> flowers = WeightedList.builder();
+        flowers.add(DWMBlocks.FLOWER_OF_REMEMBRANCE.defaultBlockState(), 2);
+        flowers.add(DWMBlocks.MOONLIGHT_BLOOM.defaultBlockState(), 1);
+        registerable.register(
+                DWMConfiguredFeatures.GALLIFREY_FLOWERS,
+                new ConfiguredFeature<>(
+                        Feature.SIMPLE_BLOCK,
+                        new SimpleBlockConfiguration(new WeightedStateProvider(flowers))
+                )
+        );
+
+        registerable.register(
+                DWMConfiguredFeatures.SACCHARINE_CANE,
+                new ConfiguredFeature<>(
+                        Feature.BLOCK_COLUMN,
+                        BlockColumnConfiguration.simple(
+                                BiasedToBottomInt.of(2, 4),
+                                BlockStateProvider.simple(DWMBlocks.SACCHARINE_CANE)
+                        )
+                )
+        );
     }
 
     private static void registerTree(

--- a/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatures.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatures.java
@@ -2,25 +2,23 @@ package com.adamkali.dwm.world;
 
 import com.adamkali.dwm.DWMReference;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 
 public final class DWMConfiguredFeatures {
-    public static final ResourceKey<ConfiguredFeature<?, ?>> ASH = ResourceKey.create(
-            Registries.CONFIGURED_FEATURE,
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "ash")
-    );
+    public static final ResourceKey<ConfiguredFeature<?, ?>> ASH = key("ash");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> DARK_ASH = key("dark_ash");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> CARDINAL = key("cardinal");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> GALLIFREY_FLOWERS = key("gallifrey_flowers");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> SACCHARINE_CANE = key("saccharine_cane");
 
-    public static final ResourceKey<ConfiguredFeature<?, ?>> DARK_ASH = ResourceKey.create(
-            Registries.CONFIGURED_FEATURE,
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "dark_ash")
-    );
-
-    public static final ResourceKey<ConfiguredFeature<?, ?>> CARDINAL = ResourceKey.create(
-            Registries.CONFIGURED_FEATURE,
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "cardinal")
-    );
+    private static ResourceKey<ConfiguredFeature<?, ?>> key(String path) {
+        return ResourceKey.create(
+                Registries.CONFIGURED_FEATURE,
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path)
+        );
+    }
 
     private DWMConfiguredFeatures() {
     }

--- a/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.world;
 
 import com.adamkali.dwm.block.DWMBlocks;
+import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderGetter;
 import net.minecraft.core.registries.Registries;
@@ -8,8 +9,17 @@ import net.minecraft.data.worldgen.BootstrapContext;
 import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.data.worldgen.placement.VegetationPlacements;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+import net.minecraft.world.level.levelgen.placement.BiomeFilter;
+import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
+import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.placement.PlacementModifier;
+import net.minecraft.world.level.levelgen.placement.RandomOffsetPlacement;
+import net.minecraft.world.level.levelgen.placement.RarityFilter;
 
 public final class DWMPlacedFeatureBootstrap {
     private DWMPlacedFeatureBootstrap() {
@@ -47,13 +57,21 @@ public final class DWMPlacedFeatureBootstrap {
                 PlacementUtils.countExtra(2, 0.1F, 1),
                 DWMBlocks.CARDINAL_SAPLING
         );
+
+        Holder<ConfiguredFeature<?, ?>> flowers = configured.getOrThrow(DWMConfiguredFeatures.GALLIFREY_FLOWERS);
+        registerFlowerPatch(registerable, DWMPlacedFeatures.GALLIFREY_FLOWERS_PLAINS, flowers, 16);
+        registerFlowerPatch(registerable, DWMPlacedFeatures.GALLIFREY_FLOWERS_FOREST, flowers, 32);
+
+        Holder<ConfiguredFeature<?, ?>> cane = configured.getOrThrow(DWMConfiguredFeatures.SACCHARINE_CANE);
+        registerSaccharineCane(registerable, DWMPlacedFeatures.SACCHARINE_CANE_WASTES, cane, 4);
+        registerSaccharineCane(registerable, DWMPlacedFeatures.SACCHARINE_CANE_BADLANDS, cane, 5);
     }
 
     private static void registerTree(
             BootstrapContext<PlacedFeature> registerable,
             ResourceKey<PlacedFeature> key,
             Holder<ConfiguredFeature<?, ?>> feature,
-            net.minecraft.world.level.levelgen.placement.PlacementModifier countModifier,
+            PlacementModifier countModifier,
             net.minecraft.world.level.block.Block sapling
     ) {
         PlacementUtils.register(
@@ -61,6 +79,54 @@ public final class DWMPlacedFeatureBootstrap {
                 key,
                 feature,
                 VegetationPlacements.treePlacement(countModifier, sapling)
+        );
+    }
+
+    private static void registerFlowerPatch(
+            BootstrapContext<PlacedFeature> registerable,
+            ResourceKey<PlacedFeature> key,
+            Holder<ConfiguredFeature<?, ?>> feature,
+            int rarity
+    ) {
+        PlacementUtils.register(
+                registerable,
+                key,
+                feature,
+                RarityFilter.onAverageOnceEvery(rarity),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP,
+                BiomeFilter.biome(),
+                CountPlacement.of(64),
+                RandomOffsetPlacement.ofTriangle(7, 3),
+                BlockPredicateFilter.forPredicate(BlockPredicate.ONLY_IN_AIR_PREDICATE)
+        );
+    }
+
+    private static void registerSaccharineCane(
+            BootstrapContext<PlacedFeature> registerable,
+            ResourceKey<PlacedFeature> key,
+            Holder<ConfiguredFeature<?, ?>> feature,
+            int rarity
+    ) {
+        PlacementUtils.register(
+                registerable,
+                key,
+                feature,
+                RarityFilter.onAverageOnceEvery(rarity),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP,
+                BiomeFilter.biome(),
+                CountPlacement.of(20),
+                RandomOffsetPlacement.ofTriangle(4, 0),
+                BlockPredicateFilter.forPredicate(
+                        BlockPredicate.allOf(
+                                BlockPredicate.ONLY_IN_AIR_PREDICATE,
+                                BlockPredicate.anyOf(
+                                        BlockPredicate.matchesTag(Direction.DOWN.getUnitVec3i(), BlockTags.DIRT),
+                                        BlockPredicate.matchesTag(Direction.DOWN.getUnitVec3i(), BlockTags.SAND)
+                                )
+                        )
+                )
         );
     }
 }

--- a/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
@@ -2,8 +2,8 @@ package com.adamkali.dwm.world;
 
 import com.adamkali.dwm.DWMReference;
 import net.minecraft.core.registries.Registries;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
 public final class DWMPlacedFeatures {
@@ -11,6 +11,10 @@ public final class DWMPlacedFeatures {
     public static final ResourceKey<PlacedFeature> ASH_FOREST = key("ash_forest");
     public static final ResourceKey<PlacedFeature> DARK_ASH_FOREST = key("dark_ash_forest");
     public static final ResourceKey<PlacedFeature> CARDINAL_FOREST = key("cardinal_forest");
+    public static final ResourceKey<PlacedFeature> GALLIFREY_FLOWERS_PLAINS = key("gallifrey_flowers_plains");
+    public static final ResourceKey<PlacedFeature> GALLIFREY_FLOWERS_FOREST = key("gallifrey_flowers_forest");
+    public static final ResourceKey<PlacedFeature> SACCHARINE_CANE_WASTES = key("saccharine_cane_wastes");
+    public static final ResourceKey<PlacedFeature> SACCHARINE_CANE_BADLANDS = key("saccharine_cane_badlands");
 
     private static ResourceKey<PlacedFeature> key(String path) {
         return ResourceKey.create(Registries.PLACED_FEATURE, Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path));


### PR DESCRIPTION
## Why this matters

- Gallifrey biomes currently have trees and terrain, but no wild flora, so the destination world still reads as empty once players leave the TARDIS.

## Proposed Implementation

- Stacks on #95. Places a Flower of Remembrance / Moonlight Bloom mix on plains (denser) and forest (sparser), and Saccharine Cane columns on wastes and badlands (no water requirement).
- Wired through configured/placed features and biome bootstrap; datagen emits the worldgen JSON.

## Problems Encountered / Decisions Made

- Cane uses `BLOCK_COLUMN` with dirt/sand block predicates instead of vanilla sugar-cane water adjacency, matching the decorative block behaviour from #95.

Made with [Cursor](https://cursor.com)