### PR TITLE
DWM-020: Place Azbantium ore in Gallifrey biomes

### DIFF
--- a/docs/feature-azbantium.md
+++ b/docs/feature-azbantium.md
@@ -1,12 +1,12 @@
 # Feature: Azbantium
 
-See also: [Docs Index](./index.md), [Gallifrey Building](./feature-gallifrey-building.md)
+See also: [Docs Index](./index.md), [Gallifrey Dimension](./feature-gallifrey-dimension.md), [Gallifrey Building](./feature-gallifrey-building.md)
 
 ## Product Intent
 Give Gallifrey a signature hard gem material—minable only with diamond-tier tools—so survival progression on the destination world has a clear late-game craft and equip goal.
 
 ## Player Outcomes
-- Obtain Azbantium Ore (creative / follow-up worldgen) and process it into gems.
+- Find Azbantium Ore in Gallifrey stone underground.
 - Smelt or blast silk-touched ore into Azbantium gems.
 - Craft diamond-tier tools, armor, and storage blocks from Azbantium.
 
@@ -15,16 +15,17 @@ Give Gallifrey a signature hard gem material—minable only with diamond-tier to
 - **Item:** Azbantium gem
 - **Tools:** sword, pickaxe, axe, shovel, hoe (diamond-equivalent stats)
 - **Armor:** helmet, chestplate, leggings, boots (diamond-equivalent defense/toughness)
+- Ore generation in all Gallifrey biomes replacing `#dwm:gallifrey_ore_replaceables` (Gallifrey stone)
 - Localization, recipes, tags, and loot via datagen
 
 ## How It Works In-Game
-1. Mine Azbantium Ore with a diamond (or better) pickaxe.
-2. Ore drops Azbantium gems (Fortune applies; Silk Touch keeps the ore for smelting/blasting).
+1. Travel to Gallifrey and mine underground stone with a diamond (or better) pickaxe.
+2. Azbantium Ore drops Azbantium gems (Fortune applies; Silk Touch keeps the ore for smelting/blasting).
 3. Craft a storage block from 9 gems, or craft tools and armor with sticks / shaped patterns like diamond gear.
 
 ## Known Constraints
 - No nugget or raw-ore form (archive coverage is gem + tools/armor only).
-- Natural ore placement in Gallifrey is a follow-up (see Gallifrey Dimension docs once shipped).
+- Vanilla overworld ores still run on Gallifrey biomes but replace `minecraft:stone`, so they do not appear in Gallifrey stone fill.
 
 ## Future Opportunities (Planned)
 - Dark Star Alloy (DWM-021) as a higher netherite-style tier reusing this material pattern.

--- a/docs/feature-gallifrey-building.md
+++ b/docs/feature-gallifrey-building.md
@@ -21,7 +21,7 @@ Give players a Gallifrey-themed terrain and builder kit—stone, woods, and Cita
   - Shared set: planks, logs/wood (and stripped), leaves, sapling (and potted), stairs, slab, fence, fence gate, button, pressure plate, signs, hanging signs, boats
   - Doors and trapdoors on all three families; Cardinal uses a three-block-tall door
 - **Citadel family:** Citadel wall, panel, tile, and glass
-- **Azbantium:** storage block and gem craft set (tools/armor — see [Azbantium](./feature-azbantium.md))
+- **Azbantium:** storage block (ore is mined in Gallifrey; gem crafts tools/armor — see [Azbantium](./feature-azbantium.md))
 - **Gallifrey decorative plants**
   - Cross flowers: Flower of Remembrance, Moonlight Bloom (with potted variants)
   - Saccharine Cane (stackable decorative cane; no water requirement, no growth)

--- a/docs/feature-gallifrey-dimension.md
+++ b/docs/feature-gallifrey-dimension.md
@@ -16,6 +16,7 @@ Give TARDIS travel a unique destination world built from Gallifrey builder block
 - Surface rules use Gallifrey grass / dirt / coarse dirt / sand / sandstone / orange sand / orange sandstone / stone (wastes stay Gallifrey-sand; badlands use orange sand).
 - Placed tree features for Ash (sparse plains + denser forest), Dark Ash, and Cardinal in forest.
 - Plant decoration: Flower of Remembrance / Moonlight Bloom mix on plains (denser) and forest (sparser); Saccharine Cane columns on wastes and badlands (no water requirement).
+- Azbantium ore veins in Gallifrey stone (all biomes; diamond pickaxe required — see [Azbantium](./feature-azbantium.md)).
 - Archive colormap and cloud textures imported under `assets/dwm/textures/` for future tinting/sky work; grass block uses pre-colored deep-red textures.
 - TARDIS `BiomeSelectorLogic` maps `dwm:gallifrey` to `#dwm:is_gallifrey`.
 

--- a/src/main/generated/data/dwm/tags/block/gallifrey_ore_replaceables.json
+++ b/src/main/generated/data/dwm/tags/block/gallifrey_ore_replaceables.json
@@ -1,0 +1,5 @@
+{
+  "values": [
+    "dwm:gallifrey_stone"
+  ]
+}

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_badlands.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_badlands.json
@@ -65,6 +65,7 @@
       "minecraft:ore_lapis_buried",
       "minecraft:ore_copper",
       "minecraft:underwater_magma",
