### PR TITLE
refactor(console): catalog control specs and unify display sync

### DIFF
--- a/src/client/java/com/adamkali/dwm/render/ConsoleControlHud.java
+++ b/src/client/java/com/adamkali/dwm/render/ConsoleControlHud.java
@@ -4,6 +4,8 @@ import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
+import com.adamkali.dwm.tardis.logic.ConsoleDisplayState;
+import com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
 import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.minecraft.client.DeltaTracker;
@@ -54,7 +56,7 @@ public final class ConsoleControlHud {
                 console = found;
             }
         }
-        Component label = labelFor(target, console);
+        Component label = labelFor(target, console == null ? null : console.syncedDisplay());
         if (label == null) {
             return;
         }
@@ -67,8 +69,8 @@ public final class ConsoleControlHud {
         graphics.text(client.font, label, x, y, color);
     }
 
-    private static Component labelFor(LookTarget target, @Nullable FirstDoctorConsoleBlockEntity console) {
-        boolean stabilisersOn = console == null || console.isSyncedStabilisersEnabled();
+    private static Component labelFor(LookTarget target, @Nullable ConsoleDisplayState display) {
+        boolean stabilisersOn = display == null || display.stabilisersEnabled();
         return switch (target) {
             case BIOME_SELECTOR -> Component.translatable("dwm.console.biome_selector");
             case WAYPOINT_SELECTOR -> Component.translatable("dwm.console.waypoint_selector");
@@ -79,30 +81,30 @@ public final class ConsoleControlHud {
             case FAST_RETURN -> Component.translatable("dwm.console.fast_return");
             case STABILISERS -> Component.translatable(
                     stabilisersOn ? "dwm.console.stabilisers_on" : "dwm.console.stabilisers_off");
-            case OXYGEN_READER -> readerLabel(console, reading -> reading.oxygen(), "dwm.console.oxygen");
-            case PRESSURE_READER -> readerLabel(console, reading -> reading.pressure(), "dwm.console.pressure");
-            case TEMPERATURE_READER -> readerLabel(console, reading -> reading.temperature(), "dwm.console.temperature");
-            case RADIATION_READER -> readerLabel(console, reading -> reading.radiation(), "dwm.console.radiation");
+            case OXYGEN_READER -> readerLabel(display, ExteriorEnvironmentReadout.Reading::oxygen, "dwm.console.oxygen");
+            case PRESSURE_READER -> readerLabel(display, ExteriorEnvironmentReadout.Reading::pressure, "dwm.console.pressure");
+            case TEMPERATURE_READER -> readerLabel(display, ExteriorEnvironmentReadout.Reading::temperature, "dwm.console.temperature");
+            case RADIATION_READER -> readerLabel(display, ExteriorEnvironmentReadout.Reading::radiation, "dwm.console.radiation");
             case REFUELER -> Component.translatable("dwm.console.refueler_stable");
             case TELEPATHIC_CIRCUIT -> Component.translatable("dwm.console.telepathic_circuit");
             case CLOAK -> Component.translatable(
-                    console != null && console.isSyncedCloaked()
+                    display != null && display.cloaked()
                             ? "dwm.console.cloak_on"
                             : "dwm.console.cloak_off");
             case DOOR_LOCK -> Component.translatable(
-                    console != null && console.isSyncedDoorsLocked()
+                    display != null && display.doorsLocked()
                             ? "dwm.console.doors_locked"
                             : "dwm.console.doors_unlocked");
             case COORDINATE_LOCK_X -> Component.translatable(
-                    console != null && console.isSyncedLockX()
+                    display != null && display.lockX()
                             ? "dwm.console.lock_x_on"
                             : "dwm.console.lock_x_off");
             case COORDINATE_LOCK_Y -> Component.translatable(
-                    console != null && console.isSyncedLockY()
+                    display != null && display.lockY()
                             ? "dwm.console.lock_y_on"
                             : "dwm.console.lock_y_off");
             case COORDINATE_LOCK_Z -> Component.translatable(
-                    console != null && console.isSyncedLockZ()
+                    display != null && display.lockZ()
                             ? "dwm.console.lock_z_on"
                             : "dwm.console.lock_z_off");
             case NONE -> null;
@@ -110,14 +112,14 @@ public final class ConsoleControlHud {
     }
 
     private static Component readerLabel(
-            @Nullable FirstDoctorConsoleBlockEntity console,
-            java.util.function.ToDoubleFunction<com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout.Reading> value,
+            @Nullable ConsoleDisplayState display,
+            java.util.function.ToDoubleFunction<ExteriorEnvironmentReadout.Reading> value,
             String key
     ) {
-        if (console == null || console.syncedReading().noSignal()) {
+        if (display == null || display.reading().noSignal()) {
             return Component.translatable("dwm.console.reader_no_signal");
         }
-        var reading = console.syncedReading();
+        ExteriorEnvironmentReadout.Reading reading = display.reading();
         int percent = Math.round(reading.needle((float) value.applyAsDouble(reading)) * 100.0F);
         return Component.translatable(key, percent);
     }

--- a/src/client/java/com/adamkali/dwm/render/FirstDoctorConsoleBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/FirstDoctorConsoleBlockEntityRenderer.java
@@ -1,7 +1,9 @@
 package com.adamkali.dwm.render;
 
+import com.adamkali.dwm.block.ConsoleControlSpec;
 import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.model.tileentity.BiomeSelectorModel;
 import com.adamkali.dwm.model.tileentity.ChameleonCircuitModel;
@@ -27,15 +29,19 @@ import com.adamkali.dwm.model.tileentity.TardisModel;
 import com.adamkali.dwm.model.tileentity.TelepathicCircuitModel;
 import com.adamkali.dwm.model.tileentity.ThirdDoctorTardisModel;
 import com.adamkali.dwm.model.tileentity.WaypointSelectorModel;
-import com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout;
 import com.adamkali.dwm.render.state.FirstDoctorConsoleBlockEntityRenderState;
 import com.adamkali.dwm.render.state.TardisRenderState;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
+import com.adamkali.dwm.tardis.logic.ConsoleDisplayState;
+import com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import java.util.HashMap;
+import java.util.List;
+import java.util.function.ToDoubleFunction;
+import net.minecraft.client.model.Model;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
@@ -50,6 +56,7 @@ import net.minecraft.util.ARGB;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Nullable;
 
 public class FirstDoctorConsoleBlockEntityRenderer
         implements BlockEntityRenderer<FirstDoctorConsoleBlockEntity, FirstDoctorConsoleBlockEntityRenderState> {
@@ -67,51 +74,66 @@ public class FirstDoctorConsoleBlockEntityRenderer
     static final float HOLOGRAM_BOB_AMPLITUDE = 0.03F;
 
     private final FirstDoctorConsoleModel model;
-    private final BiomeSelectorModel biomeSelectorModel;
-    private final WaypointSelectorModel waypointSelectorModel;
-    private final PlayerLocatorModel playerLocatorModel;
-    private final PlanetLocatorModel planetLocatorModel;
-    private final ChameleonCircuitModel chameleonCircuitModel;
-    private final MaterialisationLeverModel materialisationLeverModel;
-    private final FastReturnModel fastReturnModel;
-    private final StabilisersModel stabilisersModel;
-    private final ReaderModel readerModel;
-    private final RadiationReaderModel radiationReaderModel;
-    private final CloakLeverModel cloakLeverModel;
-    private final DoorLockModel doorLockModel;
-    private final TelepathicCircuitModel telepathicCircuitModel;
-    private final CoordinateLockModel coordinateLockModel;
+    private final List<MountedWidget> widgets;
     private final HashMap<TardisChameleonVariant, TardisModel> shellModelCache = new HashMap<>();
     private final HashMap<TardisChameleonVariant, Identifier> shellTextureCache = new HashMap<>();
 
     public FirstDoctorConsoleBlockEntityRenderer(BlockEntityRendererProvider.Context context) {
         this.model = new FirstDoctorConsoleModel(
                 context.bakeLayer(FirstDoctorConsoleModel.LAYER_LOCATION));
-        this.biomeSelectorModel = new BiomeSelectorModel(
-                context.bakeLayer(BiomeSelectorModel.LAYER_LOCATION));
-        this.waypointSelectorModel = new WaypointSelectorModel(
-                context.bakeLayer(WaypointSelectorModel.LAYER_LOCATION));
-        this.playerLocatorModel = new PlayerLocatorModel(
-                context.bakeLayer(PlayerLocatorModel.LAYER_LOCATION));
-        this.planetLocatorModel = new PlanetLocatorModel(
-                context.bakeLayer(PlanetLocatorModel.LAYER_LOCATION));
-        this.chameleonCircuitModel = new ChameleonCircuitModel(
-                context.bakeLayer(ChameleonCircuitModel.LAYER_LOCATION));
-        this.materialisationLeverModel = new MaterialisationLeverModel(
-                context.bakeLayer(MaterialisationLeverModel.LAYER_LOCATION));
-        this.fastReturnModel = new FastReturnModel(
-                context.bakeLayer(FastReturnModel.LAYER_LOCATION));
-        this.stabilisersModel = new StabilisersModel(
-                context.bakeLayer(StabilisersModel.LAYER_LOCATION));
-        this.readerModel = new ReaderModel(context.bakeLayer(ReaderModel.LAYER_LOCATION));
-        this.radiationReaderModel = new RadiationReaderModel(
-                context.bakeLayer(RadiationReaderModel.LAYER_LOCATION));
-        this.cloakLeverModel = new CloakLeverModel(context.bakeLayer(CloakLeverModel.LAYER_LOCATION));
-        this.doorLockModel = new DoorLockModel(context.bakeLayer(DoorLockModel.LAYER_LOCATION));
-        this.telepathicCircuitModel = new TelepathicCircuitModel(
-                context.bakeLayer(TelepathicCircuitModel.LAYER_LOCATION));
-        this.coordinateLockModel = new CoordinateLockModel(
-                context.bakeLayer(CoordinateLockModel.LAYER_LOCATION));
+        ReaderModel readerModel = new ReaderModel(context.bakeLayer(ReaderModel.LAYER_LOCATION));
+
+        this.widgets = List.of(
+                widget(LookTarget.BIOME_SELECTOR,
+                        new BiomeSelectorModel(context.bakeLayer(BiomeSelectorModel.LAYER_LOCATION)),
+                        BiomeSelectorModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.WAYPOINT_SELECTOR,
+                        new WaypointSelectorModel(context.bakeLayer(WaypointSelectorModel.LAYER_LOCATION)),
+                        WaypointSelectorModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.PLAYER_LOCATOR,
+                        new PlayerLocatorModel(context.bakeLayer(PlayerLocatorModel.LAYER_LOCATION)),
+                        PlayerLocatorModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.PLANET_LOCATOR,
+                        new PlanetLocatorModel(context.bakeLayer(PlanetLocatorModel.LAYER_LOCATION)),
+                        PlanetLocatorModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.CHAMELEON_CIRCUIT,
+                        new ChameleonCircuitModel(context.bakeLayer(ChameleonCircuitModel.LAYER_LOCATION)),
+                        ChameleonCircuitModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.MATERIALISATION_LEVER,
+                        new MaterialisationLeverModel(context.bakeLayer(MaterialisationLeverModel.LAYER_LOCATION)),
+                        MaterialisationLeverModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.FAST_RETURN,
+                        new FastReturnModel(context.bakeLayer(FastReturnModel.LAYER_LOCATION)),
+                        FastReturnModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.STABILISERS,
+                        new StabilisersModel(context.bakeLayer(StabilisersModel.LAYER_LOCATION)),
+                        StabilisersModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.OXYGEN_READER, readerModel, ReaderModel.OXYGEN_TEXTURE,
+                        display -> needle(display.reading(), ExteriorEnvironmentReadout.Reading::oxygen)),
+                widget(LookTarget.PRESSURE_READER, readerModel, ReaderModel.PRESSURE_TEXTURE,
+                        display -> needle(display.reading(), ExteriorEnvironmentReadout.Reading::pressure)),
+                widget(LookTarget.TEMPERATURE_READER, readerModel, ReaderModel.TEMPERATURE_TEXTURE,
+                        display -> needle(display.reading(), ExteriorEnvironmentReadout.Reading::temperature)),
+                widget(LookTarget.RADIATION_READER,
+                        new RadiationReaderModel(context.bakeLayer(RadiationReaderModel.LAYER_LOCATION)),
+                        RadiationReaderModel.TEXTURE_LOCATION,
+                        display -> needle(display.reading(), ExteriorEnvironmentReadout.Reading::radiation)),
+                widget(LookTarget.REFUELER, readerModel, ReaderModel.REFUELER_TEXTURE,
+                        display -> ReaderModel.REFUELER_NEEDLE),
+                widget(LookTarget.TELEPATHIC_CIRCUIT,
+                        new TelepathicCircuitModel(context.bakeLayer(TelepathicCircuitModel.LAYER_LOCATION)),
+                        TelepathicCircuitModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.CLOAK,
+                        new CloakLeverModel(context.bakeLayer(CloakLeverModel.LAYER_LOCATION)),
+                        CloakLeverModel.TEXTURE_LOCATION, null),
+                widget(LookTarget.DOOR_LOCK,
+                        new DoorLockModel(context.bakeLayer(DoorLockModel.LAYER_LOCATION)),
+                        DoorLockModel.TEXTURE_LOCATION, null),
+                // One mesh for all three coordinate-lock pads; Y/Z are hitboxes only.
+                widget(LookTarget.COORDINATE_LOCK_X,
+                        new CoordinateLockModel(context.bakeLayer(CoordinateLockModel.LAYER_LOCATION)),
+                        CoordinateLockModel.TEXTURE_LOCATION, null)
+        );
 
         cacheShell(TardisChameleonVariant.TT_CAPSULE,
                 new TTCapsuleModel(context.bakeLayer(TTCapsuleModel.LAYER_LOCATION)),
@@ -137,6 +159,22 @@ public class FirstDoctorConsoleBlockEntityRenderer
         cacheShell(TardisChameleonVariant.SEVENTH_DOCTOR_BOX,
                 new SeventhDoctorTardisModel(context.bakeLayer(SeventhDoctorTardisModel.LAYER_LOCATION)),
                 SeventhDoctorTardisModel.TEXTURE_LOCATION);
+    }
+
+    private static MountedWidget widget(
+            LookTarget target,
+            Model<? super TardisRenderState> controlModel,
+            Identifier texture,
+            @Nullable ToDoubleFunction<ConsoleDisplayState> needle
+    ) {
+        return new MountedWidget(target, controlModel, texture, needle);
+    }
+
+    private static float needle(
+            ExteriorEnvironmentReadout.Reading reading,
+            ToDoubleFunction<ExteriorEnvironmentReadout.Reading> value
+    ) {
+        return reading.needle((float) value.applyAsDouble(reading));
     }
 
     private void cacheShell(TardisChameleonVariant variant, TardisModel shellModel, Identifier texture) {
@@ -165,27 +203,15 @@ public class FirstDoctorConsoleBlockEntityRenderer
         TardisTravelPhase phase = TardisLogic.getTravelPhase(entity.getTardisId());
         Level world = entity.getLevel();
         float timeTicks = world == null ? partialTicks : world.getGameTime() + partialTicks;
-        boolean stabilisersEnabled = entity.isSyncedStabilisersEnabled();
-        state.stabilisersEnabled = stabilisersEnabled;
+        ConsoleDisplayState display = entity.syncedDisplay();
+        state.display = display;
         state.traveling = phase.isTraveling();
         state.rotorBobOffset = FirstDoctorConsoleModel.rotorBobOffset(
-                timeTicks, phase.isTraveling(), stabilisersEnabled);
-        state.variant = entity.getSyncedVariant();
+                timeTicks, phase.isTraveling(), display.stabilisersEnabled());
         state.hologramYawDegrees = hologramYawDegrees(timeTicks);
         state.hologramBobOffset = hologramBobOffset(timeTicks);
-        state.cloaked = entity.isSyncedCloaked();
-        state.doorsLocked = entity.isSyncedDoorsLocked();
-        state.lockX = entity.isSyncedLockX();
-        state.lockY = entity.isSyncedLockY();
-        state.lockZ = entity.isSyncedLockZ();
-        ExteriorEnvironmentReadout.Reading reading = entity.syncedReading();
-        state.readerNoSignal = reading.noSignal();
-        state.oxygen = reading.needle(reading.oxygen());
-        state.pressure = reading.needle(reading.pressure());
-        state.temperature = reading.needle(reading.temperature());
-        state.radiation = reading.needle(reading.radiation());
 
-        if (world != null && world.isClientSide() && state.traveling && !stabilisersEnabled) {
+        if (world != null && world.isClientSide() && state.traveling && !display.stabilisersEnabled()) {
             spawnUnstabilisedRotorSmoke(world, entity.getBlockPos());
         }
     }
@@ -229,12 +255,7 @@ public class FirstDoctorConsoleBlockEntityRenderer
     ) {
         TardisRenderState animState = new TardisRenderState();
         animState.setRotorBobOffset(state.rotorBobOffset);
-        animState.setStabilisersEnabled(state.stabilisersEnabled);
-        animState.setCloaked(state.cloaked);
-        animState.setDoorsLocked(state.doorsLocked);
-        animState.setLockX(state.lockX);
-        animState.setLockY(state.lockY);
-        animState.setLockZ(state.lockZ);
+        applyDisplay(animState, state.display);
 
         poseStack.pushPose();
         applyTransforms(poseStack, state.facing);
@@ -249,168 +270,24 @@ public class FirstDoctorConsoleBlockEntityRenderer
                 0,
                 state.breakProgress);
 
-        submitPanel3Dial(poseStack, submitNodeCollector, state, animState,
-                biomeSelectorModel, BiomeSelectorModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.BIOME_SELECTOR_MOUNT_X_PX);
-        submitPanel3Dial(poseStack, submitNodeCollector, state, animState,
-                waypointSelectorModel, WaypointSelectorModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.WAYPOINT_SELECTOR_MOUNT_X_PX);
-        submitPanel3Dial(poseStack, submitNodeCollector, state, animState,
-                playerLocatorModel, PlayerLocatorModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PLAYER_LOCATOR_MOUNT_X_PX);
-        submitPanel3Dial(poseStack, submitNodeCollector, state, animState,
-                planetLocatorModel, PlanetLocatorModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PLANET_LOCATOR_MOUNT_X_PX);
-
-        poseStack.pushPose();
-        applyPanel6ChameleonTransforms(poseStack);
-        submitNodeCollector.submitModel(
-                chameleonCircuitModel,
-                animState,
-                poseStack,
-                RenderTypes.entityCutout(ChameleonCircuitModel.TEXTURE_LOCATION),
-                state.lightCoords,
-                OverlayTexture.NO_OVERLAY,
-                0,
-                state.breakProgress);
-        poseStack.popPose();
-
-        submitChameleonHologram(poseStack, submitNodeCollector, state);
-
-        poseStack.pushPose();
-        applyPanel6LeverTransforms(poseStack);
-        submitNodeCollector.submitModel(
-                materialisationLeverModel,
-                animState,
-                poseStack,
-                RenderTypes.entityCutout(MaterialisationLeverModel.TEXTURE_LOCATION),
-                state.lightCoords,
-                OverlayTexture.NO_OVERLAY,
-                0,
-                state.breakProgress);
-        poseStack.popPose();
-
-        poseStack.pushPose();
-        applyPanel6FastReturnTransforms(poseStack);
-        submitNodeCollector.submitModel(
-                fastReturnModel,
-                animState,
-                poseStack,
-                RenderTypes.entityCutout(FastReturnModel.TEXTURE_LOCATION),
-                state.lightCoords,
-                OverlayTexture.NO_OVERLAY,
-                0,
-                state.breakProgress);
-        poseStack.popPose();
-
-        poseStack.pushPose();
-        applyPanel6StabilisersTransforms(poseStack);
-        submitNodeCollector.submitModel(
-                stabilisersModel,
-                animState,
-                poseStack,
-                RenderTypes.entityCutout(StabilisersModel.TEXTURE_LOCATION),
-                state.lightCoords,
-                OverlayTexture.NO_OVERLAY,
-                0,
-                state.breakProgress);
-        poseStack.popPose();
-
-        submitReader(poseStack, submitNodeCollector, state, animState,
-                ReaderModel.OXYGEN_TEXTURE, state.oxygen,
-                FirstDoctorConsoleControls.PANEL1_YAW_RAD,
-                FirstDoctorConsoleControls.READER_SCALE,
-                FirstDoctorConsoleControls.OXYGEN_READER_MOUNT_X_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX);
-        submitReader(poseStack, submitNodeCollector, state, animState,
-                ReaderModel.PRESSURE_TEXTURE, state.pressure,
-                FirstDoctorConsoleControls.PANEL1_YAW_RAD,
-                FirstDoctorConsoleControls.READER_SCALE,
-                FirstDoctorConsoleControls.PRESSURE_READER_MOUNT_X_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX);
-        submitReader(poseStack, submitNodeCollector, state, animState,
-                ReaderModel.TEMPERATURE_TEXTURE, state.temperature,
-                FirstDoctorConsoleControls.PANEL1_YAW_RAD,
-                FirstDoctorConsoleControls.READER_SCALE,
-                FirstDoctorConsoleControls.TEMPERATURE_READER_MOUNT_X_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX);
-        animState.setNeedle(state.radiation);
-        submitMounted(poseStack, submitNodeCollector, state, animState,
-                radiationReaderModel, RadiationReaderModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PANEL1_YAW_RAD,
-                FirstDoctorConsoleControls.RADIATION_SCALE,
-                0.0F,
-                FirstDoctorConsoleControls.BOTTOM_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.BOTTOM_MOUNT_Z_PX);
-        submitReader(poseStack, submitNodeCollector, state, animState,
-                ReaderModel.REFUELER_TEXTURE, ReaderModel.REFUELER_NEEDLE,
-                FirstDoctorConsoleControls.PANEL5_YAW_RAD,
-                FirstDoctorConsoleControls.READER_SCALE,
-                0.0F,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX);
-        submitMounted(poseStack, submitNodeCollector, state, animState,
-                telepathicCircuitModel, TelepathicCircuitModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PANEL2_YAW_RAD,
-                FirstDoctorConsoleControls.TELEPATHIC_SCALE,
-                0.0F,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX);
-        submitMounted(poseStack, submitNodeCollector, state, animState,
-                cloakLeverModel, CloakLeverModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PANEL4_YAW_RAD,
-                FirstDoctorConsoleControls.CLOAK_SCALE,
-                0.0F,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX);
-        submitMounted(poseStack, submitNodeCollector, state, animState,
-                doorLockModel, DoorLockModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PANEL4_YAW_RAD,
-                FirstDoctorConsoleControls.DOOR_LOCK_SCALE,
-                0.0F,
-                FirstDoctorConsoleControls.BOTTOM_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.BOTTOM_MOUNT_Z_PX);
-        submitMounted(poseStack, submitNodeCollector, state, animState,
-                coordinateLockModel, CoordinateLockModel.TEXTURE_LOCATION,
-                FirstDoctorConsoleControls.PANEL3_YAW_RAD,
-                FirstDoctorConsoleControls.COORDINATE_LOCK_SCALE,
-                0.0F,
-                FirstDoctorConsoleControls.BOTTOM_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.BOTTOM_MOUNT_Z_PX);
+        for (MountedWidget widget : widgets) {
+            submitMounted(poseStack, submitNodeCollector, state, animState, widget);
+            if (widget.target() == LookTarget.CHAMELEON_CIRCUIT) {
+                submitChameleonHologram(poseStack, submitNodeCollector, state);
+            }
+        }
 
         poseStack.popPose();
     }
 
-    private void submitReader(
-            PoseStack poseStack,
-            SubmitNodeCollector submitNodeCollector,
-            FirstDoctorConsoleBlockEntityRenderState state,
-            TardisRenderState animState,
-            Identifier texture,
-            float needle,
-            float panelYawRad,
-            float scale,
-            float mountXPx,
-            float mountYPx,
-            float mountZPx
-    ) {
-        animState.setNeedle(needle);
-        submitMounted(
-                poseStack,
-                submitNodeCollector,
-                state,
-                animState,
-                readerModel,
-                texture,
-                panelYawRad,
-                scale,
-                mountXPx,
-                mountYPx,
-                mountZPx
-        );
+    private static void applyDisplay(TardisRenderState animState, ConsoleDisplayState display) {
+        ConsoleDisplayState safe = display == null ? ConsoleDisplayState.defaults() : display;
+        animState.setStabilisersEnabled(safe.stabilisersEnabled());
+        animState.setCloaked(safe.cloaked());
+        animState.setDoorsLocked(safe.doorsLocked());
+        animState.setLockX(safe.lockX());
+        animState.setLockY(safe.lockY());
+        animState.setLockZ(safe.lockZ());
     }
 
     private void submitMounted(
@@ -418,49 +295,22 @@ public class FirstDoctorConsoleBlockEntityRenderer
             SubmitNodeCollector submitNodeCollector,
             FirstDoctorConsoleBlockEntityRenderState state,
             TardisRenderState animState,
-            net.minecraft.client.model.Model<? super TardisRenderState> controlModel,
-            Identifier texture,
-            float panelYawRad,
-            float scale,
-            float mountXPx,
-            float mountYPx,
-            float mountZPx
+            MountedWidget widget
     ) {
+        ConsoleControlSpec layout = FirstDoctorConsoleControls.spec(widget.target());
+        if (layout == null) {
+            return;
+        }
+        if (widget.needle() != null) {
+            animState.setNeedle((float) widget.needle().applyAsDouble(state.display));
+        }
         poseStack.pushPose();
-        applyPanelControlTransforms(poseStack, panelYawRad, scale, mountXPx, mountYPx, mountZPx);
+        applyPanelControlTransforms(poseStack, layout);
         submitNodeCollector.submitModel(
-                controlModel,
+                widget.model(),
                 animState,
                 poseStack,
-                RenderTypes.entityCutout(texture),
-                state.lightCoords,
-                OverlayTexture.NO_OVERLAY,
-                0,
-                state.breakProgress);
-        poseStack.popPose();
-    }
-
-    private void submitPanel3Dial(
-            PoseStack poseStack,
-            SubmitNodeCollector submitNodeCollector,
-            FirstDoctorConsoleBlockEntityRenderState state,
-            TardisRenderState animState,
-            net.minecraft.client.model.Model<? super TardisRenderState> dialModel,
-            Identifier texture,
-            float mountXPx
-    ) {
-        poseStack.pushPose();
-        applyPanelControlTransforms(
-                poseStack,
-                FirstDoctorConsoleControls.PANEL3_YAW_RAD,
-                FirstDoctorConsoleControls.SELECTOR_SCALE,
-                mountXPx
-        );
-        submitNodeCollector.submitModel(
-                dialModel,
-                animState,
-                poseStack,
-                RenderTypes.entityCutout(texture),
+                RenderTypes.entityCutout(widget.texture()),
                 state.lightCoords,
                 OverlayTexture.NO_OVERLAY,
                 0,
@@ -473,8 +323,9 @@ public class FirstDoctorConsoleBlockEntityRenderer
             SubmitNodeCollector submitNodeCollector,
             FirstDoctorConsoleBlockEntityRenderState state
     ) {
-        TardisChameleonVariant variant =
-                state.variant != null ? state.variant : TardisChameleonVariant.TT_CAPSULE;
+        TardisChameleonVariant variant = state.display == null
+                ? TardisChameleonVariant.TT_CAPSULE
+                : state.display.variant();
         TardisModel shellModel = shellModelCache.get(variant);
         Identifier texture = shellTextureCache.get(variant);
         if (shellModel == null || texture == null) {
@@ -510,39 +361,6 @@ public class FirstDoctorConsoleBlockEntityRenderer
     }
 
     /**
-     * Panel3 → deck → biome mount + scale, matching {@link FirstDoctorConsoleControls}.
-     */
-    static void applyPanel3BiomeSelectorTransforms(PoseStack matrices) {
-        applyPanelControlTransforms(
-                matrices,
-                FirstDoctorConsoleControls.PANEL3_YAW_RAD,
-                FirstDoctorConsoleControls.SELECTOR_SCALE,
-                FirstDoctorConsoleControls.BIOME_SELECTOR_MOUNT_X_PX
-        );
-    }
-
-    /**
-     * Panel3 → deck → planet locator mount + scale, matching {@link FirstDoctorConsoleControls}.
-     */
-    static void applyPanel3PlanetLocatorTransforms(PoseStack matrices) {
-        applyPanelControlTransforms(
-                matrices,
-                FirstDoctorConsoleControls.PANEL3_YAW_RAD,
-                FirstDoctorConsoleControls.SELECTOR_SCALE,
-                FirstDoctorConsoleControls.PLANET_LOCATOR_MOUNT_X_PX
-        );
-    }
-
-    static void applyPanel6ChameleonTransforms(PoseStack matrices) {
-        applyPanelControlTransforms(
-                matrices,
-                FirstDoctorConsoleControls.PANEL6_YAW_RAD,
-                FirstDoctorConsoleControls.SELECTOR_SCALE,
-                FirstDoctorConsoleControls.CHAMELEON_CIRCUIT_MOUNT_X_PX
-        );
-    }
-
-    /**
      * Mount at the chameleon control, lift above the dial (with bob), undo deck
      * pitch so the shell stands upright for the player, then scale, Java-entity
      * orientation, and turntable yaw.
@@ -552,11 +370,17 @@ public class FirstDoctorConsoleBlockEntityRenderer
             float yawDegrees,
             float bobOffset
     ) {
+        ConsoleControlSpec chameleon = FirstDoctorConsoleControls.spec(LookTarget.CHAMELEON_CIRCUIT);
+        if (chameleon == null) {
+            return;
+        }
         applyPanelControlTransforms(
                 matrices,
-                FirstDoctorConsoleControls.PANEL6_YAW_RAD,
+                chameleon.panelYaw(),
                 1.0F,
-                FirstDoctorConsoleControls.CHAMELEON_CIRCUIT_MOUNT_X_PX
+                chameleon.mountX(),
+                chameleon.mountY(),
+                chameleon.mountZ()
         );
         matrices.translate(0.0, HOLOGRAM_Y_OFFSET_PX * PX + bobOffset, 0.0);
         matrices.mulPose(Axis.XP.rotation(-FirstDoctorConsoleControls.DECK_PITCH_RAD));
@@ -566,51 +390,14 @@ public class FirstDoctorConsoleBlockEntityRenderer
         matrices.mulPose(Axis.YP.rotationDegrees(yawDegrees));
     }
 
-    /**
-     * Panel6 → deck → mount + scale, matching {@link FirstDoctorConsoleControls}.
-     */
-    static void applyPanel6LeverTransforms(PoseStack matrices) {
+    private static void applyPanelControlTransforms(PoseStack matrices, ConsoleControlSpec layout) {
         applyPanelControlTransforms(
                 matrices,
-                FirstDoctorConsoleControls.PANEL6_YAW_RAD,
-                FirstDoctorConsoleControls.LEVER_SCALE,
-                FirstDoctorConsoleControls.LEVER_MOUNT_X_PX
-        );
-    }
-
-    static void applyPanel6FastReturnTransforms(PoseStack matrices) {
-        applyPanelControlTransforms(
-                matrices,
-                FirstDoctorConsoleControls.PANEL6_YAW_RAD,
-                FirstDoctorConsoleControls.FAST_RETURN_SCALE,
-                FirstDoctorConsoleControls.FAST_RETURN_MOUNT_X_PX
-        );
-    }
-
-    static void applyPanel6StabilisersTransforms(PoseStack matrices) {
-        applyPanelControlTransforms(
-                matrices,
-                FirstDoctorConsoleControls.PANEL6_YAW_RAD,
-                FirstDoctorConsoleControls.STABILISERS_SCALE,
-                FirstDoctorConsoleControls.STABILISERS_MOUNT_X_PX,
-                FirstDoctorConsoleControls.STABILISERS_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.STABILISERS_MOUNT_Z_PX
-        );
-    }
-
-    private static void applyPanelControlTransforms(
-            PoseStack matrices,
-            float panelYawRad,
-            float scale,
-            float mountXPx
-    ) {
-        applyPanelControlTransforms(
-                matrices,
-                panelYawRad,
-                scale,
-                mountXPx,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Y_PX,
-                FirstDoctorConsoleControls.CONTROL_MOUNT_Z_PX
+                layout.panelYaw(),
+                layout.scale(),
+                layout.mountX(),
+                layout.mountY(),
+                layout.mountZ()
         );
     }
 
@@ -643,5 +430,13 @@ public class FirstDoctorConsoleBlockEntityRenderer
     @Override
     public int getViewDistance() {
         return 64;
+    }
+
+    private record MountedWidget(
+            LookTarget target,
+            Model<? super TardisRenderState> model,
+            Identifier texture,
+            @Nullable ToDoubleFunction<ConsoleDisplayState> needle
+    ) {
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/state/FirstDoctorConsoleBlockEntityRenderState.java
+++ b/src/client/java/com/adamkali/dwm/render/state/FirstDoctorConsoleBlockEntityRenderState.java
@@ -2,7 +2,7 @@ package com.adamkali.dwm.render.state;
 
 import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
 import net.minecraft.core.Direction;
-import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.logic.ConsoleDisplayState;
 
 /**
  * Extracted First Doctor console BER state for the MC 26.2 submit pipeline.
@@ -10,24 +10,12 @@ import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 public class FirstDoctorConsoleBlockEntityRenderState extends BlockEntityRenderState {
     public Direction facing = Direction.NORTH;
     public float rotorBobOffset;
-    /** Synced chameleon variant for the Panel6 hologram shell. */
-    public TardisChameleonVariant variant = TardisChameleonVariant.TT_CAPSULE;
-    /** Synced stabilisers toggle for Panel6 dial pose and unstabilised flight FX. */
-    public boolean stabilisersEnabled = true;
+    /** Synced console instruments (variant, toggles, environment readout). */
+    public ConsoleDisplayState display = ConsoleDisplayState.defaults();
     /** Whether the TARDIS is currently traveling (for rotor smoke FX). */
     public boolean traveling;
     /** Continuous turntable yaw for the chameleon hologram (degrees). */
     public float hologramYawDegrees;
     /** Vertical bob offset for the chameleon hologram (blocks, deck-local Y). */
     public float hologramBobOffset;
-    public boolean cloaked;
-    public boolean doorsLocked;
-    public boolean lockX;
-    public boolean lockY;
-    public boolean lockZ;
-    public boolean readerNoSignal = true;
-    public float oxygen;
-    public float pressure;
-    public float temperature;
-    public float radiation;
 }

--- a/src/main/java/com/adamkali/dwm/block/ConsoleControlSpec.java
+++ b/src/main/java/com/adamkali/dwm/block/ConsoleControlSpec.java
@@ -1,0 +1,22 @@
+package com.adamkali.dwm.block;
+
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+
+/**
+ * Geometry for one First Doctor console control: panel mount + local AABB before deck transforms.
+ */
+public record ConsoleControlSpec(
+        LookTarget target,
+        float panelYaw,
+        float scale,
+        float mountX,
+        float mountY,
+        float mountZ,
+        float minX,
+        float minY,
+        float minZ,
+        float maxX,
+        float maxY,
+        float maxZ
+) {
+}

--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
@@ -189,20 +189,20 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             case WAYPOINT_SELECTOR -> handleWaypointSelector(world, pos, serverPlayer, tardisId);
             case PLAYER_LOCATOR -> handlePlayerLocator(world, pos, serverPlayer, serverWorld, tardisId);
             case MATERIALISATION_LEVER -> handleMaterialisationLever(world, pos, player, serverWorld, tardisId);
-            case CHAMELEON_CIRCUIT -> handleChameleonCircuit(world, pos, player, serverWorld, console, tardisId);
+            case CHAMELEON_CIRCUIT -> handleChameleonCircuit(world, pos, player, serverWorld, tardisId);
             case FAST_RETURN -> handleFastReturn(world, pos, player, tardisId);
-            case STABILISERS -> handleStabilisers(world, pos, player, serverWorld, console, tardisId);
+            case STABILISERS -> handleStabilisers(world, pos, player, serverWorld, tardisId);
             case OXYGEN_READER -> handleReader(player, console, ExteriorEnvironmentReadout.Reading::oxygen, "dwm.console.oxygen");
             case PRESSURE_READER -> handleReader(player, console, ExteriorEnvironmentReadout.Reading::pressure, "dwm.console.pressure");
             case TEMPERATURE_READER -> handleReader(player, console, ExteriorEnvironmentReadout.Reading::temperature, "dwm.console.temperature");
             case RADIATION_READER -> handleReader(player, console, ExteriorEnvironmentReadout.Reading::radiation, "dwm.console.radiation");
             case REFUELER -> handleRefueler(player);
             case TELEPATHIC_CIRCUIT -> handleTelepathic(world, pos, player, tardisId);
-            case CLOAK -> handleCloak(world, pos, player, serverWorld, console, tardisId);
-            case DOOR_LOCK -> handleDoorLock(world, pos, player, serverWorld, console, tardisId);
-            case COORDINATE_LOCK_X -> handleCoordinateLock(world, pos, player, serverWorld, console, tardisId, CoordinateLockLogic.Axis.X);
-            case COORDINATE_LOCK_Y -> handleCoordinateLock(world, pos, player, serverWorld, console, tardisId, CoordinateLockLogic.Axis.Y);
-            case COORDINATE_LOCK_Z -> handleCoordinateLock(world, pos, player, serverWorld, console, tardisId, CoordinateLockLogic.Axis.Z);
+            case CLOAK -> handleCloak(world, pos, player, serverWorld, tardisId);
+            case DOOR_LOCK -> handleDoorLock(world, pos, player, serverWorld, tardisId);
+            case COORDINATE_LOCK_X -> handleCoordinateLock(world, pos, player, serverWorld, tardisId, CoordinateLockLogic.Axis.X);
+            case COORDINATE_LOCK_Y -> handleCoordinateLock(world, pos, player, serverWorld, tardisId, CoordinateLockLogic.Axis.Y);
+            case COORDINATE_LOCK_Z -> handleCoordinateLock(world, pos, player, serverWorld, tardisId, CoordinateLockLogic.Axis.Z);
             case NONE -> InteractionResult.PASS;
         };
     }
@@ -366,7 +366,6 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             BlockPos pos,
             Player player,
             ServerLevel serverWorld,
-            FirstDoctorConsoleBlockEntity console,
             UUID tardisId
     ) {
         Optional<TardisChameleonVariant> next =
@@ -375,8 +374,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             player.sendOverlayMessage(Component.translatable("dwm.console.chameleon_unavailable"));
             return InteractionResult.CONSUME;
         }
-        // cycleVariant already syncs via FirstDoctorConsoleSync; keep local BE fresh for same-tick hologram.
-        console.setSyncedVariant(next.get());
+        // cycleVariant already syncs via FirstDoctorConsoleSync.syncFromModel.
         Component variantName = Component.translatable(next.get().getId().toLanguageKey());
         player.sendOverlayMessage(Component.translatable("dwm.console.chameleon_selected", variantName));
         playClick(world, pos);
@@ -425,7 +423,6 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             BlockPos pos,
             Player player,
             ServerLevel serverWorld,
-            FirstDoctorConsoleBlockEntity console,
             UUID tardisId
     ) {
         TardisDataModel model = TardisDataLoader.get(tardisId);
@@ -434,8 +431,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             return InteractionResult.CONSUME;
         }
         boolean enabled = StabiliserLogic.toggle(model);
-        console.setSyncedStabilisersEnabled(enabled);
-        FirstDoctorConsoleSync.syncStabilisers(serverWorld.getServer(), tardisId, enabled);
+        FirstDoctorConsoleSync.syncFromModel(serverWorld.getServer(), tardisId);
         player.sendOverlayMessage(Component.translatable(
                 enabled ? "dwm.console.stabilisers_on" : "dwm.console.stabilisers_off"));
         playClick(world, pos);
@@ -448,7 +444,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             java.util.function.ToDoubleFunction<ExteriorEnvironmentReadout.Reading> value,
             String key
     ) {
-        ExteriorEnvironmentReadout.Reading reading = console.syncedReading();
+        ExteriorEnvironmentReadout.Reading reading = console.syncedDisplay().reading();
         if (reading.noSignal()) {
             player.sendOverlayMessage(Component.translatable("dwm.console.reader_no_signal"));
             return InteractionResult.CONSUME;
@@ -493,7 +489,6 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             BlockPos pos,
             Player player,
             ServerLevel serverWorld,
-            FirstDoctorConsoleBlockEntity console,
             UUID tardisId
     ) {
         TardisDataModel model = TardisDataLoader.get(tardisId);
@@ -502,8 +497,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             return InteractionResult.CONSUME;
         }
         boolean cloaked = CloakLogic.toggle(model);
-        console.setSyncedCloaked(cloaked);
-        FirstDoctorConsoleSync.syncCloak(serverWorld.getServer(), tardisId, cloaked);
+        FirstDoctorConsoleSync.syncFromModel(serverWorld.getServer(), tardisId);
         player.sendOverlayMessage(Component.translatable(
                 cloaked ? "dwm.console.cloak_on" : "dwm.console.cloak_off"));
         playClick(world, pos);
@@ -515,7 +509,6 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             BlockPos pos,
             Player player,
             ServerLevel serverWorld,
-            FirstDoctorConsoleBlockEntity console,
             UUID tardisId
     ) {
         TardisDataModel model = TardisDataLoader.get(tardisId);
@@ -524,8 +517,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             return InteractionResult.CONSUME;
         }
         boolean locked = DoorLockLogic.toggle(model);
-        console.setSyncedDoorsLocked(locked);
-        FirstDoctorConsoleSync.syncDoorsLocked(serverWorld.getServer(), tardisId, locked);
+        FirstDoctorConsoleSync.syncFromModel(serverWorld.getServer(), tardisId);
         player.sendOverlayMessage(Component.translatable(
                 locked ? "dwm.console.doors_locked" : "dwm.console.doors_unlocked"));
         playClick(world, pos);
@@ -537,7 +529,6 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             BlockPos pos,
             Player player,
             ServerLevel serverWorld,
-            FirstDoctorConsoleBlockEntity console,
             UUID tardisId,
             CoordinateLockLogic.Axis axis
     ) {
@@ -547,8 +538,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             return InteractionResult.CONSUME;
         }
         boolean locked = CoordinateLockLogic.toggle(model, axis);
-        console.setSyncedAxisLock(axis, locked);
-        FirstDoctorConsoleSync.syncCoordinateLocks(serverWorld.getServer(), tardisId, model);
+        FirstDoctorConsoleSync.syncFromModel(serverWorld.getServer(), tardisId);
         String axisKey = switch (axis) {
             case X -> locked ? "dwm.console.lock_x_on" : "dwm.console.lock_x_off";
             case Y -> locked ? "dwm.console.lock_y_on" : "dwm.console.lock_y_off";

--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleControls.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleControls.java
@@ -2,6 +2,11 @@ package com.adamkali.dwm.block;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.world.entity.player.Player;
@@ -13,6 +18,7 @@ import net.minecraft.world.phys.Vec3;
  * {@code FirstDoctorConsoleBlockEntityRenderer} (center, Y×0.8, facing yaw, panel decks).
  *
  * <p>Panel deck chain: panel pivot/yaw → deck bone pivot/pitch → control mount offset.
+ * Per-control layout lives in the {@link ConsoleControlSpec} catalog.
  */
 public final class FirstDoctorConsoleControls {
     /**
@@ -84,17 +90,6 @@ public final class FirstDoctorConsoleControls {
     public static final float CONTROL_MOUNT_Y_PX = 8.081F;
     public static final float CONTROL_MOUNT_Z_PX = 2.339F;
 
-    /** Panel3 four-dial layout (deck-local X). */
-    public static final float BIOME_SELECTOR_MOUNT_X_PX = -3.75F;
-    public static final float WAYPOINT_SELECTOR_MOUNT_X_PX = -1.25F;
-    public static final float PLAYER_LOCATOR_MOUNT_X_PX = 1.25F;
-    public static final float PLANET_LOCATOR_MOUNT_X_PX = 3.75F;
-
-    /** Panel6: chameleon left of center; lever centered; fast return right of lever. */
-    public static final float CHAMELEON_CIRCUIT_MOUNT_X_PX = -4.0F;
-    public static final float LEVER_MOUNT_X_PX = CONTROL_MOUNT_X_PX;
-    public static final float FAST_RETURN_MOUNT_X_PX = 4.0F;
-
     /**
      * Top (inner) row — toward the rotor, compact widget cuboid top center.
      * Inner cuboid: {@code (-5, 5.081, 5.339) 10×4×5} → top center ≈ {@code (0, 9.081, 7.839)}.
@@ -107,49 +102,33 @@ public final class FirstDoctorConsoleControls {
      * Bottom (outer) row — player-facing cuboid top center.
      * Middle-row mounts keep {@link #CONTROL_MOUNT_Y_PX} / {@link #CONTROL_MOUNT_Z_PX}.
      */
-    public static final float STABILISERS_MOUNT_X_PX = 0.0F;
-    public static final float STABILISERS_MOUNT_Y_PX = 7.081F;
-    public static final float STABILISERS_MOUNT_Z_PX = -3.661F;
-    public static final float BOTTOM_MOUNT_X_PX = STABILISERS_MOUNT_X_PX;
-    public static final float BOTTOM_MOUNT_Y_PX = STABILISERS_MOUNT_Y_PX;
-    public static final float BOTTOM_MOUNT_Z_PX = STABILISERS_MOUNT_Z_PX;
+    public static final float BOTTOM_MOUNT_X_PX = 0.0F;
+    public static final float BOTTOM_MOUNT_Y_PX = 7.081F;
+    public static final float BOTTOM_MOUNT_Z_PX = -3.661F;
 
-    /** Uniform scale — the raw 14px dial is oversized for the Panel3 deck. */
-    public static final float SELECTOR_SCALE = 0.1125F;
+    private static final float BIOME_SELECTOR_MOUNT_X_PX = -3.75F;
+    private static final float WAYPOINT_SELECTOR_MOUNT_X_PX = -1.25F;
+    private static final float PLAYER_LOCATOR_MOUNT_X_PX = 1.25F;
+    private static final float PLANET_LOCATOR_MOUNT_X_PX = 3.75F;
+    private static final float CHAMELEON_CIRCUIT_MOUNT_X_PX = -4.0F;
+    private static final float LEVER_MOUNT_X_PX = CONTROL_MOUNT_X_PX;
+    private static final float FAST_RETURN_MOUNT_X_PX = 4.0F;
+    private static final float STABILISERS_MOUNT_X_PX = 0.0F;
+    private static final float OXYGEN_READER_MOUNT_X_PX = -3.75F;
+    private static final float PRESSURE_READER_MOUNT_X_PX = 0.0F;
+    private static final float TEMPERATURE_READER_MOUNT_X_PX = 3.75F;
 
-    /** Uniform scale for the materialisation lever on Panel6. */
-    public static final float LEVER_SCALE = 0.2F;
+    private static final float SELECTOR_SCALE = 0.1125F;
+    private static final float LEVER_SCALE = 0.2F;
+    private static final float FAST_RETURN_SCALE = LEVER_SCALE;
+    private static final float STABILISERS_SCALE = 0.18F;
+    private static final float READER_SCALE = SELECTOR_SCALE;
+    private static final float RADIATION_SCALE = 0.10F;
+    private static final float TELEPATHIC_SCALE = 0.14F;
+    private static final float CLOAK_SCALE = LEVER_SCALE;
+    private static final float DOOR_LOCK_SCALE = 0.14F;
+    private static final float COORDINATE_LOCK_SCALE = 0.11F;
 
-    /** Uniform scale for the fast-return switch on Panel6 (matches lever). */
-    public static final float FAST_RETURN_SCALE = LEVER_SCALE;
-
-    /** Uniform scale for the stabilisers control on Panel6 bottom row. */
-    public static final float STABILISERS_SCALE = 0.18F;
-
-    /** Shared 16×3×16 environment / refueler dial. */
-    public static final float READER_SCALE = SELECTOR_SCALE;
-
-    /** Taller unique radiation mesh on Panel1 bottom. */
-    public static final float RADIATION_SCALE = 0.10F;
-
-    /** 18×2×8 telepathic strip. */
-    public static final float TELEPATHIC_SCALE = 0.14F;
-
-    /** Cloak lever matches the materialisation lever scale. */
-    public static final float CLOAK_SCALE = LEVER_SCALE;
-
-    /** Wide flat door-lock panel. */
-    public static final float DOOR_LOCK_SCALE = 0.14F;
-
-    /** Wide 39px coordinate-lock instrument. */
-    public static final float COORDINATE_LOCK_SCALE = 0.11F;
-
-    /** Panel1 middle-row reader layout (deck-local X). */
-    public static final float OXYGEN_READER_MOUNT_X_PX = -3.75F;
-    public static final float PRESSURE_READER_MOUNT_X_PX = 0.0F;
-    public static final float TEMPERATURE_READER_MOUNT_X_PX = 3.75F;
-
-    /** Full selector footprint in selector-local pixels (14×2×14) before {@link #SELECTOR_SCALE}. */
     private static final float SEL_MIN_X = -7.0F;
     private static final float SEL_MIN_Y = 0.0F;
     private static final float SEL_MIN_Z = -7.0F;
@@ -157,10 +136,6 @@ public final class FirstDoctorConsoleControls {
     private static final float SEL_MAX_Y = 2.0F;
     private static final float SEL_MAX_Z = 7.0F;
 
-    /**
-     * Lever footprint in lever-local pixels before {@link #LEVER_SCALE}.
-     * Tight widget bounds (handle), not the decorative 18px base plate.
-     */
     private static final float LEV_MIN_X = -2.0F;
     private static final float LEV_MIN_Y = 0.0F;
     private static final float LEV_MIN_Z = -3.0F;
@@ -168,7 +143,6 @@ public final class FirstDoctorConsoleControls {
     private static final float LEV_MAX_Y = 8.0F;
     private static final float LEV_MAX_Z = 3.0F;
 
-    /** Fast-return footprint in switch-local pixels before {@link #FAST_RETURN_SCALE}. */
     private static final float FR_MIN_X = -2.5F;
     private static final float FR_MIN_Y = 0.0F;
     private static final float FR_MIN_Z = -3.0F;
@@ -176,10 +150,6 @@ public final class FirstDoctorConsoleControls {
     private static final float FR_MAX_Y = 3.6F;
     private static final float FR_MAX_Z = 3.0F;
 
-    /**
-     * Stabilisers footprint in control-local pixels before {@link #STABILISERS_SCALE}.
-     * Tight widget bounds, not the decorative 18px base plate.
-     */
     private static final float STAB_MIN_X = -4.0F;
     private static final float STAB_MIN_Y = 0.0F;
     private static final float STAB_MIN_Z = -4.0F;
@@ -187,7 +157,6 @@ public final class FirstDoctorConsoleControls {
     private static final float STAB_MAX_Y = 7.0F;
     private static final float STAB_MAX_Z = 4.0F;
 
-    /** Shared reader dial footprint (16×3×16) before {@link #READER_SCALE}. */
     private static final float RDR_MIN_X = -8.0F;
     private static final float RDR_MIN_Y = 0.0F;
     private static final float RDR_MIN_Z = -8.0F;
@@ -195,7 +164,6 @@ public final class FirstDoctorConsoleControls {
     private static final float RDR_MAX_Y = 3.0F;
     private static final float RDR_MAX_Z = 8.0F;
 
-    /** Radiation reader footprint before {@link #RADIATION_SCALE}. */
     private static final float RAD_MIN_X = -7.0F;
     private static final float RAD_MIN_Y = 0.0F;
     private static final float RAD_MIN_Z = -11.0F;
@@ -203,7 +171,6 @@ public final class FirstDoctorConsoleControls {
     private static final float RAD_MAX_Y = 6.0F;
     private static final float RAD_MAX_Z = 8.0F;
 
-    /** Telepathic strip footprint (18×2×8) before {@link #TELEPATHIC_SCALE}. */
     private static final float TEL_MIN_X = -9.0F;
     private static final float TEL_MIN_Y = 0.0F;
     private static final float TEL_MIN_Z = -4.0F;
@@ -211,7 +178,6 @@ public final class FirstDoctorConsoleControls {
     private static final float TEL_MAX_Y = 2.0F;
     private static final float TEL_MAX_Z = 4.0F;
 
-    /** Cloak lever footprint before {@link #CLOAK_SCALE}. */
     private static final float CLK_MIN_X = -2.0F;
     private static final float CLK_MIN_Y = 0.0F;
     private static final float CLK_MIN_Z = -3.0F;
@@ -219,7 +185,6 @@ public final class FirstDoctorConsoleControls {
     private static final float CLK_MAX_Y = 8.0F;
     private static final float CLK_MAX_Z = 3.0F;
 
-    /** Door lock footprint before {@link #DOOR_LOCK_SCALE}. */
     private static final float DLK_MIN_X = -11.0F;
     private static final float DLK_MIN_Y = 0.0F;
     private static final float DLK_MIN_Z = -6.0F;
@@ -227,7 +192,6 @@ public final class FirstDoctorConsoleControls {
     private static final float DLK_MAX_Y = 2.0F;
     private static final float DLK_MAX_Z = 8.0F;
 
-    /** Per-axis coordinate-lock pads on the wide instrument. */
     private static final float CLKX_MIN_X = 7.0F;
     private static final float CLKX_MAX_X = 14.0F;
     private static final float CLKY_MIN_X = 0.0F;
@@ -239,40 +203,11 @@ public final class FirstDoctorConsoleControls {
     private static final float CLKA_MIN_Z = -12.0F;
     private static final float CLKA_MAX_Z = -6.0F;
 
-    private record ControlLayout(
-            float panelYaw,
-            float scale,
-            float mountX,
-            float mountY,
-            float mountZ,
-            float minX,
-            float minY,
-            float minZ,
-            float maxX,
-            float maxY,
-            float maxZ
-    ) {
-    }
-
     private static final float Y_SCALE = 0.8F;
     private static final float PX = 1.0F / 16.0F;
     private static final double REACH = 5.0;
 
-    /** Panel3 dials resolved by look-ray (prefer closest on overlap). */
-    public enum Panel3Control {
-        BIOME,
-        WAYPOINT,
-        PLAYER,
-        PLANET
-    }
-
-    /** Panel6 controls resolved by look-ray (prefer closest on overlap). */
-    public enum Panel6Control {
-        CHAMELEON,
-        LEVER,
-        FAST_RETURN,
-        STABILISERS
-    }
+    private static final Map<LookTarget, ConsoleControlSpec> CATALOG = buildCatalog();
 
     /**
      * Unified look-ray target for console interaction (GUI / HUD). Prefer closest on overlap.
@@ -329,6 +264,19 @@ public final class FirstDoctorConsoleControls {
     private FirstDoctorConsoleControls() {
     }
 
+    /** Spec for {@code target}, or {@code null} for {@link LookTarget#NONE}. */
+    public static @Nullable ConsoleControlSpec spec(LookTarget target) {
+        if (target == null || target == LookTarget.NONE) {
+            return null;
+        }
+        return CATALOG.get(target);
+    }
+
+    /** All interactive control specs (excludes {@link LookTarget#NONE}). */
+    public static Collection<ConsoleControlSpec> specs() {
+        return Collections.unmodifiableCollection(CATALOG.values());
+    }
+
     /**
      * World-space interaction pose for {@code target} on a console at {@code pos}.
      * Returns {@code null} for {@link LookTarget#NONE}.
@@ -356,292 +304,7 @@ public final class FirstDoctorConsoleControls {
     }
 
     /**
-     * Block-local AABB of the biome selector for the given console facing
-     * (relative to the block's min corner).
-     */
-    public static AABB biomeSelectorBox(Direction facing) {
-        return selectorBox(facing, BIOME_SELECTOR_MOUNT_X_PX);
-    }
-
-    public static AABB biomeSelectorWorldBox(BlockPos pos, Direction facing) {
-        return biomeSelectorBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isBiomeSelectorHit(Direction facing, Vec3 blockLocalHit) {
-        return biomeSelectorBox(facing).contains(blockLocalHit);
-    }
-
-    public static boolean isBiomeSelectorHit(Direction facing, BlockPos pos, Vec3 worldHit) {
-        Vec3 local = worldHit.subtract(pos.getX(), pos.getY(), pos.getZ());
-        return isBiomeSelectorHit(facing, local);
-    }
-
-    /**
-     * True when the player's look ray intersects the biome-selector AABB.
-     * Prefer this over block-outline hit positions (those land on the coarse console box).
-     */
-    public static boolean isBiomeSelectorLookHit(Direction facing, BlockPos pos, Player player) {
-        Vec3 eye = player.getEyePosition();
-        Vec3 look = player.getViewVector(1.0F);
-        return isBiomeSelectorLookHit(facing, pos, eye, look, REACH);
-    }
-
-    public static boolean isBiomeSelectorLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(biomeSelectorWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB waypointSelectorBox(Direction facing) {
-        return selectorBox(facing, WAYPOINT_SELECTOR_MOUNT_X_PX);
-    }
-
-    public static AABB waypointSelectorWorldBox(BlockPos pos, Direction facing) {
-        return waypointSelectorBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isWaypointSelectorLookHit(Direction facing, BlockPos pos, Player player) {
-        return isWaypointSelectorLookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    public static boolean isWaypointSelectorLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(waypointSelectorWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB playerLocatorBox(Direction facing) {
-        return selectorBox(facing, PLAYER_LOCATOR_MOUNT_X_PX);
-    }
-
-    public static AABB playerLocatorWorldBox(BlockPos pos, Direction facing) {
-        return playerLocatorBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isPlayerLocatorLookHit(Direction facing, BlockPos pos, Player player) {
-        return isPlayerLocatorLookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    public static boolean isPlayerLocatorLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(playerLocatorWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB planetLocatorBox(Direction facing) {
-        return selectorBox(facing, PLANET_LOCATOR_MOUNT_X_PX);
-    }
-
-    public static AABB planetLocatorWorldBox(BlockPos pos, Direction facing) {
-        return planetLocatorBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isPlanetLocatorLookHit(Direction facing, BlockPos pos, Player player) {
-        Vec3 eye = player.getEyePosition();
-        Vec3 look = player.getViewVector(1.0F);
-        return isPlanetLocatorLookHit(facing, pos, eye, look, REACH);
-    }
-
-    public static boolean isPlanetLocatorLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(planetLocatorWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB chameleonCircuitBox(Direction facing) {
-        return controlBox(facing, PANEL6_YAW_RAD, SELECTOR_SCALE, CHAMELEON_CIRCUIT_MOUNT_X_PX,
-                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-    }
-
-    public static AABB chameleonCircuitWorldBox(BlockPos pos, Direction facing) {
-        return chameleonCircuitBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isChameleonCircuitLookHit(Direction facing, BlockPos pos, Player player) {
-        return isChameleonCircuitLookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    public static boolean isChameleonCircuitLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(chameleonCircuitWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB materialisationLeverBox(Direction facing) {
-        return controlBox(facing, PANEL6_YAW_RAD, LEVER_SCALE, LEVER_MOUNT_X_PX,
-                LEV_MIN_X, LEV_MIN_Y, LEV_MIN_Z, LEV_MAX_X, LEV_MAX_Y, LEV_MAX_Z);
-    }
-
-    public static AABB materialisationLeverWorldBox(BlockPos pos, Direction facing) {
-        return materialisationLeverBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isMaterialisationLeverLookHit(Direction facing, BlockPos pos, Player player) {
-        Vec3 eye = player.getEyePosition();
-        Vec3 look = player.getViewVector(1.0F);
-        return isMaterialisationLeverLookHit(facing, pos, eye, look, REACH);
-    }
-
-    public static boolean isMaterialisationLeverLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(materialisationLeverWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB fastReturnBox(Direction facing) {
-        return controlBox(facing, PANEL6_YAW_RAD, FAST_RETURN_SCALE, FAST_RETURN_MOUNT_X_PX,
-                FR_MIN_X, FR_MIN_Y, FR_MIN_Z, FR_MAX_X, FR_MAX_Y, FR_MAX_Z);
-    }
-
-    public static AABB fastReturnWorldBox(BlockPos pos, Direction facing) {
-        return fastReturnBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isFastReturnLookHit(Direction facing, BlockPos pos, Player player) {
-        return isFastReturnLookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    public static boolean isFastReturnLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(fastReturnWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    public static AABB stabilisersBox(Direction facing) {
-        return controlBox(
-                facing,
-                PANEL6_YAW_RAD,
-                STABILISERS_SCALE,
-                STABILISERS_MOUNT_X_PX,
-                STABILISERS_MOUNT_Y_PX,
-                STABILISERS_MOUNT_Z_PX,
-                STAB_MIN_X,
-                STAB_MIN_Y,
-                STAB_MIN_Z,
-                STAB_MAX_X,
-                STAB_MAX_Y,
-                STAB_MAX_Z
-        );
-    }
-
-    public static AABB stabilisersWorldBox(BlockPos pos, Direction facing) {
-        return stabilisersBox(facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    public static boolean isStabilisersLookHit(Direction facing, BlockPos pos, Player player) {
-        return isStabilisersLookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    public static boolean isStabilisersLookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        return lookHitsBox(stabilisersWorldBox(pos, facing), eyePos, lookDir, reach);
-    }
-
-    /**
-     * When multiple Panel3 dials are along the look ray, returns the closest hit.
-     * Ties (coplanar dial tops) break toward the AABB whose center is nearest the eye in XZ.
-     * Returns {@code null} when none are hit.
-     */
-    public static @Nullable Panel3Control resolvePanel3LookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        Panel3Control best = null;
-        double bestDist = Double.POSITIVE_INFINITY;
-        double bestHoriz = Double.POSITIVE_INFINITY;
-        for (Panel3Control control : Panel3Control.values()) {
-            AABB box = panel3WorldBox(control, pos, facing);
-            double dist = lookHitDistance(box, eyePos, lookDir, reach);
-            if (dist < 0.0) {
-                continue;
-            }
-            Vec3 center = box.getCenter();
-            double horiz = horizontalDistanceSq(eyePos, center);
-            if (dist < bestDist || (dist == bestDist && horiz < bestHoriz)) {
-                bestDist = dist;
-                bestHoriz = horiz;
-                best = control;
-            }
-        }
-        return best;
-    }
-
-    public static @Nullable Panel3Control resolvePanel3LookHit(Direction facing, BlockPos pos, Player player) {
-        return resolvePanel3LookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    /**
-     * When Panel6 control rays overlap, returns the closer control.
-     * Returns {@code null} when none are hit.
-     */
-    public static @Nullable Panel6Control resolvePanel6LookHit(
-            Direction facing,
-            BlockPos pos,
-            Vec3 eyePos,
-            Vec3 lookDir,
-            double reach
-    ) {
-        Panel6Control best = null;
-        double bestDist = Double.POSITIVE_INFINITY;
-        double bestHoriz = Double.POSITIVE_INFINITY;
-        for (Panel6Control control : Panel6Control.values()) {
-            AABB box = panel6WorldBox(control, pos, facing);
-            double dist = lookHitDistance(box, eyePos, lookDir, reach);
-            if (dist < 0.0) {
-                continue;
-            }
-            double horiz = horizontalDistanceSq(eyePos, box.getCenter());
-            if (dist < bestDist || (dist == bestDist && horiz < bestHoriz)) {
-                bestDist = dist;
-                bestHoriz = horiz;
-                best = control;
-            }
-        }
-        return best;
-    }
-
-    public static @Nullable Panel6Control resolvePanel6LookHit(Direction facing, BlockPos pos, Player player) {
-        return resolvePanel6LookHit(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
-    }
-
-    /**
-     * Resolves the closest console control along the player's look ray across Panel3 and Panel6.
+     * Resolves the closest console control along the player's look ray.
      * Returns {@link LookTarget#NONE} when nothing is hit.
      */
     public static LookTarget resolveLookTarget(Direction facing, BlockPos pos, Player player) {
@@ -658,10 +321,7 @@ public final class FirstDoctorConsoleControls {
         LookTarget best = LookTarget.NONE;
         double bestDist = Double.POSITIVE_INFINITY;
         double bestHoriz = Double.POSITIVE_INFINITY;
-        for (LookTarget candidate : LookTarget.values()) {
-            if (candidate == LookTarget.NONE) {
-                continue;
-            }
+        for (LookTarget candidate : LookTarget.interactiveValues()) {
             AABB box = worldBoxFor(candidate, pos, facing);
             double dist = lookHitDistance(box, eyePos, lookDir, reach);
             if (dist < 0.0) {
@@ -675,107 +335,6 @@ public final class FirstDoctorConsoleControls {
             }
         }
         return best;
-    }
-
-    private static AABB worldBoxFor(LookTarget target, BlockPos pos, Direction facing) {
-        return unpaddedBoxFor(target, facing).move(pos.getX(), pos.getY(), pos.getZ());
-    }
-
-    private static AABB unpaddedBoxFor(LookTarget target, Direction facing) {
-        if (target == LookTarget.NONE) {
-            return new AABB(0, 0, 0, 0, 0, 0);
-        }
-        ControlLayout layout = layout(target);
-        return controlBox(
-                facing,
-                layout.panelYaw,
-                layout.scale,
-                layout.mountX,
-                layout.mountY,
-                layout.mountZ,
-                layout.minX,
-                layout.minY,
-                layout.minZ,
-                layout.maxX,
-                layout.maxY,
-                layout.maxZ
-        );
-    }
-
-    private static ControlLayout layout(LookTarget target) {
-        return switch (target) {
-            case BIOME_SELECTOR -> middle(PANEL3_YAW_RAD, SELECTOR_SCALE, BIOME_SELECTOR_MOUNT_X_PX,
-                    SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-            case WAYPOINT_SELECTOR -> middle(PANEL3_YAW_RAD, SELECTOR_SCALE, WAYPOINT_SELECTOR_MOUNT_X_PX,
-                    SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-            case PLAYER_LOCATOR -> middle(PANEL3_YAW_RAD, SELECTOR_SCALE, PLAYER_LOCATOR_MOUNT_X_PX,
-                    SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-            case PLANET_LOCATOR -> middle(PANEL3_YAW_RAD, SELECTOR_SCALE, PLANET_LOCATOR_MOUNT_X_PX,
-                    SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-            case CHAMELEON_CIRCUIT -> middle(PANEL6_YAW_RAD, SELECTOR_SCALE, CHAMELEON_CIRCUIT_MOUNT_X_PX,
-                    SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-            case MATERIALISATION_LEVER -> middle(PANEL6_YAW_RAD, LEVER_SCALE, LEVER_MOUNT_X_PX,
-                    LEV_MIN_X, LEV_MIN_Y, LEV_MIN_Z, LEV_MAX_X, LEV_MAX_Y, LEV_MAX_Z);
-            case FAST_RETURN -> middle(PANEL6_YAW_RAD, FAST_RETURN_SCALE, FAST_RETURN_MOUNT_X_PX,
-                    FR_MIN_X, FR_MIN_Y, FR_MIN_Z, FR_MAX_X, FR_MAX_Y, FR_MAX_Z);
-            case STABILISERS -> bottom(PANEL6_YAW_RAD, STABILISERS_SCALE, STABILISERS_MOUNT_X_PX,
-                    STAB_MIN_X, STAB_MIN_Y, STAB_MIN_Z, STAB_MAX_X, STAB_MAX_Y, STAB_MAX_Z);
-            case OXYGEN_READER -> middle(PANEL1_YAW_RAD, READER_SCALE, OXYGEN_READER_MOUNT_X_PX,
-                    RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z);
-            case PRESSURE_READER -> middle(PANEL1_YAW_RAD, READER_SCALE, PRESSURE_READER_MOUNT_X_PX,
-                    RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z);
-            case TEMPERATURE_READER -> middle(PANEL1_YAW_RAD, READER_SCALE, TEMPERATURE_READER_MOUNT_X_PX,
-                    RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z);
-            case RADIATION_READER -> bottom(PANEL1_YAW_RAD, RADIATION_SCALE, 0.0F,
-                    RAD_MIN_X, RAD_MIN_Y, RAD_MIN_Z, RAD_MAX_X, RAD_MAX_Y, RAD_MAX_Z);
-            case REFUELER -> middle(PANEL5_YAW_RAD, READER_SCALE, 0.0F,
-                    RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z);
-            case TELEPATHIC_CIRCUIT -> middle(PANEL2_YAW_RAD, TELEPATHIC_SCALE, 0.0F,
-                    TEL_MIN_X, TEL_MIN_Y, TEL_MIN_Z, TEL_MAX_X, TEL_MAX_Y, TEL_MAX_Z);
-            case CLOAK -> middle(PANEL4_YAW_RAD, CLOAK_SCALE, 0.0F,
-                    CLK_MIN_X, CLK_MIN_Y, CLK_MIN_Z, CLK_MAX_X, CLK_MAX_Y, CLK_MAX_Z);
-            case DOOR_LOCK -> bottom(PANEL4_YAW_RAD, DOOR_LOCK_SCALE, 0.0F,
-                    DLK_MIN_X, DLK_MIN_Y, DLK_MIN_Z, DLK_MAX_X, DLK_MAX_Y, DLK_MAX_Z);
-            case COORDINATE_LOCK_X -> bottom(PANEL3_YAW_RAD, COORDINATE_LOCK_SCALE, 0.0F,
-                    CLKX_MIN_X, CLKA_MIN_Y, CLKA_MIN_Z, CLKX_MAX_X, CLKA_MAX_Y, CLKA_MAX_Z);
-            case COORDINATE_LOCK_Y -> bottom(PANEL3_YAW_RAD, COORDINATE_LOCK_SCALE, 0.0F,
-                    CLKY_MIN_X, CLKA_MIN_Y, CLKA_MIN_Z, CLKY_MAX_X, CLKA_MAX_Y, CLKA_MAX_Z);
-            case COORDINATE_LOCK_Z -> bottom(PANEL3_YAW_RAD, COORDINATE_LOCK_SCALE, 0.0F,
-                    CLKZ_MIN_X, CLKA_MIN_Y, CLKA_MIN_Z, CLKZ_MAX_X, CLKA_MAX_Y, CLKA_MAX_Z);
-            case NONE -> new ControlLayout(0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0);
-        };
-    }
-
-    private static ControlLayout middle(
-            float yaw,
-            float scale,
-            float mountX,
-            float minX,
-            float minY,
-            float minZ,
-            float maxX,
-            float maxY,
-            float maxZ
-    ) {
-        return new ControlLayout(
-                yaw, scale, mountX, CONTROL_MOUNT_Y_PX, CONTROL_MOUNT_Z_PX,
-                minX, minY, minZ, maxX, maxY, maxZ);
-    }
-
-    private static ControlLayout bottom(
-            float yaw,
-            float scale,
-            float mountX,
-            float minX,
-            float minY,
-            float minZ,
-            float maxX,
-            float maxY,
-            float maxZ
-    ) {
-        return new ControlLayout(
-                yaw, scale, mountX, BOTTOM_MOUNT_Y_PX, BOTTOM_MOUNT_Z_PX,
-                minX, minY, minZ, maxX, maxY, maxZ);
     }
 
     public static AABB boxFor(LookTarget target, Direction facing) {
@@ -793,103 +352,120 @@ public final class FirstDoctorConsoleControls {
     }
 
     /**
-     * When biome and planet rays both hit, returns {@code true} if the biome AABB is closer.
-     * Prefer {@link #resolveLookTarget} for new callers.
+     * True when the look ray intersects {@code target}'s world AABB.
+     * Intended for tests and tooling.
      */
-    public static boolean preferBiomeOverPlanet(
+    public static boolean lookHits(
+            LookTarget target,
             Direction facing,
             BlockPos pos,
             Vec3 eyePos,
             Vec3 lookDir,
             double reach
     ) {
-        double biomeDist = lookHitDistance(biomeSelectorWorldBox(pos, facing), eyePos, lookDir, reach);
-        double planetDist = lookHitDistance(planetLocatorWorldBox(pos, facing), eyePos, lookDir, reach);
-        if (biomeDist < 0) {
+        if (target == LookTarget.NONE) {
             return false;
         }
-        if (planetDist < 0) {
-            return true;
+        return lookHitsBox(worldBoxFor(target, pos, facing), eyePos, lookDir, reach);
+    }
+
+    private static AABB worldBoxFor(LookTarget target, BlockPos pos, Direction facing) {
+        return unpaddedBoxFor(target, facing).move(pos.getX(), pos.getY(), pos.getZ());
+    }
+
+    private static AABB unpaddedBoxFor(LookTarget target, Direction facing) {
+        ConsoleControlSpec layout = spec(target);
+        if (layout == null) {
+            return new AABB(0, 0, 0, 0, 0, 0);
         }
-        return biomeDist <= planetDist;
+        return controlBox(facing, layout);
     }
 
-    public static boolean preferBiomeOverPlanet(Direction facing, BlockPos pos, Player player) {
-        return preferBiomeOverPlanet(facing, pos, player.getEyePosition(), player.getViewVector(1.0F), REACH);
+    private static Map<LookTarget, ConsoleControlSpec> buildCatalog() {
+        EnumMap<LookTarget, ConsoleControlSpec> map = new EnumMap<>(LookTarget.class);
+        put(map, middle(LookTarget.BIOME_SELECTOR, PANEL3_YAW_RAD, SELECTOR_SCALE, BIOME_SELECTOR_MOUNT_X_PX,
+                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z));
+        put(map, middle(LookTarget.WAYPOINT_SELECTOR, PANEL3_YAW_RAD, SELECTOR_SCALE, WAYPOINT_SELECTOR_MOUNT_X_PX,
+                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z));
+        put(map, middle(LookTarget.PLAYER_LOCATOR, PANEL3_YAW_RAD, SELECTOR_SCALE, PLAYER_LOCATOR_MOUNT_X_PX,
+                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z));
+        put(map, middle(LookTarget.PLANET_LOCATOR, PANEL3_YAW_RAD, SELECTOR_SCALE, PLANET_LOCATOR_MOUNT_X_PX,
+                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z));
+        put(map, middle(LookTarget.CHAMELEON_CIRCUIT, PANEL6_YAW_RAD, SELECTOR_SCALE, CHAMELEON_CIRCUIT_MOUNT_X_PX,
+                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z));
+        put(map, middle(LookTarget.MATERIALISATION_LEVER, PANEL6_YAW_RAD, LEVER_SCALE, LEVER_MOUNT_X_PX,
+                LEV_MIN_X, LEV_MIN_Y, LEV_MIN_Z, LEV_MAX_X, LEV_MAX_Y, LEV_MAX_Z));
+        put(map, middle(LookTarget.FAST_RETURN, PANEL6_YAW_RAD, FAST_RETURN_SCALE, FAST_RETURN_MOUNT_X_PX,
+                FR_MIN_X, FR_MIN_Y, FR_MIN_Z, FR_MAX_X, FR_MAX_Y, FR_MAX_Z));
+        put(map, bottom(LookTarget.STABILISERS, PANEL6_YAW_RAD, STABILISERS_SCALE, STABILISERS_MOUNT_X_PX,
+                STAB_MIN_X, STAB_MIN_Y, STAB_MIN_Z, STAB_MAX_X, STAB_MAX_Y, STAB_MAX_Z));
+        put(map, middle(LookTarget.OXYGEN_READER, PANEL1_YAW_RAD, READER_SCALE, OXYGEN_READER_MOUNT_X_PX,
+                RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z));
+        put(map, middle(LookTarget.PRESSURE_READER, PANEL1_YAW_RAD, READER_SCALE, PRESSURE_READER_MOUNT_X_PX,
+                RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z));
+        put(map, middle(LookTarget.TEMPERATURE_READER, PANEL1_YAW_RAD, READER_SCALE, TEMPERATURE_READER_MOUNT_X_PX,
+                RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z));
+        put(map, bottom(LookTarget.RADIATION_READER, PANEL1_YAW_RAD, RADIATION_SCALE, 0.0F,
+                RAD_MIN_X, RAD_MIN_Y, RAD_MIN_Z, RAD_MAX_X, RAD_MAX_Y, RAD_MAX_Z));
+        put(map, middle(LookTarget.REFUELER, PANEL5_YAW_RAD, READER_SCALE, 0.0F,
+                RDR_MIN_X, RDR_MIN_Y, RDR_MIN_Z, RDR_MAX_X, RDR_MAX_Y, RDR_MAX_Z));
+        put(map, middle(LookTarget.TELEPATHIC_CIRCUIT, PANEL2_YAW_RAD, TELEPATHIC_SCALE, 0.0F,
+                TEL_MIN_X, TEL_MIN_Y, TEL_MIN_Z, TEL_MAX_X, TEL_MAX_Y, TEL_MAX_Z));
+        put(map, middle(LookTarget.CLOAK, PANEL4_YAW_RAD, CLOAK_SCALE, 0.0F,
+                CLK_MIN_X, CLK_MIN_Y, CLK_MIN_Z, CLK_MAX_X, CLK_MAX_Y, CLK_MAX_Z));
+        put(map, bottom(LookTarget.DOOR_LOCK, PANEL4_YAW_RAD, DOOR_LOCK_SCALE, 0.0F,
+                DLK_MIN_X, DLK_MIN_Y, DLK_MIN_Z, DLK_MAX_X, DLK_MAX_Y, DLK_MAX_Z));
+        put(map, bottom(LookTarget.COORDINATE_LOCK_X, PANEL3_YAW_RAD, COORDINATE_LOCK_SCALE, 0.0F,
+                CLKX_MIN_X, CLKA_MIN_Y, CLKA_MIN_Z, CLKX_MAX_X, CLKA_MAX_Y, CLKA_MAX_Z));
+        put(map, bottom(LookTarget.COORDINATE_LOCK_Y, PANEL3_YAW_RAD, COORDINATE_LOCK_SCALE, 0.0F,
+                CLKY_MIN_X, CLKA_MIN_Y, CLKA_MIN_Z, CLKY_MAX_X, CLKA_MAX_Y, CLKA_MAX_Z));
+        put(map, bottom(LookTarget.COORDINATE_LOCK_Z, PANEL3_YAW_RAD, COORDINATE_LOCK_SCALE, 0.0F,
+                CLKZ_MIN_X, CLKA_MIN_Y, CLKA_MIN_Z, CLKZ_MAX_X, CLKA_MAX_Y, CLKA_MAX_Z));
+
+        for (LookTarget target : LookTarget.interactiveValues()) {
+            if (!map.containsKey(target)) {
+                throw new IllegalStateException("Missing ConsoleControlSpec for " + target);
+            }
+        }
+        return Map.copyOf(map);
     }
 
-    /**
-     * Transforms a point in biome-selector-local model pixels into block-local space (Panel3).
-     */
-    static Vec3 selectorLocalToBlockLocal(double px, double py, double pz, Direction facing) {
-        return controlLocalToBlockLocal(px, py, pz, facing, PANEL3_YAW_RAD, SELECTOR_SCALE, BIOME_SELECTOR_MOUNT_X_PX);
+    private static void put(EnumMap<LookTarget, ConsoleControlSpec> map, ConsoleControlSpec spec) {
+        map.put(spec.target(), spec);
     }
 
-    /**
-     * Transforms a point in planet-locator-local model pixels into block-local space (Panel3).
-     */
-    static Vec3 planetLocatorLocalToBlockLocal(double px, double py, double pz, Direction facing) {
-        return controlLocalToBlockLocal(px, py, pz, facing, PANEL3_YAW_RAD, SELECTOR_SCALE, PLANET_LOCATOR_MOUNT_X_PX);
+    private static ConsoleControlSpec middle(
+            LookTarget target,
+            float yaw,
+            float scale,
+            float mountX,
+            float minX,
+            float minY,
+            float minZ,
+            float maxX,
+            float maxY,
+            float maxZ
+    ) {
+        return new ConsoleControlSpec(
+                target, yaw, scale, mountX, CONTROL_MOUNT_Y_PX, CONTROL_MOUNT_Z_PX,
+                minX, minY, minZ, maxX, maxY, maxZ);
     }
 
-    /**
-     * Transforms a point in lever-local model pixels into block-local space (Panel6).
-     */
-    static Vec3 leverLocalToBlockLocal(double px, double py, double pz, Direction facing) {
-        return controlLocalToBlockLocal(px, py, pz, facing, PANEL6_YAW_RAD, LEVER_SCALE, LEVER_MOUNT_X_PX);
-    }
-
-    /** Horizontal distance from block center to biome selector center (for tests / tuning). */
-    public static double selectorDistanceFromCenter(Direction facing) {
-        Vec3 c = biomeSelectorBox(facing).getCenter();
-        return Math.hypot(c.x - 0.5, c.z - 0.5);
-    }
-
-    /** Horizontal distance from block center to planet locator center (for tests / tuning). */
-    public static double planetLocatorDistanceFromCenter(Direction facing) {
-        Vec3 c = planetLocatorBox(facing).getCenter();
-        return Math.hypot(c.x - 0.5, c.z - 0.5);
-    }
-
-    /** Horizontal distance from block center to lever center (for tests / tuning). */
-    public static double leverDistanceFromCenter(Direction facing) {
-        Vec3 c = materialisationLeverBox(facing).getCenter();
-        return Math.hypot(c.x - 0.5, c.z - 0.5);
-    }
-
-    /** Horizontal distance from block center to fast-return switch center (for tests / tuning). */
-    public static double fastReturnDistanceFromCenter(Direction facing) {
-        Vec3 c = fastReturnBox(facing).getCenter();
-        return Math.hypot(c.x - 0.5, c.z - 0.5);
-    }
-
-    /** Horizontal distance from block center to stabilisers control center (for tests / tuning). */
-    public static double stabilisersDistanceFromCenter(Direction facing) {
-        Vec3 c = stabilisersBox(facing).getCenter();
-        return Math.hypot(c.x - 0.5, c.z - 0.5);
-    }
-
-    private static AABB selectorBox(Direction facing, float mountXPx) {
-        return controlBox(facing, PANEL3_YAW_RAD, SELECTOR_SCALE, mountXPx,
-                SEL_MIN_X, SEL_MIN_Y, SEL_MIN_Z, SEL_MAX_X, SEL_MAX_Y, SEL_MAX_Z);
-    }
-
-    private static AABB panel3WorldBox(Panel3Control control, BlockPos pos, Direction facing) {
-        return switch (control) {
-            case BIOME -> biomeSelectorWorldBox(pos, facing);
-            case WAYPOINT -> waypointSelectorWorldBox(pos, facing);
-            case PLAYER -> playerLocatorWorldBox(pos, facing);
-            case PLANET -> planetLocatorWorldBox(pos, facing);
-        };
-    }
-
-    private static AABB panel6WorldBox(Panel6Control control, BlockPos pos, Direction facing) {
-        return switch (control) {
-            case CHAMELEON -> chameleonCircuitWorldBox(pos, facing);
-            case LEVER -> materialisationLeverWorldBox(pos, facing);
-            case FAST_RETURN -> fastReturnWorldBox(pos, facing);
-            case STABILISERS -> stabilisersWorldBox(pos, facing);
-        };
+    private static ConsoleControlSpec bottom(
+            LookTarget target,
+            float yaw,
+            float scale,
+            float mountX,
+            float minX,
+            float minY,
+            float minZ,
+            float maxX,
+            float maxY,
+            float maxZ
+    ) {
+        return new ConsoleControlSpec(
+                target, yaw, scale, mountX, BOTTOM_MOUNT_Y_PX, BOTTOM_MOUNT_Z_PX,
+                minX, minY, minZ, maxX, maxY, maxZ);
     }
 
     private static boolean lookHitsBox(AABB box, Vec3 eyePos, Vec3 lookDir, double reach) {
@@ -910,48 +486,7 @@ public final class FirstDoctorConsoleControls {
         return dx * dx + dz * dz;
     }
 
-    private static AABB controlBox(
-            Direction facing,
-            float panelYawRad,
-            float scale,
-            float mountXPx,
-            float minX,
-            float minY,
-            float minZ,
-            float maxX,
-            float maxY,
-            float maxZ
-    ) {
-        return controlBox(
-                facing,
-                panelYawRad,
-                scale,
-                mountXPx,
-                CONTROL_MOUNT_Y_PX,
-                CONTROL_MOUNT_Z_PX,
-                minX,
-                minY,
-                minZ,
-                maxX,
-                maxY,
-                maxZ
-        );
-    }
-
-    private static AABB controlBox(
-            Direction facing,
-            float panelYawRad,
-            float scale,
-            float mountXPx,
-            float mountYPx,
-            float mountZPx,
-            float minX,
-            float minY,
-            float minZ,
-            float maxX,
-            float maxY,
-            float maxZ
-    ) {
+    private static AABB controlBox(Direction facing, ConsoleControlSpec layout) {
         double outMinX = Double.POSITIVE_INFINITY;
         double outMinY = Double.POSITIVE_INFINITY;
         double outMinZ = Double.POSITIVE_INFINITY;
@@ -959,14 +494,13 @@ public final class FirstDoctorConsoleControls {
         double outMaxY = Double.NEGATIVE_INFINITY;
         double outMaxZ = Double.NEGATIVE_INFINITY;
 
-        float[] xs = {minX, maxX};
-        float[] ys = {minY, maxY};
-        float[] zs = {minZ, maxZ};
+        float[] xs = {layout.minX(), layout.maxX()};
+        float[] ys = {layout.minY(), layout.maxY()};
+        float[] zs = {layout.minZ(), layout.maxZ()};
         for (float x : xs) {
             for (float y : ys) {
                 for (float z : zs) {
-                    Vec3 p = controlLocalToBlockLocal(
-                            x, y, z, facing, panelYawRad, scale, mountXPx, mountYPx, mountZPx);
+                    Vec3 p = controlLocalToBlockLocal(x, y, z, facing, layout);
                     outMinX = Math.min(outMinX, p.x);
                     outMinY = Math.min(outMinY, p.y);
                     outMinZ = Math.min(outMinZ, p.z);
@@ -976,11 +510,7 @@ public final class FirstDoctorConsoleControls {
                 }
             }
         }
-        final double pad = 0.0;
-        return new AABB(
-                outMinX - pad, outMinY - pad, outMinZ - pad,
-                outMaxX + pad, outMaxY + pad, outMaxZ + pad
-        );
+        return new AABB(outMinX, outMinY, outMinZ, outMaxX, outMaxY, outMaxZ);
     }
 
     static Vec3 controlLocalToBlockLocal(
@@ -988,12 +518,19 @@ public final class FirstDoctorConsoleControls {
             double py,
             double pz,
             Direction facing,
-            float panelYawRad,
-            float scale,
-            float mountXPx
+            ConsoleControlSpec layout
     ) {
         return controlLocalToBlockLocal(
-                px, py, pz, facing, panelYawRad, scale, mountXPx, CONTROL_MOUNT_Y_PX, CONTROL_MOUNT_Z_PX);
+                px,
+                py,
+                pz,
+                facing,
+                layout.panelYaw(),
+                layout.scale(),
+                layout.mountX(),
+                layout.mountY(),
+                layout.mountZ()
+        );
     }
 
     static Vec3 controlLocalToBlockLocal(

--- a/src/main/java/com/adamkali/dwm/block/entities/FirstDoctorConsoleBlockEntity.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/FirstDoctorConsoleBlockEntity.java
@@ -6,15 +6,15 @@ import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
 import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
 import com.adamkali.dwm.entity.DWMEntityTypes;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
-import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
-import com.adamkali.dwm.tardis.logic.CoordinateLockLogic;
+import com.adamkali.dwm.tardis.logic.ConsoleDisplayState;
 import com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout;
 import com.adamkali.dwm.tardis.logic.TardisTravelService;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.EnumMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
@@ -37,9 +37,8 @@ import net.minecraft.world.level.storage.ValueOutput;
 import net.minecraft.world.phys.AABB;
 
 /**
- * Block entity for the First Doctor console. Holds {@code tardisId} for control interactions,
- * a synced chameleon variant for the Panel6 hologram preview, and synced console instruments
- * (stabilisers, cloak, door lock, coordinate locks, exterior environment readings).
+ * Block entity for the First Doctor console. Holds {@code tardisId} for control interactions
+ * and a synced {@link ConsoleDisplayState} for client instruments / HUD / BER.
  * Server tick maintains one {@link ConsoleControlInteractionEntity} per control.
  */
 public class FirstDoctorConsoleBlockEntity extends BlockEntity {
@@ -49,18 +48,7 @@ public class FirstDoctorConsoleBlockEntity extends BlockEntity {
     private static final int READOUT_INTERVAL_TICKS = 20;
 
     private @Nullable UUID tardisId;
-    private TardisChameleonVariant syncedVariant = TardisChameleonVariant.TT_CAPSULE;
-    private boolean syncedStabilisersEnabled = true;
-    private boolean syncedCloaked;
-    private boolean syncedDoorsLocked;
-    private boolean syncedLockX;
-    private boolean syncedLockY;
-    private boolean syncedLockZ;
-    private boolean syncedNoSignal = true;
-    private float syncedOxygen;
-    private float syncedPressure;
-    private float syncedTemperature;
-    private float syncedRadiation;
+    private ConsoleDisplayState synced = ConsoleDisplayState.defaults();
 
     public FirstDoctorConsoleBlockEntity(BlockPos pos, BlockState state) {
         super(DWMBlockEntities.FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY, pos, state);
@@ -141,150 +129,41 @@ public class FirstDoctorConsoleBlockEntity extends BlockEntity {
         return tardisId;
     }
 
-    public TardisChameleonVariant getSyncedVariant() {
-        return syncedVariant == null ? TardisChameleonVariant.TT_CAPSULE : syncedVariant;
+    public ConsoleDisplayState syncedDisplay() {
+        return synced;
     }
 
     /**
-     * Updates the hologram variant and notifies tracking clients when on the server.
+     * Replaces the synced display snapshot and notifies tracking clients when on the server.
+     * No-ops when the snapshot is equal to the current value.
      */
-    public void setSyncedVariant(@Nullable TardisChameleonVariant variant) {
-        this.syncedVariant = variant == null ? TardisChameleonVariant.TT_CAPSULE : variant;
-        setChanged();
-        notifyClients();
-    }
-
-    public boolean isSyncedStabilisersEnabled() {
-        return syncedStabilisersEnabled;
-    }
-
-    /**
-     * Updates the stabilisers dial pose and notifies tracking clients when on the server.
-     */
-    public void setSyncedStabilisersEnabled(boolean enabled) {
-        this.syncedStabilisersEnabled = enabled;
-        setChanged();
-        notifyClients();
-    }
-
-    public boolean isSyncedCloaked() {
-        return syncedCloaked;
-    }
-
-    public void setSyncedCloaked(boolean cloaked) {
-        this.syncedCloaked = cloaked;
-        setChanged();
-        notifyClients();
-    }
-
-    public boolean isSyncedDoorsLocked() {
-        return syncedDoorsLocked;
-    }
-
-    public void setSyncedDoorsLocked(boolean locked) {
-        this.syncedDoorsLocked = locked;
-        setChanged();
-        notifyClients();
-    }
-
-    public boolean isSyncedLockX() {
-        return syncedLockX;
-    }
-
-    public boolean isSyncedLockY() {
-        return syncedLockY;
-    }
-
-    public boolean isSyncedLockZ() {
-        return syncedLockZ;
-    }
-
-    public void setSyncedAxisLock(CoordinateLockLogic.Axis axis, boolean locked) {
-        switch (axis) {
-            case X -> syncedLockX = locked;
-            case Y -> syncedLockY = locked;
-            case Z -> syncedLockZ = locked;
-        }
-        setChanged();
-        notifyClients();
-    }
-
-    public void setSyncedCoordinateLocks(boolean lockX, boolean lockY, boolean lockZ) {
-        this.syncedLockX = lockX;
-        this.syncedLockY = lockY;
-        this.syncedLockZ = lockZ;
-        setChanged();
-        notifyClients();
-    }
-
-    public ExteriorEnvironmentReadout.Reading syncedReading() {
-        if (syncedNoSignal) {
-            return ExteriorEnvironmentReadout.Reading.none();
-        }
-        return new ExteriorEnvironmentReadout.Reading(
-                false, syncedOxygen, syncedPressure, syncedTemperature, syncedRadiation);
-    }
-
-    public void setSyncedReading(ExteriorEnvironmentReadout.Reading reading) {
-        boolean noSignal = reading == null || reading.noSignal();
-        float oxygen = noSignal ? 0.0F : reading.oxygen();
-        float pressure = noSignal ? 0.0F : reading.pressure();
-        float temperature = noSignal ? 0.0F : reading.temperature();
-        float radiation = noSignal ? 0.0F : reading.radiation();
-        if (this.syncedNoSignal == noSignal
-                && this.syncedOxygen == oxygen
-                && this.syncedPressure == pressure
-                && this.syncedTemperature == temperature
-                && this.syncedRadiation == radiation) {
+    public void setSyncedDisplay(ConsoleDisplayState next) {
+        ConsoleDisplayState safe = next == null ? ConsoleDisplayState.defaults() : next;
+        if (Objects.equals(this.synced, safe)) {
             return;
         }
-        this.syncedNoSignal = noSignal;
-        this.syncedOxygen = oxygen;
-        this.syncedPressure = pressure;
-        this.syncedTemperature = temperature;
-        this.syncedRadiation = radiation;
+        this.synced = safe;
         setChanged();
         notifyClients();
     }
 
     private void refreshLinkedState(ServerLevel interiorWorld) {
-        refreshSecurityState();
-        refreshEnvironmentReadout(interiorWorld);
+        TardisDataModel model = tardisId == null ? null : TardisDataLoader.get(tardisId);
+        ExteriorEnvironmentReadout.Reading reading = sampleReading(interiorWorld, model);
+        setSyncedDisplay(ConsoleDisplayState.from(model, reading));
     }
 
-    private void refreshSecurityState() {
-        if (tardisId == null) {
-            return;
-        }
-        TardisDataModel model = TardisDataLoader.get(tardisId);
-        if (model == null) {
-            return;
-        }
-        if (syncedCloaked != model.cloaked) {
-            setSyncedCloaked(model.cloaked);
-        }
-        if (syncedDoorsLocked != model.doorsLocked) {
-            setSyncedDoorsLocked(model.doorsLocked);
-        }
-        if (syncedLockX != model.lockX || syncedLockY != model.lockY || syncedLockZ != model.lockZ) {
-            setSyncedCoordinateLocks(model.lockX, model.lockY, model.lockZ);
-        }
-    }
-
-    private void refreshEnvironmentReadout(ServerLevel interiorWorld) {
-        if (tardisId == null) {
-            setSyncedReading(ExteriorEnvironmentReadout.Reading.none());
-            return;
-        }
-        TardisDataModel model = TardisDataLoader.get(tardisId);
-        if (model == null || !model.hasExteriorLocation || model.exteriorDimension == null) {
-            setSyncedReading(ExteriorEnvironmentReadout.Reading.none());
-            return;
+    private ExteriorEnvironmentReadout.Reading sampleReading(
+            ServerLevel interiorWorld,
+            @Nullable TardisDataModel model
+    ) {
+        if (tardisId == null || model == null || !model.hasExteriorLocation || model.exteriorDimension == null) {
+            return ExteriorEnvironmentReadout.Reading.none();
         }
         boolean inFlight = TardisTravelService.isTraveling(tardisId);
         ServerLevel exterior = resolveExterior(interiorWorld, model.exteriorDimension);
         BlockPos exteriorPos = new BlockPos(model.exteriorX, model.exteriorY, model.exteriorZ);
-        setSyncedReading(ExteriorEnvironmentReadout.sample(exterior, exteriorPos, inFlight));
+        return ExteriorEnvironmentReadout.sample(exterior, exteriorPos, inFlight);
     }
 
     private static @Nullable ServerLevel resolveExterior(ServerLevel interiorWorld, String dimensionId) {
@@ -320,51 +199,14 @@ public class FirstDoctorConsoleBlockEntity extends BlockEntity {
         if (tardisId != null) {
             output.store("tardisId", UUIDUtil.CODEC, tardisId);
         }
-        output.putString("syncedVariant", getSyncedVariant().getId().toString());
-        output.putBoolean("syncedStabilisersEnabled", syncedStabilisersEnabled);
-        output.putBoolean("syncedCloaked", syncedCloaked);
-        output.putBoolean("syncedDoorsLocked", syncedDoorsLocked);
-        output.putBoolean("syncedLockX", syncedLockX);
-        output.putBoolean("syncedLockY", syncedLockY);
-        output.putBoolean("syncedLockZ", syncedLockZ);
-        output.putBoolean("syncedNoSignal", syncedNoSignal);
-        output.putFloat("syncedOxygen", syncedOxygen);
-        output.putFloat("syncedPressure", syncedPressure);
-        output.putFloat("syncedTemperature", syncedTemperature);
-        output.putFloat("syncedRadiation", syncedRadiation);
+        synced.write(output);
     }
 
     @Override
     protected void loadAdditional(ValueInput input) {
         super.loadAdditional(input);
         tardisId = input.read("tardisId", UUIDUtil.CODEC).orElse(null);
-        syncedVariant = parseVariant(input.getStringOr("syncedVariant", ""));
-        syncedStabilisersEnabled = input.getBooleanOr("syncedStabilisersEnabled", true);
-        syncedCloaked = input.getBooleanOr("syncedCloaked", false);
-        syncedDoorsLocked = input.getBooleanOr("syncedDoorsLocked", false);
-        syncedLockX = input.getBooleanOr("syncedLockX", false);
-        syncedLockY = input.getBooleanOr("syncedLockY", false);
-        syncedLockZ = input.getBooleanOr("syncedLockZ", false);
-        syncedNoSignal = input.getBooleanOr("syncedNoSignal", true);
-        syncedOxygen = input.getFloatOr("syncedOxygen", 0.0F);
-        syncedPressure = input.getFloatOr("syncedPressure", 0.0F);
-        syncedTemperature = input.getFloatOr("syncedTemperature", 0.0F);
-        syncedRadiation = input.getFloatOr("syncedRadiation", 0.0F);
-    }
-
-    private static TardisChameleonVariant parseVariant(String id) {
-        if (id == null || id.isBlank()) {
-            return TardisChameleonVariant.TT_CAPSULE;
-        }
-        Identifier identifier = Identifier.tryParse(id);
-        if (identifier == null) {
-            return TardisChameleonVariant.TT_CAPSULE;
-        }
-        try {
-            return TardisChameleonVariant.fromId(identifier);
-        } catch (IllegalArgumentException ignored) {
-            return TardisChameleonVariant.TT_CAPSULE;
-        }
+        synced = ConsoleDisplayState.read(input);
     }
 
     @Override

--- a/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -4,9 +4,7 @@ import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.TardisInteriorDoorBlock;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.block.entities.TardisInteriorDoorBlockEntity;
-import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.logic.FirstDoctorConsoleSync;
-import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.mojang.logging.LogUtils;
 import java.util.Optional;
 import java.util.UUID;
@@ -60,12 +58,7 @@ public final class FirstDoctorConsoleRoomPlacer {
 
         completeInteriorDoorBank(world, origin);
         stampInteriorEntities(world, origin, tardisId);
-
-        TardisChameleonVariant variant = TardisLogic.getVariant(tardisId);
-        if (variant == null) {
-            variant = TardisChameleonVariant.TT_CAPSULE;
-        }
-        FirstDoctorConsoleSync.syncVariant(world.getServer(), tardisId, variant);
+        FirstDoctorConsoleSync.syncFromModel(world.getServer(), tardisId);
 
         return origin.offset(LOCAL_ENTRANCE);
     }

--- a/src/main/java/com/adamkali/dwm/tardis/logic/ConsoleDisplayState.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/ConsoleDisplayState.java
@@ -1,0 +1,164 @@
+package com.adamkali.dwm.tardis.logic;
+
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Objects;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+
+/**
+ * Client-facing snapshot of First Doctor console instruments.
+ * Built from {@link TardisDataModel} plus an exterior environment {@link ExteriorEnvironmentReadout.Reading}.
+ */
+public record ConsoleDisplayState(
+        TardisChameleonVariant variant,
+        boolean stabilisersEnabled,
+        boolean cloaked,
+        boolean doorsLocked,
+        boolean lockX,
+        boolean lockY,
+        boolean lockZ,
+        ExteriorEnvironmentReadout.Reading reading
+) {
+    public ConsoleDisplayState {
+        variant = variant == null ? TardisChameleonVariant.TT_CAPSULE : variant;
+        reading = reading == null ? ExteriorEnvironmentReadout.Reading.none() : reading;
+    }
+
+    public static ConsoleDisplayState defaults() {
+        return new ConsoleDisplayState(
+                TardisChameleonVariant.TT_CAPSULE,
+                true,
+                false,
+                false,
+                false,
+                false,
+                false,
+                ExteriorEnvironmentReadout.Reading.none()
+        );
+    }
+
+    public static ConsoleDisplayState from(
+            @Nullable TardisDataModel model,
+            ExteriorEnvironmentReadout.Reading reading
+    ) {
+        ExteriorEnvironmentReadout.Reading safeReading =
+                reading == null ? ExteriorEnvironmentReadout.Reading.none() : reading;
+        if (model == null) {
+            return new ConsoleDisplayState(
+                    TardisChameleonVariant.TT_CAPSULE,
+                    true,
+                    false,
+                    false,
+                    false,
+                    false,
+                    false,
+                    safeReading
+            );
+        }
+        return new ConsoleDisplayState(
+                model.variant == null ? TardisChameleonVariant.TT_CAPSULE : model.variant,
+                StabiliserLogic.isEnabled(model),
+                model.cloaked,
+                model.doorsLocked,
+                model.lockX,
+                model.lockY,
+                model.lockZ,
+                safeReading
+        );
+    }
+
+    public ConsoleDisplayState withReading(ExteriorEnvironmentReadout.Reading nextReading) {
+        return new ConsoleDisplayState(
+                variant,
+                stabilisersEnabled,
+                cloaked,
+                doorsLocked,
+                lockX,
+                lockY,
+                lockZ,
+                nextReading == null ? ExteriorEnvironmentReadout.Reading.none() : nextReading
+        );
+    }
+
+    public void write(ValueOutput output) {
+        output.putString("syncedVariant", variant.getId().toString());
+        output.putBoolean("syncedStabilisersEnabled", stabilisersEnabled);
+        output.putBoolean("syncedCloaked", cloaked);
+        output.putBoolean("syncedDoorsLocked", doorsLocked);
+        output.putBoolean("syncedLockX", lockX);
+        output.putBoolean("syncedLockY", lockY);
+        output.putBoolean("syncedLockZ", lockZ);
+        boolean noSignal = reading.noSignal();
+        output.putBoolean("syncedNoSignal", noSignal);
+        output.putFloat("syncedOxygen", noSignal ? 0.0F : reading.oxygen());
+        output.putFloat("syncedPressure", noSignal ? 0.0F : reading.pressure());
+        output.putFloat("syncedTemperature", noSignal ? 0.0F : reading.temperature());
+        output.putFloat("syncedRadiation", noSignal ? 0.0F : reading.radiation());
+    }
+
+    public static ConsoleDisplayState read(ValueInput input) {
+        boolean noSignal = input.getBooleanOr("syncedNoSignal", true);
+        ExteriorEnvironmentReadout.Reading reading = noSignal
+                ? ExteriorEnvironmentReadout.Reading.none()
+                : new ExteriorEnvironmentReadout.Reading(
+                        false,
+                        input.getFloatOr("syncedOxygen", 0.0F),
+                        input.getFloatOr("syncedPressure", 0.0F),
+                        input.getFloatOr("syncedTemperature", 0.0F),
+                        input.getFloatOr("syncedRadiation", 0.0F)
+                );
+        return new ConsoleDisplayState(
+                parseVariant(input.getStringOr("syncedVariant", "")),
+                input.getBooleanOr("syncedStabilisersEnabled", true),
+                input.getBooleanOr("syncedCloaked", false),
+                input.getBooleanOr("syncedDoorsLocked", false),
+                input.getBooleanOr("syncedLockX", false),
+                input.getBooleanOr("syncedLockY", false),
+                input.getBooleanOr("syncedLockZ", false),
+                reading
+        );
+    }
+
+    private static TardisChameleonVariant parseVariant(String id) {
+        if (id == null || id.isBlank()) {
+            return TardisChameleonVariant.TT_CAPSULE;
+        }
+        Identifier identifier = Identifier.tryParse(id);
+        if (identifier == null) {
+            return TardisChameleonVariant.TT_CAPSULE;
+        }
+        try {
+            return TardisChameleonVariant.fromId(identifier);
+        } catch (IllegalArgumentException ignored) {
+            return TardisChameleonVariant.TT_CAPSULE;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ConsoleDisplayState other)) {
+            return false;
+        }
+        return stabilisersEnabled == other.stabilisersEnabled
+                && cloaked == other.cloaked
+                && doorsLocked == other.doorsLocked
+                && lockX == other.lockX
+                && lockY == other.lockY
+                && lockZ == other.lockZ
+                && variant == other.variant
+                && Objects.equals(reading, other.reading);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                variant, stabilisersEnabled, cloaked, doorsLocked, lockX, lockY, lockZ, reading);
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/logic/FirstDoctorConsoleSync.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/FirstDoctorConsoleSync.java
@@ -3,7 +3,6 @@ package com.adamkali.dwm.tardis.logic;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
-import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
@@ -20,84 +19,35 @@ import java.util.UUID;
 
 /**
  * Syncs console-facing state onto the First Doctor console block entity for client rendering.
- * Other agents may call {@link #syncVariant} / {@link #syncStabilisers} after model changes
- * initiated outside console click handlers.
+ * Call {@link #syncFromModel} after model changes initiated outside the console tick refresh.
  */
 public final class FirstDoctorConsoleSync {
     private FirstDoctorConsoleSync() {
     }
 
     /**
-     * Writes {@code variant} onto the interior console BE for {@code tardisId} and pushes a client update.
+     * Rebuilds the console display snapshot from {@code tardisId}'s model (keeping the current
+     * environment reading when present) and pushes cloak onto the linked exterior BE.
      */
-    public static void syncVariant(
+    public static void syncFromModel(
             @Nullable MinecraftServer server,
-            @Nullable UUID tardisId,
-            @Nullable TardisChameleonVariant variant
+            @Nullable UUID tardisId
     ) {
-        FirstDoctorConsoleBlockEntity console = findConsole(server, tardisId);
-        if (console != null && variant != null) {
-            console.setSyncedVariant(variant);
+        if (server == null || tardisId == null) {
+            return;
         }
-    }
-
-    /**
-     * Writes cloak state onto the interior console and linked exterior BEs.
-     */
-    public static void syncCloak(
-            @Nullable MinecraftServer server,
-            @Nullable UUID tardisId,
-            boolean cloaked
-    ) {
+        TardisDataModel model = TardisDataLoader.get(tardisId);
+        if (model == null) {
+            return;
+        }
         FirstDoctorConsoleBlockEntity console = findConsole(server, tardisId);
         if (console != null) {
-            console.setSyncedCloaked(cloaked);
+            ExteriorEnvironmentReadout.Reading reading = console.syncedDisplay().reading();
+            console.setSyncedDisplay(ConsoleDisplayState.from(model, reading));
         }
         TardisBlockEntity exterior = findExterior(server, tardisId);
         if (exterior != null) {
-            exterior.setSyncedCloaked(cloaked);
-        }
-    }
-
-    /**
-     * Writes door-lock state onto the interior console BE.
-     */
-    public static void syncDoorsLocked(
-            @Nullable MinecraftServer server,
-            @Nullable UUID tardisId,
-            boolean locked
-    ) {
-        FirstDoctorConsoleBlockEntity console = findConsole(server, tardisId);
-        if (console != null) {
-            console.setSyncedDoorsLocked(locked);
-        }
-    }
-
-    /**
-     * Writes coordinate-lock flags onto the interior console BE.
-     */
-    public static void syncCoordinateLocks(
-            @Nullable MinecraftServer server,
-            @Nullable UUID tardisId,
-            @Nullable TardisDataModel model
-    ) {
-        FirstDoctorConsoleBlockEntity console = findConsole(server, tardisId);
-        if (console != null && model != null) {
-            console.setSyncedCoordinateLocks(model.lockX, model.lockY, model.lockZ);
-        }
-    }
-
-    /**
-     * Writes stabilisers enabled state onto the interior console BE and pushes a client update.
-     */
-    public static void syncStabilisers(
-            @Nullable MinecraftServer server,
-            @Nullable UUID tardisId,
-            boolean enabled
-    ) {
-        FirstDoctorConsoleBlockEntity console = findConsole(server, tardisId);
-        if (console != null) {
-            console.setSyncedStabilisersEnabled(enabled);
+            exterior.setSyncedCloaked(model.cloaked);
         }
     }
 

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
@@ -87,7 +87,7 @@ public class TardisLogic {
         tardis.variant = variant;
         tardis.setChanged();
         PortalStreamSyncService.setMetaChanged(tardisId);
-        FirstDoctorConsoleSync.syncVariant(server, tardisId, variant);
+        FirstDoctorConsoleSync.syncFromModel(server, tardisId);
     }
 
     /**

--- a/src/test/java/com/adamkali/dwm/block/FirstDoctorConsoleControlsTest.java
+++ b/src/test/java/com/adamkali/dwm/block/FirstDoctorConsoleControlsTest.java
@@ -47,65 +47,91 @@ class FirstDoctorConsoleControlsTest {
     }
 
     @Test
+    void catalog_coversEveryInteractiveLookTarget() {
+        for (FirstDoctorConsoleControls.LookTarget target :
+                FirstDoctorConsoleControls.LookTarget.interactiveValues()) {
+            assertNotNull(FirstDoctorConsoleControls.spec(target), target.name());
+        }
+        assertNull(FirstDoctorConsoleControls.spec(FirstDoctorConsoleControls.LookTarget.NONE));
+        assertEquals(
+                FirstDoctorConsoleControls.LookTarget.interactiveValues().length,
+                FirstDoctorConsoleControls.specs().size()
+        );
+    }
+
+    @Test
     void biomeSelectorBox_sitsOnPanelDeckAwayFromCenter() {
-        AABB box = FirstDoctorConsoleControls.biomeSelectorBox(Direction.NORTH);
+        AABB box = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, Direction.NORTH);
         assertTrue(box.minY > 0.5, "selector should sit on panel deck, was minY=" + box.minY);
         assertTrue(box.maxY < 1.7, "selector should stay near console top, was maxY=" + box.maxY);
         assertTrue(box.getXsize() > 0.08);
         assertTrue(box.getZsize() > 0.08);
         assertTrue(
-                FirstDoctorConsoleControls.selectorDistanceFromCenter(Direction.NORTH) > 0.45,
+                FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, Direction.NORTH) > 0.45,
                 "selector should be out on Panel3 deck, not at the time rotor"
         );
     }
 
     @Test
-    void isBiomeSelectorHit_acceptsCenterRejectsOrigin() {
+    void boxFor_acceptsCenterRejectsOrigin() {
         Direction facing = Direction.SOUTH;
-        AABB box = FirstDoctorConsoleControls.biomeSelectorBox(facing);
+        AABB box = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, facing);
         Vec3 center = box.getCenter();
-        assertTrue(FirstDoctorConsoleControls.isBiomeSelectorHit(facing, center));
-        assertFalse(FirstDoctorConsoleControls.isBiomeSelectorHit(facing, Vec3.ZERO));
-        assertFalse(FirstDoctorConsoleControls.isBiomeSelectorHit(facing, new Vec3(0.5, 0.1, 0.5)));
+        assertTrue(box.contains(center));
+        assertFalse(box.contains(Vec3.ZERO));
+        assertFalse(box.contains(new Vec3(0.5, 0.1, 0.5)));
     }
 
     @Test
     void lookRay_hitsSelectorFromAbove() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB box = FirstDoctorConsoleControls.biomeSelectorWorldBox(pos, facing);
+        AABB box = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, pos, facing);
         Vec3 center = box.getCenter();
         Vec3 eye = new Vec3(center.x, center.y + 1.5, center.z);
         Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.isBiomeSelectorLookHit(facing, pos, eye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, facing, pos, eye, look, 5.0));
 
         Vec3 missEye = new Vec3(-2.0, 2.0, -2.0);
         Vec3 missLook = new Vec3(0, -1, 0);
-        assertFalse(FirstDoctorConsoleControls.isBiomeSelectorLookHit(facing, pos, missEye, missLook, 5.0));
+        assertFalse(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, facing, pos, missEye, missLook, 5.0));
     }
 
     @Test
     void facingRotation_movesSelectorHorizontally() {
-        AABB north = FirstDoctorConsoleControls.biomeSelectorBox(Direction.NORTH);
-        AABB east = FirstDoctorConsoleControls.biomeSelectorBox(Direction.EAST);
+        AABB north = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, Direction.NORTH);
+        AABB east = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, Direction.EAST);
         assertNotEquals(north.getCenter().x, east.getCenter().x, EPSILON);
         assertEquals(north.getCenter().y, east.getCenter().y, EPSILON);
     }
 
     @Test
-    void selectorLocalToBlockLocal_panel3North_isOffsetFromCenter() {
-        Vec3 p = FirstDoctorConsoleControls.selectorLocalToBlockLocal(0, 1, 0, Direction.NORTH);
+    void controlLocalToBlockLocal_panel3North_isOffsetFromCenter() {
+        ConsoleControlSpec biome = FirstDoctorConsoleControls.spec(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR);
+        assertNotNull(biome);
+        Vec3 p = FirstDoctorConsoleControls.controlLocalToBlockLocal(0, 1, 0, Direction.NORTH, biome);
         assertTrue(Math.hypot(p.x - 0.5, p.z - 0.5) > 0.45);
         assertTrue(p.y > 0.5);
     }
 
     @Test
     void materialisationLeverBox_sitsOnPanel6DeckAwayFromCenter() {
-        AABB box = FirstDoctorConsoleControls.materialisationLeverBox(Direction.NORTH);
+        AABB box = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, Direction.NORTH);
         assertTrue(box.minY > 0.4, "lever should sit on panel deck, was minY=" + box.minY);
         assertTrue(box.maxY < 2.0, "lever should stay near console top, was maxY=" + box.maxY);
         assertTrue(
-                FirstDoctorConsoleControls.leverDistanceFromCenter(Direction.NORTH) > 0.45,
+                FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, Direction.NORTH) > 0.45,
                 "lever should be out on Panel6 deck, not at the time rotor"
         );
     }
@@ -114,29 +140,36 @@ class FirstDoctorConsoleControlsTest {
     void lookRay_hitsLeverFromAbove() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB box = FirstDoctorConsoleControls.materialisationLeverWorldBox(pos, facing);
+        AABB box = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, pos, facing);
         Vec3 center = box.getCenter();
         Vec3 eye = new Vec3(center.x, center.y + 1.5, center.z);
         Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.isMaterialisationLeverLookHit(facing, pos, eye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, facing, pos, eye, look, 5.0));
 
         Vec3 missEye = new Vec3(-2.0, 2.0, -2.0);
         Vec3 missLook = new Vec3(0, -1, 0);
-        assertFalse(FirstDoctorConsoleControls.isMaterialisationLeverLookHit(facing, pos, missEye, missLook, 5.0));
+        assertFalse(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, facing, pos, missEye, missLook, 5.0));
     }
 
     @Test
     void facingRotation_movesLeverHorizontally() {
-        AABB north = FirstDoctorConsoleControls.materialisationLeverBox(Direction.NORTH);
-        AABB east = FirstDoctorConsoleControls.materialisationLeverBox(Direction.EAST);
+        AABB north = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, Direction.NORTH);
+        AABB east = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, Direction.EAST);
         assertNotEquals(north.getCenter().x, east.getCenter().x, EPSILON);
         assertEquals(north.getCenter().y, east.getCenter().y, EPSILON);
     }
 
     @Test
     void leverAndSelector_areOnDifferentPanels() {
-        AABB selector = FirstDoctorConsoleControls.biomeSelectorBox(Direction.NORTH);
-        AABB lever = FirstDoctorConsoleControls.materialisationLeverBox(Direction.NORTH);
+        AABB selector = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, Direction.NORTH);
+        AABB lever = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, Direction.NORTH);
         double dx = selector.getCenter().x - lever.getCenter().x;
         double dz = selector.getCenter().z - lever.getCenter().z;
         assertTrue(Math.hypot(dx, dz) > 0.3, "Panel3 and Panel6 controls should not share the same center");
@@ -145,17 +178,22 @@ class FirstDoctorConsoleControlsTest {
     @Test
     void panel3FourDials_haveDistinctCenters() {
         Direction facing = Direction.NORTH;
-        AABB biome = FirstDoctorConsoleControls.biomeSelectorBox(facing);
-        AABB waypoint = FirstDoctorConsoleControls.waypointSelectorBox(facing);
-        AABB player = FirstDoctorConsoleControls.playerLocatorBox(facing);
-        AABB planet = FirstDoctorConsoleControls.planetLocatorBox(facing);
+        AABB biome = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, facing);
+        AABB waypoint = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR, facing);
+        AABB player = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.PLAYER_LOCATOR, facing);
+        AABB planet = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR, facing);
 
         assertTrue(biome.minY > 0.5);
         assertTrue(waypoint.minY > 0.5);
         assertTrue(player.minY > 0.5);
         assertTrue(planet.minY > 0.5);
         assertTrue(
-                FirstDoctorConsoleControls.planetLocatorDistanceFromCenter(facing) > 0.45,
+                FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR, facing) > 0.45,
                 "planet locator should be out on Panel3 deck"
         );
 
@@ -169,15 +207,18 @@ class FirstDoctorConsoleControlsTest {
     void lookRay_hitsPlanetLocatorFromAbove() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB box = FirstDoctorConsoleControls.planetLocatorWorldBox(pos, facing);
+        AABB box = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR, pos, facing);
         Vec3 center = box.getCenter();
         Vec3 eye = new Vec3(center.x, center.y + 1.5, center.z);
         Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.isPlanetLocatorLookHit(facing, pos, eye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR, facing, pos, eye, look, 5.0));
 
         Vec3 missEye = new Vec3(-2.0, 2.0, -2.0);
         Vec3 missLook = new Vec3(0, -1, 0);
-        assertFalse(FirstDoctorConsoleControls.isPlanetLocatorLookHit(facing, pos, missEye, missLook, 5.0));
+        assertFalse(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR, facing, pos, missEye, missLook, 5.0));
     }
 
     @Test
@@ -186,132 +227,143 @@ class FirstDoctorConsoleControlsTest {
         BlockPos pos = BlockPos.ZERO;
         Vec3 look = new Vec3(0, -1, 0);
 
-        AABB waypoint = FirstDoctorConsoleControls.waypointSelectorWorldBox(pos, facing);
+        AABB waypoint = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR, pos, facing);
         Vec3 waypointEye = new Vec3(waypoint.getCenter().x, waypoint.getCenter().y + 1.5, waypoint.getCenter().z);
-        assertTrue(FirstDoctorConsoleControls.isWaypointSelectorLookHit(facing, pos, waypointEye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR, facing, pos, waypointEye, look, 5.0));
 
-        AABB player = FirstDoctorConsoleControls.playerLocatorWorldBox(pos, facing);
+        AABB player = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.PLAYER_LOCATOR, pos, facing);
         Vec3 playerEye = new Vec3(player.getCenter().x, player.getCenter().y + 1.5, player.getCenter().z);
-        assertTrue(FirstDoctorConsoleControls.isPlayerLocatorLookHit(facing, pos, playerEye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.PLAYER_LOCATOR, facing, pos, playerEye, look, 5.0));
     }
 
     @Test
     void lookRay_hitsChameleonCircuitFromAbove() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB box = FirstDoctorConsoleControls.chameleonCircuitWorldBox(pos, facing);
+        AABB box = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT, pos, facing);
         Vec3 center = box.getCenter();
         Vec3 eye = new Vec3(center.x, center.y + 1.5, center.z);
         Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.isChameleonCircuitLookHit(facing, pos, eye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT, facing, pos, eye, look, 5.0));
     }
 
     @Test
-    void preferBiomeOverPlanet_picksCloserDial() {
-        Direction facing = Direction.NORTH;
-        BlockPos pos = BlockPos.ZERO;
-        AABB biome = FirstDoctorConsoleControls.biomeSelectorWorldBox(pos, facing);
-        Vec3 biomeCenter = biome.getCenter();
-        Vec3 eye = new Vec3(biomeCenter.x, biomeCenter.y + 1.5, biomeCenter.z);
-        Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.preferBiomeOverPlanet(facing, pos, eye, look, 5.0));
-
-        AABB planet = FirstDoctorConsoleControls.planetLocatorWorldBox(pos, facing);
-        Vec3 planetCenter = planet.getCenter();
-        Vec3 planetEye = new Vec3(planetCenter.x, planetCenter.y + 1.5, planetCenter.z);
-        assertFalse(FirstDoctorConsoleControls.preferBiomeOverPlanet(facing, pos, planetEye, look, 5.0));
-    }
-
-    @Test
-    void resolvePanel3LookHit_prefersClosestDial() {
+    void resolveLookTarget_prefersClosestDialOnPanel3() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
         Vec3 look = new Vec3(0, -1, 0);
 
-        AABB waypoint = FirstDoctorConsoleControls.waypointSelectorWorldBox(pos, facing);
-        Vec3 waypointEye = new Vec3(waypoint.getCenter().x, waypoint.getCenter().y + 1.5, waypoint.getCenter().z);
+        AABB biome = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR, pos, facing);
+        Vec3 biomeEye = new Vec3(biome.getCenter().x, biome.getCenter().y + 1.5, biome.getCenter().z);
         assertEquals(
-                FirstDoctorConsoleControls.Panel3Control.WAYPOINT,
-                FirstDoctorConsoleControls.resolvePanel3LookHit(facing, pos, waypointEye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.BIOME_SELECTOR,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, biomeEye, look, 5.0)
         );
 
-        AABB player = FirstDoctorConsoleControls.playerLocatorWorldBox(pos, facing);
-        Vec3 playerEye = new Vec3(player.getCenter().x, player.getCenter().y + 1.5, player.getCenter().z);
-        assertEquals(
-                FirstDoctorConsoleControls.Panel3Control.PLAYER,
-                FirstDoctorConsoleControls.resolvePanel3LookHit(facing, pos, playerEye, look, 5.0)
-        );
-
-        AABB planet = FirstDoctorConsoleControls.planetLocatorWorldBox(pos, facing);
+        AABB planet = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR, pos, facing);
         Vec3 planetEye = new Vec3(planet.getCenter().x, planet.getCenter().y + 1.5, planet.getCenter().z);
         assertEquals(
-                FirstDoctorConsoleControls.Panel3Control.PLANET,
-                FirstDoctorConsoleControls.resolvePanel3LookHit(facing, pos, planetEye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.PLANET_LOCATOR,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, planetEye, look, 5.0)
+        );
+
+        AABB waypoint = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR, pos, facing);
+        Vec3 waypointEye = new Vec3(waypoint.getCenter().x, waypoint.getCenter().y + 1.5, waypoint.getCenter().z);
+        assertEquals(
+                FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, waypointEye, look, 5.0)
+        );
+
+        AABB player = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.PLAYER_LOCATOR, pos, facing);
+        Vec3 playerEye = new Vec3(player.getCenter().x, player.getCenter().y + 1.5, player.getCenter().z);
+        assertEquals(
+                FirstDoctorConsoleControls.LookTarget.PLAYER_LOCATOR,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, playerEye, look, 5.0)
         );
     }
 
     @Test
-    void resolvePanel6LookHit_prefersCloserControl() {
+    void resolveLookTarget_prefersCloserPanel6Control() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
         Vec3 look = new Vec3(0, -1, 0);
 
-        AABB chameleon = FirstDoctorConsoleControls.chameleonCircuitWorldBox(pos, facing);
+        AABB chameleon = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT, pos, facing);
         Vec3 chameleonEye = new Vec3(chameleon.getCenter().x, chameleon.getCenter().y + 1.5, chameleon.getCenter().z);
         assertEquals(
-                FirstDoctorConsoleControls.Panel6Control.CHAMELEON,
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, chameleonEye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, chameleonEye, look, 5.0)
         );
 
-        AABB lever = FirstDoctorConsoleControls.materialisationLeverWorldBox(pos, facing);
+        AABB lever = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, pos, facing);
         Vec3 leverEye = new Vec3(lever.getCenter().x, lever.getCenter().y + 1.5, lever.getCenter().z);
         assertEquals(
-                FirstDoctorConsoleControls.Panel6Control.LEVER,
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, leverEye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, leverEye, look, 5.0)
         );
 
-        AABB fastReturn = FirstDoctorConsoleControls.fastReturnWorldBox(pos, facing);
-        Vec3 fastReturnEye = new Vec3(fastReturn.getCenter().x, fastReturn.getCenter().y + 1.5, fastReturn.getCenter().z);
+        AABB fastReturn = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN, pos, facing);
+        Vec3 fastReturnEye = new Vec3(
+                fastReturn.getCenter().x, fastReturn.getCenter().y + 1.5, fastReturn.getCenter().z);
         assertEquals(
-                FirstDoctorConsoleControls.Panel6Control.FAST_RETURN,
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, fastReturnEye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, fastReturnEye, look, 5.0)
         );
 
-        AABB stabilisers = FirstDoctorConsoleControls.stabilisersWorldBox(pos, facing);
-        Vec3 stabilisersEye = new Vec3(stabilisers.getCenter().x, stabilisers.getCenter().y + 1.5, stabilisers.getCenter().z);
+        AABB stabilisers = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.STABILISERS, pos, facing);
+        Vec3 stabilisersEye = new Vec3(
+                stabilisers.getCenter().x, stabilisers.getCenter().y + 1.5, stabilisers.getCenter().z);
         assertEquals(
-                FirstDoctorConsoleControls.Panel6Control.STABILISERS,
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, stabilisersEye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.STABILISERS,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, stabilisersEye, look, 5.0)
         );
     }
 
     @Test
     void stabilisersBox_sitsOnPanel6BottomRowAwayFromRotor() {
-        AABB box = FirstDoctorConsoleControls.stabilisersBox(Direction.NORTH);
+        AABB box = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.STABILISERS, Direction.NORTH);
         assertTrue(box.minY > 0.3, "stabilisers should sit on panel deck, was minY=" + box.minY);
         assertTrue(box.maxY < 2.0, "stabilisers should stay near console top, was maxY=" + box.maxY);
         assertTrue(
-                FirstDoctorConsoleControls.stabilisersDistanceFromCenter(Direction.NORTH) > 0.45,
+                FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.STABILISERS, Direction.NORTH) > 0.45,
                 "stabilisers should be out on Panel6 deck, not at the time rotor"
         );
-        // Bottom row is farther from the rotor (block center) than the middle-row lever.
         assertTrue(
-                FirstDoctorConsoleControls.stabilisersDistanceFromCenter(Direction.NORTH)
-                        > FirstDoctorConsoleControls.leverDistanceFromCenter(Direction.NORTH),
+                FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.STABILISERS, Direction.NORTH)
+                        > FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.MATERIALISATION_LEVER, Direction.NORTH),
                 "bottom-row stabilisers should be farther from center than the middle-row lever"
         );
     }
 
     @Test
-    void resolvePanel6LookHit_prefersStabilisersOverLeverFromOuterDeck() {
+    void resolveLookTarget_prefersStabilisersOverLeverFromOuterDeck() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB stabilisers = FirstDoctorConsoleControls.stabilisersWorldBox(pos, facing);
+        AABB stabilisers = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.STABILISERS, pos, facing);
         Vec3 eye = new Vec3(stabilisers.getCenter().x, stabilisers.getCenter().y + 1.5, stabilisers.getCenter().z);
         Vec3 look = new Vec3(0, -1, 0);
         assertEquals(
-                FirstDoctorConsoleControls.Panel6Control.STABILISERS,
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, eye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.STABILISERS,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, eye, look, 5.0)
         );
     }
 
@@ -319,18 +371,21 @@ class FirstDoctorConsoleControlsTest {
     void lookRay_hitsStabilisersFromAbove() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB box = FirstDoctorConsoleControls.stabilisersWorldBox(pos, facing);
+        AABB box = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.STABILISERS, pos, facing);
         Vec3 center = box.getCenter();
         Vec3 eye = new Vec3(center.x, center.y + 1.5, center.z);
         Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.isStabilisersLookHit(facing, pos, eye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.STABILISERS, facing, pos, eye, look, 5.0));
     }
 
     @Test
     void resolveLookTarget_includesStabilisers() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB stabilisers = FirstDoctorConsoleControls.stabilisersWorldBox(pos, facing);
+        AABB stabilisers = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.STABILISERS, pos, facing);
         Vec3 eye = new Vec3(stabilisers.getCenter().x, stabilisers.getCenter().y + 1.5, stabilisers.getCenter().z);
         Vec3 look = new Vec3(0, -1, 0);
         assertEquals(
@@ -341,11 +396,13 @@ class FirstDoctorConsoleControlsTest {
 
     @Test
     void fastReturnBox_sitsOnPanel6DeckAwayFromCenter() {
-        AABB box = FirstDoctorConsoleControls.fastReturnBox(Direction.NORTH);
+        AABB box = FirstDoctorConsoleControls.boxFor(
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN, Direction.NORTH);
         assertTrue(box.minY > 0.4, "fast return should sit on panel deck, was minY=" + box.minY);
         assertTrue(box.maxY < 2.0, "fast return should stay near console top, was maxY=" + box.maxY);
         assertTrue(
-                FirstDoctorConsoleControls.fastReturnDistanceFromCenter(Direction.NORTH) > 0.45,
+                FirstDoctorConsoleControls.distanceFromCenter(
+                        FirstDoctorConsoleControls.LookTarget.FAST_RETURN, Direction.NORTH) > 0.45,
                 "fast return should be out on Panel6 deck, not at the time rotor"
         );
     }
@@ -354,23 +411,26 @@ class FirstDoctorConsoleControlsTest {
     void lookRay_hitsFastReturnFromAbove() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB box = FirstDoctorConsoleControls.fastReturnWorldBox(pos, facing);
+        AABB box = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN, pos, facing);
         Vec3 center = box.getCenter();
         Vec3 eye = new Vec3(center.x, center.y + 1.5, center.z);
         Vec3 look = new Vec3(0, -1, 0);
-        assertTrue(FirstDoctorConsoleControls.isFastReturnLookHit(facing, pos, eye, look, 5.0));
+        assertTrue(FirstDoctorConsoleControls.lookHits(
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN, facing, pos, eye, look, 5.0));
     }
 
     @Test
-    void resolvePanel6LookHit_prefersFastReturnOverLeverWhenCloser() {
+    void resolveLookTarget_prefersFastReturnOverLeverWhenCloser() {
         Direction facing = Direction.NORTH;
         BlockPos pos = BlockPos.ZERO;
-        AABB fastReturn = FirstDoctorConsoleControls.fastReturnWorldBox(pos, facing);
+        AABB fastReturn = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN, pos, facing);
         Vec3 eye = new Vec3(fastReturn.getCenter().x, fastReturn.getCenter().y + 1.5, fastReturn.getCenter().z);
         Vec3 look = new Vec3(0, -1, 0);
         assertEquals(
-                FirstDoctorConsoleControls.Panel6Control.FAST_RETURN,
-                FirstDoctorConsoleControls.resolvePanel6LookHit(facing, pos, eye, look, 5.0)
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN,
+                FirstDoctorConsoleControls.resolveLookTarget(facing, pos, eye, look, 5.0)
         );
     }
 
@@ -380,22 +440,26 @@ class FirstDoctorConsoleControlsTest {
         BlockPos pos = BlockPos.ZERO;
         Vec3 look = new Vec3(0, -1, 0);
 
-        AABB waypoint = FirstDoctorConsoleControls.waypointSelectorWorldBox(pos, facing);
+        AABB waypoint = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR, pos, facing);
         Vec3 waypointEye = new Vec3(waypoint.getCenter().x, waypoint.getCenter().y + 1.5, waypoint.getCenter().z);
         assertEquals(
                 FirstDoctorConsoleControls.LookTarget.WAYPOINT_SELECTOR,
                 FirstDoctorConsoleControls.resolveLookTarget(facing, pos, waypointEye, look, 5.0)
         );
 
-        AABB chameleon = FirstDoctorConsoleControls.chameleonCircuitWorldBox(pos, facing);
+        AABB chameleon = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT, pos, facing);
         Vec3 chameleonEye = new Vec3(chameleon.getCenter().x, chameleon.getCenter().y + 1.5, chameleon.getCenter().z);
         assertEquals(
                 FirstDoctorConsoleControls.LookTarget.CHAMELEON_CIRCUIT,
                 FirstDoctorConsoleControls.resolveLookTarget(facing, pos, chameleonEye, look, 5.0)
         );
 
-        AABB fastReturn = FirstDoctorConsoleControls.fastReturnWorldBox(pos, facing);
-        Vec3 fastReturnEye = new Vec3(fastReturn.getCenter().x, fastReturn.getCenter().y + 1.5, fastReturn.getCenter().z);
+        AABB fastReturn = FirstDoctorConsoleControls.worldBoxForTarget(
+                FirstDoctorConsoleControls.LookTarget.FAST_RETURN, pos, facing);
+        Vec3 fastReturnEye = new Vec3(
+                fastReturn.getCenter().x, fastReturn.getCenter().y + 1.5, fastReturn.getCenter().z);
         assertEquals(
                 FirstDoctorConsoleControls.LookTarget.FAST_RETURN,
                 FirstDoctorConsoleControls.resolveLookTarget(facing, pos, fastReturnEye, look, 5.0)

--- a/src/test/java/com/adamkali/dwm/tardis/logic/ConsoleDisplayStateTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/logic/ConsoleDisplayStateTest.java
@@ -1,0 +1,73 @@
+package com.adamkali.dwm.tardis.logic;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConsoleDisplayStateTest {
+    @BeforeEach
+    void setUp() {
+        MinecraftTestBootstrap.ensure();
+    }
+
+    @Test
+    void from_copiesModelFlagsAndReading() {
+        TardisDataModel model = new TardisDataModel();
+        model.variant = TardisChameleonVariant.FIRST_DOCTOR_BOX;
+        model.stabilisersEnabled = Boolean.FALSE;
+        model.cloaked = true;
+        model.doorsLocked = true;
+        model.lockX = true;
+        model.lockY = false;
+        model.lockZ = true;
+
+        ExteriorEnvironmentReadout.Reading reading =
+                new ExteriorEnvironmentReadout.Reading(false, 0.25F, 0.5F, 0.75F, 1.0F);
+
+        ConsoleDisplayState state = ConsoleDisplayState.from(model, reading);
+
+        assertEquals(TardisChameleonVariant.FIRST_DOCTOR_BOX, state.variant());
+        assertFalse(state.stabilisersEnabled());
+        assertTrue(state.cloaked());
+        assertTrue(state.doorsLocked());
+        assertTrue(state.lockX());
+        assertFalse(state.lockY());
+        assertTrue(state.lockZ());
+        assertEquals(reading, state.reading());
+    }
+
+    @Test
+    void from_nullModel_usesDefaultsWithReading() {
+        ExteriorEnvironmentReadout.Reading reading =
+                new ExteriorEnvironmentReadout.Reading(false, 0.1F, 0.2F, 0.3F, 0.4F);
+        ConsoleDisplayState state = ConsoleDisplayState.from(null, reading);
+
+        assertEquals(TardisChameleonVariant.TT_CAPSULE, state.variant());
+        assertTrue(state.stabilisersEnabled());
+        assertFalse(state.cloaked());
+        assertEquals(reading, state.reading());
+    }
+
+    @Test
+    void withReading_preservesFlags() {
+        ConsoleDisplayState base = ConsoleDisplayState.from(null, ExteriorEnvironmentReadout.Reading.none())
+                .withReading(new ExteriorEnvironmentReadout.Reading(false, 0.9F, 0.8F, 0.7F, 0.6F));
+
+        assertEquals(0.9F, base.reading().oxygen(), 1e-4);
+        assertTrue(base.stabilisersEnabled());
+        assertEquals(TardisChameleonVariant.TT_CAPSULE, base.variant());
+    }
+
+    @Test
+    void defaults_matchSafeConsoleStartup() {
+        ConsoleDisplayState defaults = ConsoleDisplayState.defaults();
+        assertEquals(TardisChameleonVariant.TT_CAPSULE, defaults.variant());
+        assertTrue(defaults.stabilisersEnabled());
+        assertFalse(defaults.cloaked());
+        assertTrue(defaults.reading().noSignal());
+    }
+}

--- a/src/test/java/com/adamkali/dwm/tardis/logic/TardisLogicDestinationModeTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/logic/TardisLogicDestinationModeTest.java
@@ -43,7 +43,7 @@ class TardisLogicDestinationModeTest {
             assertTrue(next.isPresent());
             assertEquals(values[0], next.get());
             assertEquals(values[0], model.variant);
-            sync.verify(() -> FirstDoctorConsoleSync.syncVariant(null, tardisId, values[0]));
+            sync.verify(() -> FirstDoctorConsoleSync.syncFromModel(null, tardisId));
         }
     }
 


### PR DESCRIPTION
## Why this matters

- Adding First Doctor console controls currently means touching geometry, hitboxes, renderer mounts, block-entity sync fields, NBT, HUD, and sync helpers in parallel.
- A single catalog + display snapshot cuts that tax so future console work (including DWM-035) is safer and cheaper without changing gameplay.

## Proposed Implementation

- Introduce `ConsoleControlSpec` catalog as the source of truth for control geometry; collapse leftover per-control box/look-hit APIs onto `boxFor` / `resolveLookTarget` / `interactionPose`.
- Drive ordinary First Doctor console widget rendering from that catalog; keep the chameleon hologram as the only special path.
- Introduce `ConsoleDisplayState` for variant/toggles/environment readout; fold BE NBT, `FirstDoctorConsoleSync.syncFromModel`, BER extract, and HUD reads onto one snapshot.
- Leave `activateControl` as a `LookTarget` switch. Tests rewritten for the kept geometry API; add `ConsoleDisplayStateTest`. Validated with `./gradlew test`.

## Problems Encountered / Decisions Made

- Coordinate-lock X/Y/Z remain three hit specs but one mesh (bound to `COORDINATE_LOCK_X`).
- Did not strategy-map click handlers or HUD labels; those cases stay genuinely different.
- Did not sync the full `TardisDataModel` to the client; display snapshot stays console-facing only.

Made with [Cursor](https://cursor.com)