### PR TITLE
feat(dimensions): humanize DimensionNames fallback for missing translations

### DIFF
--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
@@ -20,6 +20,7 @@ import com.adamkali.dwm.tardis.logic.StabiliserLogic;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.adamkali.dwm.tardis.logic.TardisTravelService;
 import com.adamkali.dwm.tardis.logic.TelepathicCircuitLogic;
+import com.adamkali.dwm.text.DimensionNames;
 import com.mojang.serialization.MapCodec;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import org.jetbrains.annotations.Nullable;
@@ -319,7 +320,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             return InteractionResult.CONSUME;
         }
 
-        Component dimensionName = Component.translatable(selected.get().toLanguageKey("dimension"));
+        Component dimensionName = DimensionNames.of(selected.get());
         player.sendOverlayMessage(Component.translatable("dwm.console.dimension_selected", dimensionName));
         playClick(world, pos);
         return InteractionResult.SUCCESS;
@@ -553,11 +554,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
         if (dimensionId == null || dimensionId.isBlank()) {
             return Component.literal("?");
         }
-        Identifier id = Identifier.tryParse(dimensionId);
-        if (id == null) {
-            return Component.literal(dimensionId);
-        }
-        return Component.translatable(id.toLanguageKey("dimension"));
+        return DimensionNames.of(dimensionId);
     }
 
     private static void playClick(Level world, BlockPos pos) {

--- a/src/main/java/com/adamkali/dwm/text/DimensionNames.java
+++ b/src/main/java/com/adamkali/dwm/text/DimensionNames.java
@@ -6,6 +6,7 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Localizes dimension registry ids for UI (e.g. {@code dwm:gallifrey} → {@code dimension.dwm.gallifrey}).
+ * When no translation exists, falls back to a title-cased path (e.g. {@code the_nether} → {@code The Nether}).
  */
 public final class DimensionNames {
     private DimensionNames() {
@@ -13,7 +14,7 @@ public final class DimensionNames {
 
     /**
      * Returns a localized display name for a dimension id string from network payloads.
-     * Blank/null → empty; unparseable → literal id; otherwise translation with id fallback.
+     * Blank/null → empty; unparseable → literal id; otherwise translation with humanized-path fallback.
      */
     public static Component of(@Nullable String dimensionId) {
         if (dimensionId == null || dimensionId.isBlank()) {
@@ -30,6 +31,37 @@ public final class DimensionNames {
      * Returns a localized display name for a dimension {@link Identifier}.
      */
     public static Component of(Identifier dimensionId) {
-        return Component.translatableWithFallback(dimensionId.toLanguageKey("dimension"), dimensionId.toString());
+        return Component.translatableWithFallback(
+                dimensionId.toLanguageKey("dimension"),
+                fallbackName(dimensionId)
+        );
+    }
+
+    /**
+     * Title-cases the identifier path for display when no translation exists.
+     * Splits on {@code _} and {@code /}; e.g. {@code the_nether} → {@code The Nether}.
+     */
+    static String fallbackName(Identifier dimensionId) {
+        String path = dimensionId.getPath();
+        if (path == null || path.isBlank()) {
+            return dimensionId.toString();
+        }
+        StringBuilder result = new StringBuilder(path.length());
+        for (String segment : path.split("[_/]")) {
+            if (segment.isEmpty()) {
+                continue;
+            }
+            if (!result.isEmpty()) {
+                result.append(' ');
+            }
+            result.append(Character.toUpperCase(segment.charAt(0)));
+            if (segment.length() > 1) {
+                result.append(segment, 1, segment.length());
+            }
+        }
+        if (result.isEmpty()) {
+            return dimensionId.toString();
+        }
+        return result.toString();
     }
 }

--- a/src/test/java/com/adamkali/dwm/text/DimensionNamesTest.java
+++ b/src/test/java/com/adamkali/dwm/text/DimensionNamesTest.java
@@ -10,14 +10,41 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class DimensionNamesTest {
     @Test
-    void of_knownIds_useDimensionTranslationKeyWithIdFallback() {
-        assertTranslatable(DimensionNames.of("dwm:gallifrey"), "dimension.dwm.gallifrey", "dwm:gallifrey");
-        assertTranslatable(DimensionNames.of("minecraft:overworld"), "dimension.minecraft.overworld", "minecraft:overworld");
+    void of_knownIds_useDimensionTranslationKeyWithHumanizedFallback() {
+        assertTranslatable(DimensionNames.of("dwm:gallifrey"), "dimension.dwm.gallifrey", "Gallifrey");
+        assertTranslatable(DimensionNames.of("minecraft:overworld"), "dimension.minecraft.overworld", "Overworld");
         assertTranslatable(
                 DimensionNames.of(Identifier.fromNamespaceAndPath("minecraft", "the_nether")),
                 "dimension.minecraft.the_nether",
-                "minecraft:the_nether"
+                "The Nether"
         );
+        assertTranslatable(
+                DimensionNames.of("minecraft:the_end"),
+                "dimension.minecraft.the_end",
+                "The End"
+        );
+        assertTranslatable(
+                DimensionNames.of("ad_astra:glacio"),
+                "dimension.ad_astra.glacio",
+                "Glacio"
+        );
+        assertTranslatable(
+                DimensionNames.of("some_mod:my_custom_dim"),
+                "dimension.some_mod.my_custom_dim",
+                "My Custom Dim"
+        );
+        assertTranslatable(
+                DimensionNames.of(Identifier.fromNamespaceAndPath("mod", "foo/bar_baz")),
+                "dimension.mod.foo/bar_baz",
+                "Foo Bar Baz"
+        );
+    }
+
+    @Test
+    void fallbackName_titleCasesPathSegments() {
+        assertEquals("Overworld", DimensionNames.fallbackName(Identifier.parse("minecraft:overworld")));
+        assertEquals("The Nether", DimensionNames.fallbackName(Identifier.parse("minecraft:the_nether")));
+        assertEquals("Foo Bar Baz", DimensionNames.fallbackName(Identifier.fromNamespaceAndPath("mod", "foo/bar_baz")));
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Vanilla and most mods never ship `dimension.*` translations, so waypoint / player-locator / console overlays were showing raw ids like `minecraft:overworld`. Players should see readable names instead.

## Proposed Implementation

- Keep `Component.translatableWithFallback` so real lang entries (e.g. `dimension.dwm.gallifrey`) still win.
- Change the fallback to a title-cased identifier path (`the_nether` → `The Nether`, `foo/bar_baz` → `Foo Bar Baz`) via `DimensionNames.fallbackName`.
- Route First Doctor console planet-locator and fast-return overlays through `DimensionNames.of` (blank fast-return dims still show `?`).
- Extend `DimensionNamesTest` for vanilla, modded, multi-segment, and slash paths.

## Problems Encountered / Decisions Made

- Namespace is omitted from the fallback; rare path collisions still lose to a real translation key when present.
- `Identifier.toLanguageKey` keeps `/` in the key (`dimension.mod.foo/bar_baz`); tests assert that behavior as-is.

Made with [Cursor](https://cursor.com)