+      "dwm:azbantium_ore",
       "minecraft:disk_sand",
       "minecraft:disk_clay",
       "minecraft:disk_gravel"

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_forest.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_forest.json
@@ -65,6 +65,7 @@
       "minecraft:ore_lapis_buried",
       "minecraft:ore_copper",
       "minecraft:underwater_magma",
+      "dwm:azbantium_ore",
       "minecraft:disk_sand",
       "minecraft:disk_clay",
       "minecraft:disk_gravel"

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_plains.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_plains.json
@@ -65,6 +65,7 @@
       "minecraft:ore_lapis_buried",
       "minecraft:ore_copper",
       "minecraft:underwater_magma",
+      "dwm:azbantium_ore",
       "minecraft:disk_sand",
       "minecraft:disk_clay",
       "minecraft:disk_gravel"

--- a/src/main/generated/data/dwm/worldgen/biome/gallifrey_wastes.json
+++ b/src/main/generated/data/dwm/worldgen/biome/gallifrey_wastes.json
@@ -65,6 +65,7 @@
       "minecraft:ore_lapis_buried",
       "minecraft:ore_copper",
       "minecraft:underwater_magma",
+      "dwm:azbantium_ore",
       "minecraft:disk_sand",
       "minecraft:disk_clay",
       "minecraft:disk_gravel"

--- a/src/main/generated/data/dwm/worldgen/configured_feature/azbantium_ore.json
+++ b/src/main/generated/data/dwm/worldgen/configured_feature/azbantium_ore.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:ore",
+  "config": {
+    "discard_chance_on_air_exposure": 0.5,
+    "size": 9,
+    "targets": [
+      {
+        "state": {
+          "Name": "dwm:azbantium_ore"
+        },
+        "target": {
+          "predicate_type": "minecraft:tag_match",
+          "tag": "dwm:gallifrey_ore_replaceables"
+        }
+      }
+    ]
+  }
+}

--- a/src/main/generated/data/dwm/worldgen/placed_feature/azbantium_ore.json
+++ b/src/main/generated/data/dwm/worldgen/placed_feature/azbantium_ore.json
@@ -1,0 +1,27 @@
+{
+  "feature": "dwm:azbantium_ore",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": 8
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:trapezoid",
+        "max_inclusive": {
+          "absolute": 32
+        },
+        "min_inclusive": {
+          "absolute": -64
+        }
+      }
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/src/main/java/com/adamkali/dwm/block/DWMBlockTags.java
+++ b/src/main/java/com/adamkali/dwm/block/DWMBlockTags.java
@@ -27,6 +27,12 @@ public final class DWMBlockTags {
             Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "gallifrey_plants")
     );
 
+    /** Gallifrey stone only — ore replacement target (excludes dirt/sand/grass family members). */
+    public static final TagKey<Block> GALLIFREY_ORE_REPLACEABLES = TagKey.create(
+            Registries.BLOCK,
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "gallifrey_ore_replaceables")
+    );
+
     public static final TagKey<Block> AZBANTIUM_ORES = TagKey.create(
             Registries.BLOCK,
             Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "azbantium_ores")

--- a/src/main/java/com/adamkali/dwm/datagen/DWMBlockTagProvider.java
+++ b/src/main/java/com/adamkali/dwm/datagen/DWMBlockTagProvider.java
@@ -51,6 +51,9 @@ public class DWMBlockTagProvider extends FabricTagsProvider.BlockTagsProvider {
             gallifreyPlantsTag.add(key(plant));
         }
 
+        builder(DWMBlockTags.GALLIFREY_ORE_REPLACEABLES)
+                .add(key(DWMBlocks.GALLIFREY_STONE));
+
         builder(DWMBlockTags.AZBANTIUM_ORES)
                 .add(key(DWMBlocks.AZBANTIUM_ORE));
 

