### PR TITLE
feat(console): pick controls via interaction entities

### DIFF
--- a/src/client/java/com/adamkali/dwm/client/DWMEntityRenderers.java
+++ b/src/client/java/com/adamkali/dwm/client/DWMEntityRenderers.java
@@ -29,5 +29,6 @@ public final class DWMEntityRenderers {
             );
         }
         EntityRendererRegistry.register(DWMEntityTypes.TARDIS_SEAT, NoopRenderer::new);
+        EntityRendererRegistry.register(DWMEntityTypes.CONSOLE_CONTROL, NoopRenderer::new);
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/ConsoleControlHud.java
+++ b/src/client/java/com/adamkali/dwm/render/ConsoleControlHud.java
@@ -1,27 +1,24 @@
 package com.adamkali.dwm.render;
 
 import com.adamkali.dwm.DWMReference;
-import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
-import com.adamkali.dwm.block.FirstDoctorConsoleControls;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
+import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.ARGB;
 import net.minecraft.world.level.block.entity.BlockEntity;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.EntityHitResult;
 import net.minecraft.world.phys.HitResult;
 
 /**
- * Crosshair tooltip for First Doctor console controls.
+ * Crosshair tooltip for First Doctor console controls (via interaction entities).
  */
 public final class ConsoleControlHud {
     private static final Identifier ELEMENT_ID =
@@ -40,21 +37,22 @@ public final class ConsoleControlHud {
             return;
         }
         HitResult hit = client.hitResult;
-        if (!(hit instanceof BlockHitResult blockHit) || blockHit.getType() != HitResult.Type.BLOCK) {
+        if (!(hit instanceof EntityHitResult entityHit) || entityHit.getType() != HitResult.Type.ENTITY) {
+            return;
+        }
+        if (!(entityHit.getEntity() instanceof ConsoleControlInteractionEntity control)) {
             return;
         }
 
-        BlockPos pos = blockHit.getBlockPos();
-        BlockState state = client.level.getBlockState(pos);
-        if (!(state.getBlock() instanceof FirstDoctorConsoleBlock)) {
-            return;
+        LookTarget target = control.getLookTarget();
+        BlockPos consolePos = control.getConsolePos();
+        boolean stabilisersOn = true;
+        if (consolePos != null) {
+            BlockEntity be = client.level.getBlockEntity(consolePos);
+            if (be instanceof FirstDoctorConsoleBlockEntity console) {
+                stabilisersOn = console.isSyncedStabilisersEnabled();
+            }
         }
-
-        Direction facing = state.getValueOrElse(FirstDoctorConsoleBlock.FACING, Direction.NORTH);
-        LookTarget target = FirstDoctorConsoleControls.resolveLookTarget(facing, pos, client.player);
-        BlockEntity be = client.level.getBlockEntity(pos);
-        boolean stabilisersOn = !(be instanceof FirstDoctorConsoleBlockEntity console)
-                || console.isSyncedStabilisersEnabled();
         Component label = labelFor(target, stabilisersOn);
         if (label == null) {
             return;

--- a/src/client/java/com/adamkali/dwm/render/ConsoleHitboxDebugRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/ConsoleHitboxDebugRenderer.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.render;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderContext;
 import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
 import net.minecraft.client.Minecraft;
@@ -81,41 +82,25 @@ public final class ConsoleHitboxDebugRenderer {
                             );
                         }
 
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.biomeSelectorWorldBox(mutable, facing),
-                                GizmoStyle.stroke(BIOME_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.waypointSelectorWorldBox(mutable, facing),
-                                GizmoStyle.stroke(WAYPOINT_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.playerLocatorWorldBox(mutable, facing),
-                                GizmoStyle.stroke(PLAYER_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.planetLocatorWorldBox(mutable, facing),
-                                GizmoStyle.stroke(PLANET_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.chameleonCircuitWorldBox(mutable, facing),
-                                GizmoStyle.stroke(CHAMELEON_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.materialisationLeverWorldBox(mutable, facing),
-                                GizmoStyle.stroke(LEVER_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.fastReturnWorldBox(mutable, facing),
-                                GizmoStyle.stroke(FAST_RETURN_COLOR)
-                        );
-                        Gizmos.cuboid(
-                                FirstDoctorConsoleControls.stabilisersWorldBox(mutable, facing),
-                                GizmoStyle.stroke(STABILISERS_COLOR)
-                        );
+                        drawPose(mutable, facing, LookTarget.BIOME_SELECTOR, BIOME_COLOR);
+                        drawPose(mutable, facing, LookTarget.WAYPOINT_SELECTOR, WAYPOINT_COLOR);
+                        drawPose(mutable, facing, LookTarget.PLAYER_LOCATOR, PLAYER_COLOR);
+                        drawPose(mutable, facing, LookTarget.PLANET_LOCATOR, PLANET_COLOR);
+                        drawPose(mutable, facing, LookTarget.CHAMELEON_CIRCUIT, CHAMELEON_COLOR);
+                        drawPose(mutable, facing, LookTarget.MATERIALISATION_LEVER, LEVER_COLOR);
+                        drawPose(mutable, facing, LookTarget.FAST_RETURN, FAST_RETURN_COLOR);
+                        drawPose(mutable, facing, LookTarget.STABILISERS, STABILISERS_COLOR);
                     }
                 }
             }
+        }
+    }
+
+    private static void drawPose(BlockPos pos, Direction facing, LookTarget target, int color) {
+        FirstDoctorConsoleControls.InteractionPose pose =
+                FirstDoctorConsoleControls.interactionPose(target, pos, facing);
+        if (pose != null) {
+            Gizmos.cuboid(pose.aabb(), GizmoStyle.stroke(color));
         }
     }
 }

--- a/src/main/generated/assets/dwm/lang/en_us.json
+++ b/src/main/generated/assets/dwm/lang/en_us.json
@@ -210,6 +210,7 @@
   "dwm.tt_capsule": "TT Capsule",
   "entity.dwm.ash_boat": "Ash Boat",
   "entity.dwm.cardinal_boat": "Cardinal Boat",
+  "entity.dwm.console_control": "Console Control",
   "entity.dwm.dark_ash_boat": "Dark Ash Boat",
   "entity.dwm.tardis_seat": "TARDIS Seat",
   "item.dwm.ash_boat": "Ash Boat",

--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.block;
 
+import com.adamkali.dwm.block.entities.DWMBlockEntities;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.network.OpenPlayerLocatorScreen;
 import com.adamkali.dwm.network.OpenWaypointScreen;
@@ -40,6 +41,8 @@ import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -60,8 +63,11 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
     /** Approximate hexagonal pedestal: ~1.6×1.6 footprint, ~1.25 blocks tall. */
     public static final VoxelShape COLLISION_SHAPE = Shapes.box(-0.3, 0.0, -0.3, 1.3, 1.25, 1.3);
 
-    /** Outline includes Panel3 selectors so raycast can target them. */
-    public static final VoxelShape OUTLINE_SHAPE = Shapes.box(-0.5, 0.0, -0.5, 1.5, 1.6, 1.5);
+    /**
+     * Outline matches the pedestal, not a solid 3×3 volume. Control picking uses interaction
+     * entities on the outer deck; a large outline box occludes those entities from outside.
+     */
+    public static final VoxelShape OUTLINE_SHAPE = COLLISION_SHAPE;
 
     public FirstDoctorConsoleBlock(Properties settings) {
         super(settings);
@@ -119,6 +125,18 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
     }
 
     @Override
+    public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> type) {
+        if (world.isClientSide()) {
+            return null;
+        }
+        return createTickerHelper(
+                type,
+                DWMBlockEntities.FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY,
+                FirstDoctorConsoleBlockEntity::serverTick
+        );
+    }
+
+    @Override
     protected InteractionResult useWithoutItem(
             BlockState state,
             Level world,
@@ -126,23 +144,28 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             Player player,
             BlockHitResult hit
     ) {
+        // Controls are activated via ConsoleControlInteractionEntity hitboxes, not look-ray AABBs.
+        return InteractionResult.PASS;
+    }
+
+    /**
+     * Routes an interaction-entity click to the matching console control handler.
+     */
+    public static InteractionResult activateControl(
+            FirstDoctorConsoleControls.LookTarget target,
+            Level world,
+            BlockPos pos,
+            Player player
+    ) {
+        if (target == FirstDoctorConsoleControls.LookTarget.NONE) {
+            return InteractionResult.PASS;
+        }
         if (player.isShiftKeyDown()) {
             return InteractionResult.PASS;
         }
-
-        Direction facing = state.getValue(FACING);
-        FirstDoctorConsoleControls.Panel3Control panel3 =
-                FirstDoctorConsoleControls.resolvePanel3LookHit(facing, pos, player);
-        FirstDoctorConsoleControls.Panel6Control panel6 =
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, player);
-        if (panel3 == null && panel6 == null) {
-            return InteractionResult.PASS;
-        }
-
         if (world.isClientSide()) {
             return InteractionResult.SUCCESS;
         }
-
         if (!(world.getBlockEntity(pos) instanceof FirstDoctorConsoleBlockEntity console)
                 || !(world instanceof ServerLevel serverWorld)
                 || !(player instanceof ServerPlayer serverPlayer)) {
@@ -151,50 +174,34 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
 
         UUID tardisId = console.getTardisId();
         if (tardisId == null) {
-            player.sendOverlayMessage(Component.translatable(unavailableKey(panel3, panel6)));
+            player.sendOverlayMessage(Component.translatable(unavailableKey(target)));
             return InteractionResult.CONSUME;
         }
 
-        // Prefer Panel3 when both panels somehow hit (unusual; different deck angles).
-        if (panel3 != null) {
-            return switch (panel3) {
-                case BIOME -> handleBiomeSelector(world, pos, player, serverWorld, tardisId);
-                case PLANET -> handlePlanetLocator(world, pos, player, serverWorld, tardisId);
-                case WAYPOINT -> handleWaypointSelector(world, pos, serverPlayer, tardisId);
-                case PLAYER -> handlePlayerLocator(world, pos, serverPlayer, serverWorld, tardisId);
-            };
-        }
-
-        return switch (panel6) {
-            case LEVER -> handleMaterialisationLever(world, pos, player, serverWorld, tardisId);
-            case CHAMELEON -> handleChameleonCircuit(world, pos, player, serverWorld, console, tardisId);
+        return switch (target) {
+            case BIOME_SELECTOR -> handleBiomeSelector(world, pos, player, serverWorld, tardisId);
+            case PLANET_LOCATOR -> handlePlanetLocator(world, pos, player, serverWorld, tardisId);
+            case WAYPOINT_SELECTOR -> handleWaypointSelector(world, pos, serverPlayer, tardisId);
+            case PLAYER_LOCATOR -> handlePlayerLocator(world, pos, serverPlayer, serverWorld, tardisId);
+            case MATERIALISATION_LEVER -> handleMaterialisationLever(world, pos, player, serverWorld, tardisId);
+            case CHAMELEON_CIRCUIT -> handleChameleonCircuit(world, pos, player, serverWorld, console, tardisId);
             case FAST_RETURN -> handleFastReturn(world, pos, player, tardisId);
             case STABILISERS -> handleStabilisers(world, pos, player, serverWorld, console, tardisId);
+            case NONE -> InteractionResult.PASS;
         };
     }
 
-    private static String unavailableKey(
-            @Nullable FirstDoctorConsoleControls.Panel3Control panel3,
-            @Nullable FirstDoctorConsoleControls.Panel6Control panel6
-    ) {
-        if (panel3 != null) {
-            return switch (panel3) {
-                case PLANET -> "dwm.console.dimension_unavailable";
-                case WAYPOINT -> "dwm.console.waypoint_unavailable";
-                case PLAYER -> "dwm.console.player_locator_unavailable";
-                case BIOME -> "dwm.console.biome_unavailable";
-            };
-        }
-        if (panel6 == FirstDoctorConsoleControls.Panel6Control.CHAMELEON) {
-            return "dwm.console.chameleon_unavailable";
-        }
-        if (panel6 == FirstDoctorConsoleControls.Panel6Control.FAST_RETURN) {
-            return "dwm.console.fast_return_unavailable";
-        }
-        if (panel6 == FirstDoctorConsoleControls.Panel6Control.STABILISERS) {
-            return "dwm.console.stabilisers_unavailable";
-        }
-        return "dwm.console.travel_unavailable";
+    private static String unavailableKey(FirstDoctorConsoleControls.LookTarget target) {
+        return switch (target) {
+            case PLANET_LOCATOR -> "dwm.console.dimension_unavailable";
+            case WAYPOINT_SELECTOR -> "dwm.console.waypoint_unavailable";
+            case PLAYER_LOCATOR -> "dwm.console.player_locator_unavailable";
+            case BIOME_SELECTOR -> "dwm.console.biome_unavailable";
+            case CHAMELEON_CIRCUIT -> "dwm.console.chameleon_unavailable";
+            case FAST_RETURN -> "dwm.console.fast_return_unavailable";
+            case STABILISERS -> "dwm.console.stabilisers_unavailable";
+            case MATERIALISATION_LEVER, NONE -> "dwm.console.travel_unavailable";
+        };
     }
 
     private static InteractionResult handleMaterialisationLever(

--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleControls.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleControls.java
@@ -76,29 +76,35 @@ public final class FirstDoctorConsoleControls {
     private static final float SEL_MAX_Y = 2.0F;
     private static final float SEL_MAX_Z = 7.0F;
 
-    /** Lever footprint in lever-local pixels before {@link #LEVER_SCALE}. */
-    private static final float LEV_MIN_X = -4.0F;
+    /**
+     * Lever footprint in lever-local pixels before {@link #LEVER_SCALE}.
+     * Tight widget bounds (handle), not the decorative 18px base plate.
+     */
+    private static final float LEV_MIN_X = -2.0F;
     private static final float LEV_MIN_Y = 0.0F;
-    private static final float LEV_MIN_Z = -9.0F;
+    private static final float LEV_MIN_Z = -3.0F;
     private static final float LEV_MAX_X = 3.0F;
-    private static final float LEV_MAX_Y = 8.2F;
-    private static final float LEV_MAX_Z = 9.0F;
+    private static final float LEV_MAX_Y = 8.0F;
+    private static final float LEV_MAX_Z = 3.0F;
 
     /** Fast-return footprint in switch-local pixels before {@link #FAST_RETURN_SCALE}. */
-    private static final float FR_MIN_X = -3.0F;
+    private static final float FR_MIN_X = -2.5F;
     private static final float FR_MIN_Y = 0.0F;
-    private static final float FR_MIN_Z = -8.0F;
-    private static final float FR_MAX_X = 3.0F;
+    private static final float FR_MIN_Z = -3.0F;
+    private static final float FR_MAX_X = 2.5F;
     private static final float FR_MAX_Y = 3.6F;
-    private static final float FR_MAX_Z = 8.3F;
+    private static final float FR_MAX_Z = 3.0F;
 
-    /** Stabilisers footprint in control-local pixels before {@link #STABILISERS_SCALE}. */
-    private static final float STAB_MIN_X = -9.0F;
+    /**
+     * Stabilisers footprint in control-local pixels before {@link #STABILISERS_SCALE}.
+     * Tight widget bounds, not the decorative 18px base plate.
+     */
+    private static final float STAB_MIN_X = -4.0F;
     private static final float STAB_MIN_Y = 0.0F;
-    private static final float STAB_MIN_Z = -9.0F;
-    private static final float STAB_MAX_X = 8.0F;
-    private static final float STAB_MAX_Y = 8.2F;
-    private static final float STAB_MAX_Z = 9.0F;
+    private static final float STAB_MIN_Z = -4.0F;
+    private static final float STAB_MAX_X = 4.0F;
+    private static final float STAB_MAX_Y = 7.0F;
+    private static final float STAB_MAX_Z = 4.0F;
 
     private static final float Y_SCALE = 0.8F;
     private static final float PX = 1.0F / 16.0F;
@@ -132,10 +138,62 @@ public final class FirstDoctorConsoleControls {
         CHAMELEON_CIRCUIT,
         MATERIALISATION_LEVER,
         FAST_RETURN,
-        STABILISERS
+        STABILISERS;
+
+        /** Controls that spawn interaction entities (excludes {@link #NONE}). */
+        public static LookTarget[] interactiveValues() {
+            LookTarget[] all = values();
+            LookTarget[] interactive = new LookTarget[all.length - 1];
+            System.arraycopy(all, 1, interactive, 0, interactive.length);
+            return interactive;
+        }
+    }
+
+    /**
+     * Axis-aligned interaction entity pose for a console control.
+     * {@code position} is the bottom-center of the entity in world space.
+     */
+    public record InteractionPose(Vec3 position, float width, float height) {
+        public AABB aabb() {
+            double half = width * 0.5;
+            return new AABB(
+                    position.x - half,
+                    position.y,
+                    position.z - half,
+                    position.x + half,
+                    position.y + height,
+                    position.z + half
+            );
+        }
     }
 
     private FirstDoctorConsoleControls() {
+    }
+
+    /**
+     * World-space interaction pose for {@code target} on a console at {@code pos}.
+     * Returns {@code null} for {@link LookTarget#NONE}.
+     *
+     * <p>The entity is centered on the control AABB so minimum size clamps expand
+     * around the widget instead of only upward (which forced aiming above flat dials).
+     */
+    public static @Nullable InteractionPose interactionPose(LookTarget target, BlockPos pos, Direction facing) {
+        if (target == LookTarget.NONE) {
+            return null;
+        }
+        AABB local = unpaddedBoxFor(target, facing);
+        double xSize = local.getXsize();
+        double zSize = local.getZsize();
+        // Flat dial meshes are only a few scaled pixels tall; clamp so entity picking stays usable.
+        float width = (float) Math.max(Math.min(xSize, zSize), 0.18);
+        float height = (float) Math.max(local.getYsize(), 0.18);
+        Vec3 center = local.getCenter();
+        Vec3 bottomCenter = new Vec3(
+                pos.getX() + center.x,
+                pos.getY() + center.y - height * 0.5,
+                pos.getZ() + center.z
+        );
+        return new InteractionPose(bottomCenter, width, height);
     }
 
     /**
@@ -474,6 +532,36 @@ public final class FirstDoctorConsoleControls {
         };
     }
 
+    private static AABB unpaddedBoxFor(LookTarget target, Direction facing) {
+        return switch (target) {
+            case BIOME_SELECTOR -> selectorBox(facing, BIOME_SELECTOR_MOUNT_X_PX);
+            case WAYPOINT_SELECTOR -> selectorBox(facing, WAYPOINT_SELECTOR_MOUNT_X_PX);
+            case PLAYER_LOCATOR -> selectorBox(facing, PLAYER_LOCATOR_MOUNT_X_PX);
+            case PLANET_LOCATOR -> selectorBox(facing, PLANET_LOCATOR_MOUNT_X_PX);
+            case CHAMELEON_CIRCUIT -> controlBox(facing, PANEL6_YAW_RAD, SELECTOR_SCALE, CHAMELEON_CIRCUIT_MOUNT_X_PX,
+                    SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
+            case MATERIALISATION_LEVER -> controlBox(facing, PANEL6_YAW_RAD, LEVER_SCALE, LEVER_MOUNT_X_PX,
+                    LEV_MIN_X, LEV_MIN_Y, LEV_MIN_Z, LEV_MAX_X, LEV_MAX_Y, LEV_MAX_Z);
+            case FAST_RETURN -> controlBox(facing, PANEL6_YAW_RAD, FAST_RETURN_SCALE, FAST_RETURN_MOUNT_X_PX,
+                    FR_MIN_X, FR_MIN_Y, FR_MIN_Z, FR_MAX_X, FR_MAX_Y, FR_MAX_Z);
+            case STABILISERS -> controlBox(
+                    facing,
+                    PANEL6_YAW_RAD,
+                    STABILISERS_SCALE,
+                    STABILISERS_MOUNT_X_PX,
+                    STABILISERS_MOUNT_Y_PX,
+                    STABILISERS_MOUNT_Z_PX,
+                    STAB_MIN_X,
+                    STAB_MIN_Y,
+                    STAB_MIN_Z,
+                    STAB_MAX_X,
+                    STAB_MAX_Y,
+                    STAB_MAX_Z
+            );
+            case NONE -> new AABB(0, 0, 0, 0, 0, 0);
+        };
+    }
+
     /**
      * When biome and planet rays both hit, returns {@code true} if the biome AABB is closer.
      * Prefer {@link #resolveLookTarget} for new callers.
@@ -658,7 +746,7 @@ public final class FirstDoctorConsoleControls {
                 }
             }
         }
-        final double pad = 0.08;
+        final double pad = 0.0;
         return new AABB(
                 outMinX - pad, outMinY - pad, outMinZ - pad,
                 outMaxX + pad, outMaxY + pad, outMaxZ + pad

--- a/src/main/java/com/adamkali/dwm/block/entities/FirstDoctorConsoleBlockEntity.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/FirstDoctorConsoleBlockEntity.java
@@ -1,10 +1,18 @@
 package com.adamkali.dwm.block.entities;
 
+import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
+import com.adamkali.dwm.entity.DWMEntityTypes;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.EnumMap;
+import java.util.List;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.nbt.CompoundTag;
@@ -12,23 +20,92 @@ import net.minecraft.network.protocol.Packet;
 import net.minecraft.network.protocol.game.ClientGamePacketListener;
 import net.minecraft.network.protocol.game.ClientboundBlockEntityDataPacket;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
+import net.minecraft.world.phys.AABB;
 
 /**
  * Block entity for the First Doctor console. Holds {@code tardisId} for control interactions,
  * a synced chameleon variant for the Panel6 hologram preview, and synced stabilisers state.
+ * Server tick maintains one {@link ConsoleControlInteractionEntity} per control.
  */
 public class FirstDoctorConsoleBlockEntity extends BlockEntity {
+    /** Search radius so outer-deck controls (outside the 1×1 cell) are found. */
+    private static final double CONTROL_SEARCH_PADDING = 2.5;
+
     private @Nullable UUID tardisId;
     private TardisChameleonVariant syncedVariant = TardisChameleonVariant.TT_CAPSULE;
     private boolean syncedStabilisersEnabled = true;
 
     public FirstDoctorConsoleBlockEntity(BlockPos pos, BlockState state) {
         super(DWMBlockEntities.FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY, pos, state);
+    }
+
+    public static void serverTick(
+            Level world,
+            BlockPos pos,
+            BlockState state,
+            FirstDoctorConsoleBlockEntity console
+    ) {
+        console.maintainControlEntities(world, pos, state);
+    }
+
+    private void maintainControlEntities(Level world, BlockPos pos, BlockState state) {
+        Direction facing = state.getValueOrElse(FirstDoctorConsoleBlock.FACING, Direction.NORTH);
+        AABB search = new AABB(pos).inflate(CONTROL_SEARCH_PADDING);
+        List<ConsoleControlInteractionEntity> existing = world.getEntitiesOfClass(
+                ConsoleControlInteractionEntity.class,
+                search,
+                entity -> entity.isBoundTo(pos)
+        );
+
+        EnumMap<LookTarget, ConsoleControlInteractionEntity> byTarget = new EnumMap<>(LookTarget.class);
+        for (ConsoleControlInteractionEntity entity : existing) {
+            LookTarget target = entity.getLookTarget();
+            if (target == LookTarget.NONE) {
+                entity.discard();
+                continue;
+            }
+            ConsoleControlInteractionEntity prior = byTarget.putIfAbsent(target, entity);
+            if (prior != null) {
+                entity.discard();
+            }
+        }
+
+        for (LookTarget target : LookTarget.interactiveValues()) {
+            FirstDoctorConsoleControls.InteractionPose pose =
+                    FirstDoctorConsoleControls.interactionPose(target, pos, facing);
+            if (pose == null) {
+                continue;
+            }
+            ConsoleControlInteractionEntity entity = byTarget.get(target);
+            if (entity == null || entity.isRemoved()) {
+                entity = new ConsoleControlInteractionEntity(DWMEntityTypes.CONSOLE_CONTROL, world);
+                entity.bind(pos, target, pose);
+                world.addFreshEntity(entity);
+            } else {
+                entity.applyPose(pose);
+            }
+        }
+    }
+
+    private void discardControlEntities() {
+        if (level == null || level.isClientSide()) {
+            return;
+        }
+        AABB search = new AABB(worldPosition).inflate(CONTROL_SEARCH_PADDING);
+        List<ConsoleControlInteractionEntity> existing = level.getEntitiesOfClass(
+                ConsoleControlInteractionEntity.class,
+                search,
+                entity -> entity.isBoundTo(worldPosition)
+        );
+        for (ConsoleControlInteractionEntity entity : existing) {
+            entity.discard();
+        }
     }
 
     public void setTardisId(@Nullable UUID tardisId) {
@@ -71,6 +148,18 @@ public class FirstDoctorConsoleBlockEntity extends BlockEntity {
             BlockState state = getBlockState();
             level.sendBlockUpdated(worldPosition, state, state, Block.UPDATE_CLIENTS);
         }
+    }
+
+    @Override
+    public void setRemoved() {
+        discardControlEntities();
+        super.setRemoved();
+    }
+
+    @Override
+    public void preRemoveSideEffects(BlockPos pos, BlockState state) {
+        discardControlEntities();
+        super.preRemoveSideEffects(pos, state);
     }
 
     @Override

--- a/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
+++ b/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
@@ -252,6 +252,7 @@ public class DWMLanguageProvider extends FabricLanguageProvider {
 
     private static void addMisc(TranslationBuilder t) {
         t.add(DWMEntityTypes.TARDIS_SEAT, "TARDIS Seat");
+        t.add(DWMEntityTypes.CONSOLE_CONTROL, "Console Control");
         t.add("dimension.dwm.gallifrey", "Gallifrey");
         t.add("biome.dwm.gallifrey_plains", "Gallifrey Plains");
         t.add("biome.dwm.gallifrey_forest", "Gallifrey Forest");

--- a/src/main/java/com/adamkali/dwm/entity/ConsoleControlInteractionEntity.java
+++ b/src/main/java/com/adamkali/dwm/entity/ConsoleControlInteractionEntity.java
@@ -1,0 +1,156 @@
+package com.adamkali.dwm.entity;
+
+import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+import java.util.Optional;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.syncher.EntityDataAccessor;
+import net.minecraft.network.syncher.EntityDataSerializers;
+import net.minecraft.network.syncher.SynchedEntityData;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.Interaction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.material.PushReaction;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Invisible {@link Interaction} hitbox for one First Doctor console control.
+ * Spawned and maintained by {@link com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity}.
+ */
+public class ConsoleControlInteractionEntity extends Interaction {
+    private static final EntityDataAccessor<Byte> DATA_LOOK_TARGET =
+            SynchedEntityData.defineId(ConsoleControlInteractionEntity.class, EntityDataSerializers.BYTE);
+    private static final EntityDataAccessor<Optional<BlockPos>> DATA_CONSOLE_POS =
+            SynchedEntityData.defineId(ConsoleControlInteractionEntity.class, EntityDataSerializers.OPTIONAL_BLOCK_POS);
+
+    public ConsoleControlInteractionEntity(EntityType<? extends ConsoleControlInteractionEntity> type, Level level) {
+        super(type, level);
+        this.noPhysics = true;
+        this.setNoGravity(true);
+        this.setResponse(true);
+    }
+
+    public void bind(BlockPos consolePos, LookTarget target, FirstDoctorConsoleControls.InteractionPose pose) {
+        setConsolePos(consolePos);
+        setLookTarget(target);
+        setPos(pose.position());
+        setWidth(pose.width());
+        setHeight(pose.height());
+    }
+
+    public boolean isBoundTo(BlockPos pos) {
+        BlockPos bound = getConsolePos();
+        return bound != null && bound.equals(pos);
+    }
+
+    public @Nullable BlockPos getConsolePos() {
+        return entityData.get(DATA_CONSOLE_POS).orElse(null);
+    }
+
+    public void setConsolePos(@Nullable BlockPos pos) {
+        entityData.set(DATA_CONSOLE_POS, Optional.ofNullable(pos == null ? null : pos.immutable()));
+    }
+
+    public LookTarget getLookTarget() {
+        return lookTargetFromId(entityData.get(DATA_LOOK_TARGET));
+    }
+
+    public void setLookTarget(LookTarget target) {
+        entityData.set(DATA_LOOK_TARGET, (byte) target.ordinal());
+    }
+
+    public void applyPose(FirstDoctorConsoleControls.InteractionPose pose) {
+        setPos(pose.position());
+        if (Math.abs(getWidth() - pose.width()) > 1.0e-3f) {
+            setWidth(pose.width());
+        }
+        if (Math.abs(getHeight() - pose.height()) > 1.0e-3f) {
+            setHeight(pose.height());
+        }
+    }
+
+    @Override
+    protected void defineSynchedData(SynchedEntityData.Builder builder) {
+        super.defineSynchedData(builder);
+        builder.define(DATA_LOOK_TARGET, (byte) LookTarget.NONE.ordinal());
+        builder.define(DATA_CONSOLE_POS, Optional.empty());
+    }
+
+    @Override
+    public InteractionResult interact(Player player, InteractionHand hand, Vec3 location) {
+        if (player.isShiftKeyDown()) {
+            return InteractionResult.PASS;
+        }
+        if (level().isClientSide()) {
+            return InteractionResult.SUCCESS;
+        }
+        BlockPos consolePos = getConsolePos();
+        if (consolePos == null) {
+            return InteractionResult.CONSUME;
+        }
+        LookTarget target = getLookTarget();
+        if (target == LookTarget.NONE) {
+            return InteractionResult.CONSUME;
+        }
+        return FirstDoctorConsoleBlock.activateControl(target, level(), consolePos, player);
+    }
+
+    @Override
+    public void tick() {
+        super.tick();
+        if (level().isClientSide()) {
+            return;
+        }
+        BlockPos consolePos = getConsolePos();
+        if (consolePos == null) {
+            discard();
+            return;
+        }
+        if (!(level().getBlockState(consolePos).getBlock() instanceof FirstDoctorConsoleBlock)) {
+            discard();
+        }
+    }
+
+    @Override
+    public PushReaction getPistonPushReaction() {
+        return PushReaction.IGNORE;
+    }
+
+    @Override
+    public boolean isIgnoringBlockTriggers() {
+        return true;
+    }
+
+    @Override
+    protected void readAdditionalSaveData(ValueInput input) {
+        super.readAdditionalSaveData(input);
+        setConsolePos(input.read("ConsolePos", BlockPos.CODEC).orElse(null));
+        setLookTarget(lookTargetFromId(input.getByteOr("LookTarget", (byte) 0)));
+    }
+
+    @Override
+    protected void addAdditionalSaveData(ValueOutput output) {
+        super.addAdditionalSaveData(output);
+        BlockPos consolePos = getConsolePos();
+        if (consolePos != null) {
+            output.store("ConsolePos", BlockPos.CODEC, consolePos);
+        }
+        output.putByte("LookTarget", (byte) getLookTarget().ordinal());
+    }
+
+    private static LookTarget lookTargetFromId(byte id) {
+        LookTarget[] values = LookTarget.values();
+        int index = id & 0xFF;
+        if (index < 0 || index >= values.length) {
+            return LookTarget.NONE;
+        }
+        return values[index];
+    }
+}

--- a/src/main/java/com/adamkali/dwm/entity/DWMEntityTypes.java
+++ b/src/main/java/com/adamkali/dwm/entity/DWMEntityTypes.java
@@ -18,6 +18,7 @@ public final class DWMEntityTypes {
     public static EntityType<Boat> DARK_ASH_BOAT;
     public static EntityType<Boat> CARDINAL_BOAT;
     public static EntityType<TardisSeatEntity> TARDIS_SEAT;
+    public static EntityType<ConsoleControlInteractionEntity> CONSOLE_CONTROL;
 
     private DWMEntityTypes() {
     }
@@ -30,6 +31,7 @@ public final class DWMEntityTypes {
         DARK_ASH_BOAT = DWMBlocks.DARK_ASH.boatEntity();
         CARDINAL_BOAT = DWMBlocks.CARDINAL.boatEntity();
         TARDIS_SEAT = registerSeat();
+        CONSOLE_CONTROL = registerConsoleControl();
     }
 
     private static EntityType<TardisSeatEntity> registerSeat() {
@@ -42,6 +44,24 @@ public final class DWMEntityTypes {
                         .sized(0.5F, 0.1F)
                         .passengerAttachments(0.0F)
                         .noSummon()
+                        .fireImmune()
+                        .noLootTable()
+                        .clientTrackingRange(10)
+                        .updateInterval(Integer.MAX_VALUE)
+                        .build(key)
+        );
+    }
+
+    private static EntityType<ConsoleControlInteractionEntity> registerConsoleControl() {
+        Identifier id = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "console_control");
+        ResourceKey<EntityType<?>> key = ResourceKey.create(Registries.ENTITY_TYPE, id);
+        return Registry.register(
+                BuiltInRegistries.ENTITY_TYPE,
+                key,
+                EntityType.Builder.of(ConsoleControlInteractionEntity::new, MobCategory.MISC)
+                        .sized(0.0F, 0.0F)
+                        .noSummon()
+                        .noSave()
                         .fireImmune()
                         .noLootTable()
                         .clientTrackingRange(10)

--- a/src/main/java/com/adamkali/dwm/gametest/ConsoleControlInteractionGameTests.java
+++ b/src/main/java/com/adamkali/dwm/gametest/ConsoleControlInteractionGameTests.java
@@ -1,0 +1,136 @@
+package com.adamkali.dwm.gametest;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
+import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+
+public class ConsoleControlInteractionGameTests {
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void consoleSpawnsEightControlEntities(GameTestHelper context) {
+        BlockPos rel = new BlockPos(2, 2, 2);
+        BlockPos abs = context.absolutePos(rel);
+        context.setBlock(
+                rel,
+                DWMBlocks.FIRST_DOCTOR_CONSOLE.defaultBlockState().setValue(FirstDoctorConsoleBlock.FACING, Direction.NORTH)
+        );
+        context.assertBlockPresent(DWMBlocks.FIRST_DOCTOR_CONSOLE, rel);
+
+        if (!(context.getLevel().getBlockEntity(abs) instanceof FirstDoctorConsoleBlockEntity)) {
+            throw new AssertionError("Expected FirstDoctorConsoleBlockEntity");
+        }
+
+        // Server ticker spawns interaction entities.
+        context.runAtTickTime(1, () -> {
+            List<ConsoleControlInteractionEntity> controls = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(abs).inflate(2.5),
+                    entity -> entity.isBoundTo(abs)
+            );
+            if (controls.size() != LookTarget.interactiveValues().length) {
+                throw new AssertionError(
+                        "Expected " + LookTarget.interactiveValues().length
+                                + " console control entities, got " + controls.size()
+                );
+            }
+            context.succeed();
+        });
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void removingConsoleDiscardsControlEntities(GameTestHelper context) {
+        BlockPos rel = new BlockPos(2, 2, 2);
+        BlockPos abs = context.absolutePos(rel);
+        context.setBlock(
+                rel,
+                DWMBlocks.FIRST_DOCTOR_CONSOLE.defaultBlockState().setValue(FirstDoctorConsoleBlock.FACING, Direction.SOUTH)
+        );
+
+        context.runAtTickTime(1, () -> {
+            List<ConsoleControlInteractionEntity> before = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(abs).inflate(2.5),
+                    entity -> entity.isBoundTo(abs)
+            );
+            if (before.isEmpty()) {
+                throw new AssertionError("Expected control entities before removal");
+            }
+
+            context.setBlock(rel, net.minecraft.world.level.block.Blocks.AIR.defaultBlockState());
+
+            context.runAtTickTime(2, () -> {
+                List<ConsoleControlInteractionEntity> after = context.getLevel().getEntitiesOfClass(
+                        ConsoleControlInteractionEntity.class,
+                        new AABB(abs).inflate(2.5),
+                        entity -> entity.isBoundTo(abs) && !entity.isRemoved()
+                );
+                if (!after.isEmpty()) {
+                    throw new AssertionError("Expected control entities discarded after console removal, got " + after.size());
+                }
+                context.succeed();
+            });
+        });
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void interactingStabilisersWithoutTardisIdConsumes(GameTestHelper context) {
+        BlockPos rel = new BlockPos(2, 2, 2);
+        BlockPos abs = context.absolutePos(rel);
+        BlockState consoleState = DWMBlocks.FIRST_DOCTOR_CONSOLE.defaultBlockState()
+                .setValue(FirstDoctorConsoleBlock.FACING, Direction.EAST);
+        context.setBlock(rel, consoleState);
+
+        context.runAtTickTime(1, () -> {
+            List<ConsoleControlInteractionEntity> controls = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(abs).inflate(2.5),
+                    entity -> entity.isBoundTo(abs)
+                            && entity.getLookTarget() == LookTarget.STABILISERS
+            );
+            if (controls.isEmpty()) {
+                throw new AssertionError("Expected stabilisers control entity");
+            }
+
+            Player player = context.makeMockPlayer(GameType.SURVIVAL);
+            InteractionResult result = controls.getFirst().interact(
+                    player,
+                    InteractionHand.MAIN_HAND,
+                    Vec3.ZERO
+            );
+            if (result != InteractionResult.CONSUME && result != InteractionResult.SUCCESS) {
+                throw new AssertionError("Expected CONSUME/SUCCESS without tardisId, got " + result);
+            }
+
+            ConsoleControlInteractionEntity lever = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(abs).inflate(2.5),
+                    entity -> entity.isBoundTo(abs)
+                            && entity.getLookTarget() == LookTarget.MATERIALISATION_LEVER
+            ).stream().findFirst().orElse(null);
+            if (lever == null) {
+                throw new AssertionError("Expected materialisation lever control entity");
+            }
+            InteractionResult leverResult = lever.interact(player, InteractionHand.MAIN_HAND, Vec3.ZERO);
+            if (leverResult != InteractionResult.CONSUME && leverResult != InteractionResult.SUCCESS) {
+                throw new AssertionError("Expected CONSUME/SUCCESS for lever without tardisId, got " + leverResult);
+            }
+
+            context.succeed();
+        });
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.tardis.boti;
 
 import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
@@ -243,6 +244,9 @@ public final class BotiInteriorSampler {
      */
     public static BotiEntitySample captureEntity(Entity entity, BlockPos plotOrigin) {
         if (entity == null || entity.isRemoved() || plotOrigin == null) {
+            return null;
+        }
+        if (entity instanceof ConsoleControlInteractionEntity) {
             return null;
         }
         CompoundTag nbt = captureEntityNbt(entity);

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -37,6 +37,7 @@
       "com.adamkali.dwm.gametest.AzbantiumGameTests",
       "com.adamkali.dwm.gametest.GallifreyVanillaOresGameTests",
       "com.adamkali.dwm.gametest.SonicInteractionGameTests",
+      "com.adamkali.dwm.gametest.ConsoleControlInteractionGameTests",
       "com.adamkali.dwm.network.ChameleonGameTests"
     ]
   },

--- a/src/test/java/com/adamkali/dwm/block/FirstDoctorConsoleControlsTest.java
+++ b/src/test/java/com/adamkali/dwm/block/FirstDoctorConsoleControlsTest.java
@@ -17,8 +17,8 @@ class FirstDoctorConsoleControlsTest {
         AABB box = FirstDoctorConsoleControls.biomeSelectorBox(Direction.NORTH);
         assertTrue(box.minY > 0.5, "selector should sit on panel deck, was minY=" + box.minY);
         assertTrue(box.maxY < 1.7, "selector should stay near console top, was maxY=" + box.maxY);
-        assertTrue(box.getXsize() > 0.2);
-        assertTrue(box.getZsize() > 0.2);
+        assertTrue(box.getXsize() > 0.08);
+        assertTrue(box.getZsize() > 0.08);
         assertTrue(
                 FirstDoctorConsoleControls.selectorDistanceFromCenter(Direction.NORTH) > 0.45,
                 "selector should be out on Panel3 deck, not at the time rotor"
@@ -366,6 +366,54 @@ class FirstDoctorConsoleControlsTest {
                 FirstDoctorConsoleControls.LookTarget.FAST_RETURN,
                 FirstDoctorConsoleControls.resolveLookTarget(facing, pos, fastReturnEye, look, 5.0)
         );
+    }
+
+    @Test
+    void panel6InteractionPoses_doNotOverlap() {
+        Direction facing = Direction.NORTH;
+        BlockPos pos = BlockPos.ZERO;
+        FirstDoctorConsoleControls.LookTarget[] panel6 = {
+                FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT,
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER,
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN,
+                FirstDoctorConsoleControls.LookTarget.STABILISERS
+        };
+        for (int i = 0; i < panel6.length; i++) {
+            FirstDoctorConsoleControls.InteractionPose a =
+                    FirstDoctorConsoleControls.interactionPose(panel6[i], pos, facing);
+            assertNotNull(a);
+            assertTrue(a.height() > 0.05f, panel6[i] + " height");
+            assertTrue(a.width() > 0.05f, panel6[i] + " width");
+            for (int j = i + 1; j < panel6.length; j++) {
+                FirstDoctorConsoleControls.InteractionPose b =
+                        FirstDoctorConsoleControls.interactionPose(panel6[j], pos, facing);
+                assertNotNull(b);
+                assertFalse(
+                        a.aabb().intersects(b.aabb()),
+                        panel6[i] + " must not overlap " + panel6[j]
+                );
+            }
+        }
+    }
+
+    @Test
+    void leverAndStabilisersInteractionPoses_sitOnOuterDeck() {
+        Direction facing = Direction.NORTH;
+        BlockPos pos = BlockPos.ZERO;
+        FirstDoctorConsoleControls.InteractionPose lever =
+                FirstDoctorConsoleControls.interactionPose(
+                        FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, pos, facing);
+        FirstDoctorConsoleControls.InteractionPose stabilisers =
+                FirstDoctorConsoleControls.interactionPose(
+                        FirstDoctorConsoleControls.LookTarget.STABILISERS, pos, facing);
+        assertNotNull(lever);
+        assertNotNull(stabilisers);
+        assertTrue(lever.position().y > 0.3);
+        assertTrue(stabilisers.position().y > 0.3);
+        double leverDist = Math.hypot(lever.position().x - 0.5, lever.position().z - 0.5);
+        double stabDist = Math.hypot(stabilisers.position().x - 0.5, stabilisers.position().z - 0.5);
+        assertTrue(leverDist > 0.45, "lever should be out on Panel6 deck");
+        assertTrue(stabDist > leverDist, "stabilisers should be farther out than lever");
     }
 
     private static void assertCentersDistinct(AABB a, AABB b) {

--- a/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
@@ -2,11 +2,13 @@ package com.adamkali.dwm.tardis.boti;
 
 import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -103,6 +105,13 @@ class BotiInteriorSamplerTest {
     @Test
     void captureEntity_NullEntityReturnsNull() {
         assertNull(BotiInteriorSampler.captureEntity(null, BlockPos.ZERO));
+    }
+
+    @Test
+    void captureEntity_skipsConsoleControlInteraction() {
+        ConsoleControlInteractionEntity entity = Mockito.mock(ConsoleControlInteractionEntity.class);
+        Mockito.when(entity.isRemoved()).thenReturn(false);
+        assertNull(BotiInteriorSampler.captureEntity(entity, BlockPos.ZERO));
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Outer-deck console controls were hard to hit because look-ray AABB picking needed a large solid outline that occluded widgets from outside the pedestal.
- Interaction entities let each control keep a tight, usable hitbox without that 3×3 outline.

## Proposed Implementation

- Spawn and maintain one `ConsoleControlInteractionEntity` per control from the First Doctor console block entity.
- Route clicks through `FirstDoctorConsoleBlock.activateControl`; shrink the block outline to the pedestal collision shape.
- Point the control HUD and F3+B debug overlay at entity poses; skip these entities in BOTI sampling.
- Cover spawn/discard/interact in GameTests and lock Panel 6 poses so they do not overlap.

Stacked on #107 (`feat/console-stabilisers`) because this edits the same console files and uses `LookTarget.STABILISERS`.

## Problems Encountered / Decisions Made

- Tightened lever / fast-return / stabilisers widget bounds (and dropped AABB padding) so interaction boxes sit on the mesh instead of the decorative base plate.
- Minimum entity size is clamped around the widget center so flat dials stay aimable without expanding only upward.


Made with [Cursor](https://cursor.com)