### PR TITLE
fix(tardis): correct chameleon portal aperture depth

### DIFF
--- a/src/main/java/com/adamkali/dwm/tardis/data/model/TardisChameleonVariant.java
+++ b/src/main/java/com/adamkali/dwm/tardis/data/model/TardisChameleonVariant.java
@@ -7,11 +7,11 @@ public enum TardisChameleonVariant {
     TT_CAPSULE(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "tt_capsule"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -7.5f)),
     FIRST_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "first_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -5.5f)),
     SECOND_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "second_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -6.0f)),
-    THIRD_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "third_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -6.0f)),
-    FOURTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "fourth_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -6.0f)),
-    FIFTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "fifth_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -6.0f)),
-    SIXTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sixth_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -6.0f)),
-    SEVENTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "seventh_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -6.0f));
+    THIRD_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "third_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -5.5f)),
+    FOURTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "fourth_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -5.5f)),
+    FIFTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "fifth_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -5.5f)),
+    SIXTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sixth_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -5.5f)),
+    SEVENTH_DOCTOR_BOX(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "seventh_doctor_box"), PortalAperture.ofPixels(-5.0f, 5.0f, 1.0f, 23.0f, -5.5f));
 
     private final Identifier id;
     private final PortalAperture aperture;

--- a/src/test/java/com/adamkali/dwm/tardis/data/model/PortalApertureTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/data/model/PortalApertureTest.java
@@ -30,12 +30,23 @@ class PortalApertureTest {
     }
 
     @Test
-    void firstAndFifthDoctor_doorPlanesDiffer() {
+    void laterDoctorBoxes_shareFirstDoctorDoorPlane() {
         float firstZ = TardisChameleonVariant.FIRST_DOCTOR_BOX.getAperture().z();
-        float fifthZ = TardisChameleonVariant.FIFTH_DOCTOR_BOX.getAperture().z();
-
         assertEquals(-5.5f / 16.0f, firstZ, EPSILON);
-        assertEquals(-6.0f / 16.0f, fifthZ, EPSILON);
+        assertEquals(firstZ, TardisChameleonVariant.THIRD_DOCTOR_BOX.getAperture().z(), EPSILON);
+        assertEquals(firstZ, TardisChameleonVariant.FOURTH_DOCTOR_BOX.getAperture().z(), EPSILON);
+        assertEquals(firstZ, TardisChameleonVariant.FIFTH_DOCTOR_BOX.getAperture().z(), EPSILON);
+        assertEquals(firstZ, TardisChameleonVariant.SIXTH_DOCTOR_BOX.getAperture().z(), EPSILON);
+        assertEquals(firstZ, TardisChameleonVariant.SEVENTH_DOCTOR_BOX.getAperture().z(), EPSILON);
+    }
+
+    @Test
+    void secondDoctor_doorPlaneDiffersFromFirst() {
+        float firstZ = TardisChameleonVariant.FIRST_DOCTOR_BOX.getAperture().z();
+        float secondZ = TardisChameleonVariant.SECOND_DOCTOR_BOX.getAperture().z();
+
+        assertEquals(-6.0f / 16.0f, secondZ, EPSILON);
+        assertTrue(Math.abs(firstZ - secondZ) > EPSILON);
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Exterior BOTI portals for Third–Seventh Doctor chameleon variants sat on the wrong door plane, so the interior preview did not line up with those boxes.

## Proposed Implementation

- Update `PortalAperture` Z offsets in `TardisChameleonVariant` from `-6.0f` to `-5.5f` for Third through Seventh Doctor boxes, matching the First Doctor box door plane. Second Doctor box stays at `-6.0f`.

## Problems Encountered / Decisions Made

- None

Made with [Cursor](https://cursor.com)