--- a/src/main/java/com/adamkali/dwm/world/DWMBiomeBootstrap.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMBiomeBootstrap.java
@@ -106,6 +106,7 @@ public final class DWMBiomeBootstrap {
         BiomeDefaultFeatures.addDefaultMonsterRoom(generation);
         BiomeDefaultFeatures.addDefaultUndergroundVariety(generation);
         BiomeDefaultFeatures.addDefaultOres(generation);
+        generation.addFeature(GenerationStep.Decoration.UNDERGROUND_ORES, DWMPlacedFeatures.AZBANTIUM_ORE);
         BiomeDefaultFeatures.addDefaultSoftDisks(generation);
         BiomeDefaultFeatures.addDefaultSprings(generation);
         BiomeDefaultFeatures.addSurfaceFreezing(generation);

--- a/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatureBootstrap.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatureBootstrap.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.world;
 
+import com.adamkali.dwm.block.DWMBlockTags;
 import com.adamkali.dwm.block.DWMBlocks;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.BootstrapContext;
@@ -12,6 +13,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.BlockColumnConfiguration;
+import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.SimpleBlockConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.levelgen.feature.featuresize.TwoLayersFeatureSize;
@@ -19,6 +21,7 @@ import net.minecraft.world.level.levelgen.feature.foliageplacers.BlobFoliagePlac
 import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
 import net.minecraft.world.level.levelgen.feature.stateproviders.WeightedStateProvider;
 import net.minecraft.world.level.levelgen.feature.trunkplacers.StraightTrunkPlacer;
+import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
 
 public final class DWMConfiguredFeatureBootstrap {
     private DWMConfiguredFeatureBootstrap() {
@@ -47,6 +50,19 @@ public final class DWMConfiguredFeatureBootstrap {
                         BlockColumnConfiguration.simple(
                                 BiasedToBottomInt.of(2, 4),
                                 BlockStateProvider.simple(DWMBlocks.SACCHARINE_CANE)
+                        )
+                )
+        );
+
+        registerable.register(
+                DWMConfiguredFeatures.AZBANTIUM_ORE,
+                new ConfiguredFeature<>(
+                        Feature.ORE,
+                        new OreConfiguration(
+                                new TagMatchTest(DWMBlockTags.GALLIFREY_ORE_REPLACEABLES),
+                                DWMBlocks.AZBANTIUM_ORE.defaultBlockState(),
+                                9,
+                                0.5F
                         )
                 )
         );

--- a/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatures.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatures.java
@@ -12,6 +12,7 @@ public final class DWMConfiguredFeatures {
     public static final ResourceKey<ConfiguredFeature<?, ?>> CARDINAL = key("cardinal");
     public static final ResourceKey<ConfiguredFeature<?, ?>> GALLIFREY_FLOWERS = key("gallifrey_flowers");
     public static final ResourceKey<ConfiguredFeature<?, ?>> SACCHARINE_CANE = key("saccharine_cane");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> AZBANTIUM_ORE = key("azbantium_ore");
 
     private static ResourceKey<ConfiguredFeature<?, ?>> key(String path) {
         return ResourceKey.create(

--- a/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
@@ -10,11 +10,13 @@ import net.minecraft.data.worldgen.placement.PlacementUtils;
 import net.minecraft.data.worldgen.placement.VegetationPlacements;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.tags.BlockTags;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
 import net.minecraft.world.level.levelgen.blockpredicates.BlockPredicate;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.placement.BiomeFilter;
 import net.minecraft.world.level.levelgen.placement.BlockPredicateFilter;
 import net.minecraft.world.level.levelgen.placement.CountPlacement;
+import net.minecraft.world.level.levelgen.placement.HeightRangePlacement;
 import net.minecraft.world.level.levelgen.placement.InSquarePlacement;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 import net.minecraft.world.level.levelgen.placement.PlacementModifier;
@@ -65,6 +67,16 @@ public final class DWMPlacedFeatureBootstrap {
         Holder<ConfiguredFeature<?, ?>> cane = configured.getOrThrow(DWMConfiguredFeatures.SACCHARINE_CANE);
         registerSaccharineCane(registerable, DWMPlacedFeatures.SACCHARINE_CANE_WASTES, cane, 4);
         registerSaccharineCane(registerable, DWMPlacedFeatures.SACCHARINE_CANE_BADLANDS, cane, 5);
+
+        PlacementUtils.register(
+                registerable,
+                DWMPlacedFeatures.AZBANTIUM_ORE,
+                configured.getOrThrow(DWMConfiguredFeatures.AZBANTIUM_ORE),
+                CountPlacement.of(8),
+                InSquarePlacement.spread(),
+                HeightRangePlacement.triangle(VerticalAnchor.absolute(-64), VerticalAnchor.absolute(32)),
+                BiomeFilter.biome()
+        );
     }
 
     private static void registerTree(

--- a/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
+++ b/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
@@ -15,6 +15,7 @@ public final class DWMPlacedFeatures {
     public static final ResourceKey<PlacedFeature> GALLIFREY_FLOWERS_FOREST = key("gallifrey_flowers_forest");
     public static final ResourceKey<PlacedFeature> SACCHARINE_CANE_WASTES = key("saccharine_cane_wastes");
     public static final ResourceKey<PlacedFeature> SACCHARINE_CANE_BADLANDS = key("saccharine_cane_badlands");
+    public static final ResourceKey<PlacedFeature> AZBANTIUM_ORE = key("azbantium_ore");
 
     private static ResourceKey<PlacedFeature> key(String path) {
         return ResourceKey.create(Registries.PLACED_FEATURE, Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path));


### PR DESCRIPTION
## Why this matters

- Completes Azbantium survival progression by generating ore in Gallifrey stone so players can find the material in-world, not only via creative.

## Proposed Implementation

- Add `#dwm:gallifrey_ore_replaceables` (Gallifrey stone), configured/placed Azbantium ore features, and wire them into all four Gallifrey biomes.
- Document worldgen on Azbantium and Gallifrey Dimension feature pages.
- Stacked on `feat/azbantium-set` (merge that PR first).

## Problems Encountered / Decisions Made

- None


Made with [Cursor](https://cursor.com)