### PR TITLE
chore(version): prepare v26.2-1.3.0 release notes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version=26.2
 loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 # Mod Properties
-mod_version=1.2.0
+mod_version=1.3.0
 maven_group=com.adamkali.dwm
 archives_base_name=dwm
 # Dependencies

--- a/metadata/modrinth-body.md
+++ b/metadata/modrinth-body.md
@@ -7,21 +7,30 @@ Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — 
 - Search the overworld for a TARDIS, open the doors, and walk into a First Doctor–style console room
 - Look through open exterior doors for a bigger-on-the-inside preview of the console room
 - Look back out through open interior doors to see the world outside
-- Set a destination at the First Doctor console with the biome and planet dials
+- Set a destination at the First Doctor console with biome/planet dials, saved waypoints, or an online player
 - Pull the materialisation lever to dematerialise, fly, and land — with travel and ambient sound
-- Cycle the chameleon circuit among First–Seventh Doctor boxes and the TT Capsule
+- Use the chameleon circuit dial to pick First–Seventh Doctor boxes or the TT Capsule, with a spinning shell hologram
 
 ## Explore Gallifrey
 
 - Travel to the Gallifrey destination dimension from the console planet locator
-- Choose among Gallifrey Plains, Forest, and Wastes before you materialise
-- Explore orange-tinted terrain surfaced with Gallifrey stone, sand, and themed woods
+- Choose among Gallifrey Plains, Forest, Wastes, and Badlands before you materialise
+- Explore deep-red grass, orange sand and badlands, Gallifrey stone, and themed woods
+- Find Flower of Remembrance and Moonlight Bloom on plains and forest, and Saccharine Cane on wastes and badlands
+- Mine Azbantium veins and Gallifrey-textured coal, iron, gold, and diamond ores
 
 ## Build
 
 - Ash, Dark Ash, and Cardinal wood families (logs through doors, boats, and more)
-- Gallifrey stone, sandstone, dirt, and Citadel wall / panel / tile / glass
+- Gallifrey stone, sandstone, dirt, grass, and Citadel wall / panel / tile / glass
+- Orange sand and orange sandstone (stairs, slabs, walls, cut, chiseled, and smooth)
+- Flower of Remembrance, Moonlight Bloom, and Saccharine Cane
 - Chronoplasm powder, colored TARDIS walls, and roundels for console-room builds
+
+## Azbantium
+
+- Mine Azbantium ore in Gallifrey stone and smelt it into gems
+- Craft diamond-tier Azbantium tools and armor
 
 ## Sonic Screwdrivers
 

--- a/version.json
+++ b/version.json
@@ -1,5 +1,56 @@
 {
   "26.2": {
+    "1.3.0": {
+      "summary": "Gallifrey survival depth — Azbantium gear, Gallifrey ores and plants, orange sand and badlands, plus console waypoints, player locator, and chameleon hologram.",
+      "added": [
+        "Block: Azbantium Ore",
+        "Block: Azbantium Block",
+        "Item: Azbantium",
+        "Item: Azbantium Sword",
+        "Item: Azbantium Pickaxe",
+        "Item: Azbantium Axe",
+        "Item: Azbantium Shovel",
+        "Item: Azbantium Hoe",
+        "Item: Azbantium Helmet",
+        "Item: Azbantium Chestplate",
+        "Item: Azbantium Leggings",
+        "Item: Azbantium Boots",
+        "Block: Gallifrey Coal Ore",
+        "Block: Gallifrey Iron Ore",
+        "Block: Gallifrey Gold Ore",
+        "Block: Gallifrey Diamond Ore",
+        "Block: Gallifrey Grass",
+        "Block: Orange Sand",
+        "Block: Orange Sandstone",
+        "Block: Orange Sandstone Stairs",
+        "Block: Orange Sandstone Slab",
+        "Block: Orange Sandstone Wall",
+        "Block: Cut Orange Sandstone",
+        "Block: Cut Orange Sandstone Slab",
+        "Block: Chiseled Orange Sandstone",
+        "Block: Smooth Orange Sandstone",
+        "Block: Smooth Orange Sandstone Stairs",
+        "Block: Smooth Orange Sandstone Slab",
+        "Block: Flower of Remembrance",
+        "Block: Potted Flower of Remembrance",
+        "Block: Moonlight Bloom",
+        "Block: Potted Moonlight Bloom",
+        "Block: Saccharine Cane",
+        "Biome: Gallifrey Badlands",
+        "Misc: Azbantium ore generation in Gallifrey stone",
+        "Misc: Gallifrey-textured coal, iron, gold, and diamond ores in Gallifrey stone (drop vanilla items)",
+        "Misc: Gallifrey biome decoration (flowers on plains and forest; saccharine cane on wastes and badlands)",
+        "Misc: First Doctor console waypoint selector (save, rename, delete, select)",
+        "Misc: First Doctor console player locator (set an online player as destination)",
+        "Misc: First Doctor console chameleon circuit dial with animated shell hologram"
+      ],
+      "changed": [
+        "Misc: TARDIS landing requires door-column clearance (feet + head), not only the shell cell",
+        "Misc: Avoid crash when remote clients lack a local TARDIS save directory",
+        "Misc: Massive performance improvements to Bigger-on-the-Inside / Smaller-on-the-Outside door portal previews"
+      ],
+      "removed": []
+    },
     "1.2.0": {
       "summary": "Port to Minecraft 26.2 (Java 25) — Fabric Loader 0.19 / Loom 1.17, with BOTI/SOTO rendering re-hooked for the new client APIs.",
       "added": [],
@@ -235,7 +286,7 @@
     }
   },
   "promos": {
-    "latest": "26.2-1.2.0",
-    "recommended": "26.2-1.2.0"
+    "latest": "26.2-1.3.0",
+    "recommended": "26.2-1.3.0"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Cuts player-facing notes for `v26.2-1.3.0` so GitHub, Modrinth, and Discord can publish from `version.json`.
- Brings the Modrinth listing body in line with Gallifrey content and console travel shipped since `v26.2-1.2.0`.

## Proposed Implementation

- Bump `mod_version` to `1.3.0` and set `promos.latest` / `promos.recommended` to `26.2-1.3.0`.
- Fill `version.json` `26.2` / `1.3.0` with summary plus added/changed lists (Azbantium, Gallifrey ores/plants/badlands, console waypoints/player locator/chameleon hologram, landing and remote-client fixes, BOTI/SOTO performance).
- Update `metadata/modrinth-body.md` for the shipped 1.3.0 survival pitch. Listing publish still needs the separate **Sync Modrinth Project** workflow after merge; this PR does not create the git tag.

## Problems Encountered / Decisions Made

- `./gradlew syncVersionJson` rewrote existing changelog formatting (escaped em dashes, expanded empty arrays); the 1.3.0 entry and promos were written by hand to avoid that churn.
- `metadata/modrinth.json` was left unchanged: short description and categories still fit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c712003f-2361-4d05-a7e8-e074a6a3bc3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c712003f-2361-4d05-a7e8-e074a6a3bc3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

