### PR TITLE
feat(tardis): sync interior and exterior door state

### DIFF
--- a/docs/feature-tardis-block.md
+++ b/docs/feature-tardis-block.md
@@ -16,7 +16,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 ## Implemented Now
 - Placeable `tardis_block` with block entity backing data.
 - Persistent per-instance identity data (including UUID and variant metadata).
-- Interactive door state transitions with sound feedback.
+- Interactive door state: exterior and interior share {@code TardisDataModel.doorState}; clicking either side opens/closes both.
 - Custom client rendering for TARDIS model presentation.
 - Exterior BOTI (bigger on the inside): deferred portal FBO composites a hitch-fixed console-room look-in through the chameleon door aperture when `doorSwing >= 0.15`.
 - Interior SOTO (smaller on the outside): deferred portal FBO composites a hitch-fixed exterior look-out through the classic interior door aperture when interior `doorSwing >= 0.15`.
@@ -53,7 +53,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 
 ## How It Works In-Game
 1. Place the TARDIS block.
-2. Interact with the block to toggle door-state behavior (server-authoritative).
+2. Interact with the exterior or interior doors to toggle shared door-state behavior (server-authoritative).
 3. As the door opens, the console room becomes visible through the doorway (client preview).
 4. When the door is fully open, walk into the exterior block to teleport to the interior entrance.
 5. From inside, look through open interior doors to see the exterior world (SOTO preview).
@@ -75,7 +75,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 ## Known Constraints
 - Interior visuals use the shipped `first_doctor_console_room` structure (11×7×17) with decor props; console and interior-door bank are linked to the exterior via `tardisId` on placement.
 - Ownership is first-enter only (no place-time claim); worldgen TARDISes stay unowned until entered. `/tardis rebuild` only targets the caller's owned TARDIS (or any UUID for ops).
-- Door open/closed for entry is server-authoritative; swing animation still updates locally on both sides.
+- Door open/closed for entry is server-authoritative and shared between exterior and interior; swing animation still updates locally on both sides.
 - Shared exterior BOTI door aperture table per chameleon variant (`PortalAperture`); interior SOTO uses one classic 3×2 opening aperture.
 - Shared single full-window portal FBO: last END_MAIN writer wins when multiple door portals render in one frame (no FBO pooling yet).
 - Exterior SOTO footprint is axis-aligned (not rotated with exterior facing). Exit teleport and SOTO look-out follow the chameleon shell door facing (`TardisExteriorFacing`), which is opposite the raw `FACING_ROTATION` skull/banner south=0 convention because of shell BER transforms.

--- a/src/main/java/com/adamkali/dwm/block/TardisInteriorDoorBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/TardisInteriorDoorBlock.java
@@ -2,6 +2,9 @@ package com.adamkali.dwm.block;
 
 import com.adamkali.dwm.block.entities.DWMBlockEntities;
 import com.adamkali.dwm.block.entities.TardisInteriorDoorBlockEntity;
+import com.adamkali.dwm.sound.DWMSounds;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.interior.TardisInteriorDoorShapes;
 import com.adamkali.dwm.tardis.interior.TardisInteriorService;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
@@ -31,11 +34,15 @@ import net.minecraft.world.level.block.state.properties.BooleanProperty;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.level.block.state.properties.EnumProperty;
 import net.minecraft.world.level.block.state.properties.IntegerProperty;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.phys.BlockHitResult;
 import net.minecraft.world.phys.shapes.CollisionContext;
 import net.minecraft.world.phys.shapes.Shapes;
 import net.minecraft.world.phys.shapes.VoxelShape;
 import org.jetbrains.annotations.Nullable;
+
+import java.util.UUID;
 
 /**
  * Classic interior double-door bank (3 wide × 2 tall), modeled after vanilla {@code DoorBlock}:
@@ -111,14 +118,19 @@ public class TardisInteriorDoorBlock extends Block implements EntityBlock {
 
     /**
      * Sets {@link #OPEN} on every cell in the bank and drives the origin BE swing target.
+     * Mid-swing clicks are ignored unless {@code ignoreSwing} is true (canonical model sync).
      */
     public static void setOpen(Level world, BlockPos pos, BlockState state, boolean open) {
+        setOpen(world, pos, state, open, false);
+    }
+
+    public static void setOpen(Level world, BlockPos pos, BlockState state, boolean open, boolean ignoreSwing) {
         Direction facing = state.getValue(FACING);
         BlockPos origin = originPos(pos, state);
         TardisInteriorDoorBlockEntity originEntity = null;
         if (world.getBlockEntity(origin) instanceof TardisInteriorDoorBlockEntity door) {
             originEntity = door;
-            if (door.isSwingInProgress()) {
+            if (!ignoreSwing && door.isSwingInProgress()) {
                 return;
             }
         }
@@ -184,11 +196,23 @@ public class TardisInteriorDoorBlock extends Block implements EntityBlock {
         if (world.isClientSide()) {
             return InteractionResult.SUCCESS;
         }
-        boolean currentlyOpen = state.getValue(OPEN);
         TardisInteriorDoorBlockEntity origin = getOriginEntity(world, pos, state);
-        if (!currentlyOpen && origin != null && TardisLogic.areDoorsLocked(origin.getTardisId())) {
-            player.sendOverlayMessage(Component.translatable("dwm.console.doors_are_locked"));
-            return InteractionResult.CONSUME;
+        UUID tardisId = origin == null ? null : origin.getTardisId();
+        TardisDataModel model = tardisId == null ? null : TardisDataLoader.get(tardisId);
+        if (model != null) {
+            InteractionResult result = TardisLogic.toggleDoor(tardisId);
+            if (result == InteractionResult.FAIL && TardisLogic.areDoorsLocked(tardisId)) {
+                player.sendOverlayMessage(Component.translatable("dwm.console.doors_are_locked"));
+                return InteractionResult.CONSUME;
+            }
+            if (result != InteractionResult.SUCCESS) {
+                return InteractionResult.CONSUME;
+            }
+            boolean open = model.doorState.isOpen;
+            setOpen(world, pos, state, open, true);
+            SoundEvent sound = open ? DWMSounds.TARDIS_DOOR_OPEN : DWMSounds.TARDIS_DOOR_CLOSE;
+            world.playSound(null, pos, sound, SoundSource.BLOCKS, 1.0F, 1.0F);
+            return InteractionResult.SUCCESS;
         }
         toggleOpen(world, pos, state);
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
@@ -56,7 +56,7 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
     @Override
     public void tick(Level world, BlockPos pos, BlockState state, TardisBlockEntity blockEntity) {
         if (this.tardisId != null) {
-            TardisLogic.updateDoorState(this.tardisId);
+            TardisLogic.updateDoorState(this.tardisId, world);
             if (!world.isClientSide()) {
                 boolean cloaked = TardisLogic.isCloaked(this.tardisId);
                 if (cloaked != syncedCloaked) {

--- a/src/main/java/com/adamkali/dwm/block/entities/TardisInteriorDoorBlockEntity.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/TardisInteriorDoorBlockEntity.java
@@ -1,7 +1,9 @@
 package com.adamkali.dwm.block.entities;
 
 import com.adamkali.dwm.block.TardisInteriorDoorBlock;
+import com.adamkali.dwm.tardis.data.model.TardisDoorState;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
@@ -21,8 +23,9 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 
 /**
- * Origin-cell state for a 3×2 interior door bank. {@link TardisInteriorDoorBlock#OPEN} on the
- * blockstates is the source of truth for open/closed; this BE owns swing animation and tardisId.
+ * Origin-cell state for a 3×2 interior door bank. Linked doors mirror
+ * {@code TardisDataModel.doorState.isOpen} onto {@link TardisInteriorDoorBlock#OPEN};
+ * this BE owns local swing animation and tardisId.
  */
 public class TardisInteriorDoorBlockEntity extends BlockEntity implements BlockEntityTicker<TardisInteriorDoorBlockEntity> {
     private @Nullable UUID tardisId;
@@ -63,7 +66,14 @@ public class TardisInteriorDoorBlockEntity extends BlockEntity implements BlockE
     }
 
     public void setOpen(boolean open) {
+        setOpen(open, false);
+    }
+
+    public void setOpen(boolean open, boolean snapSwing) {
         this.open = open;
+        if (snapSwing) {
+            this.doorSwing = open ? 1.0f : 0.0f;
+        }
         setChanged();
         if (level != null) {
             BlockState state = getBlockState();
@@ -73,6 +83,16 @@ public class TardisInteriorDoorBlockEntity extends BlockEntity implements BlockE
 
     @Override
     public void tick(Level world, BlockPos pos, BlockState state, TardisInteriorDoorBlockEntity blockEntity) {
+        if (tardisId != null && !world.isClientSide()) {
+            TardisLogic.updateDoorState(tardisId, world);
+            TardisDoorState doorState = TardisLogic.getDoorState(tardisId);
+            if (doorState != null
+                    && state.hasProperty(TardisInteriorDoorBlock.OPEN)
+                    && state.getValue(TardisInteriorDoorBlock.OPEN) != doorState.isOpen) {
+                TardisInteriorDoorBlock.setOpen(world, pos, state, doorState.isOpen, true);
+                state = world.getBlockState(pos);
+            }
+        }
         if (state.hasProperty(TardisInteriorDoorBlock.OPEN)) {
             open = state.getValue(TardisInteriorDoorBlock.OPEN);
         }

--- a/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
+++ b/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
@@ -183,6 +183,9 @@ public class TardisInteriorGameTests {
         if (!tardisId.equals(door.getTardisId())) {
             throw new AssertionError("Door tardisId not stamped: " + door.getTardisId());
         }
+        if (door.isOpen() || context.getLevel().getBlockState(doorOriginAbs).getValue(TardisInteriorDoorBlock.OPEN)) {
+            throw new AssertionError("Placed interior doors should start closed to match the exterior");
+        }
 
         context.succeed();
     }
@@ -248,5 +251,98 @@ public class TardisInteriorGameTests {
         }
 
         context.succeed();
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void interiorDoor_LinkedUse_TogglesSharedDoorState(GameTestHelper context) {
+        TardisDataLoader.tardisSaveDirectory = context.getLevel().getServer()
+                .getWorldPath(LevelResource.ROOT).resolve("gametest_tardis_data");
+        TardisDataModel model = TardisDataLoader.create();
+
+        Direction facing = Direction.SOUTH;
+        BlockPos originRel = new BlockPos(1, 2, 1);
+        placeClosedDoorBank(context, originRel, facing);
+
+        BlockPos originAbs = context.absolutePos(originRel);
+        if (!(context.getLevel().getBlockEntity(originAbs) instanceof TardisInteriorDoorBlockEntity originDoor)) {
+            throw new AssertionError("Expected origin TardisInteriorDoorBlockEntity");
+        }
+        originDoor.setTardisId(model.uuid);
+
+        Player player = context.makeMockPlayer(GameType.SURVIVAL);
+        BlockState originState = context.getLevel().getBlockState(originAbs);
+        BlockHitResult hit = new BlockHitResult(Vec3.atCenterOf(originAbs), Direction.NORTH, originAbs, false);
+        originState.useWithoutItem(context.getLevel(), player, hit);
+
+        if (!model.doorState.isOpen) {
+            throw new AssertionError("Interior use should open shared TardisDataModel door state");
+        }
+        assertBankOpen(context, originRel, facing, true);
+        if (!originDoor.isOpen()) {
+            throw new AssertionError("Origin BE should be open after linked toggle");
+        }
+
+        context.succeed();
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void interiorDoor_MirrorsExteriorToggleOnTick(GameTestHelper context) {
+        TardisDataLoader.tardisSaveDirectory = context.getLevel().getServer()
+                .getWorldPath(LevelResource.ROOT).resolve("gametest_tardis_data");
+        TardisDataModel model = TardisDataLoader.create();
+
+        Direction facing = Direction.SOUTH;
+        BlockPos originRel = new BlockPos(1, 2, 1);
+        placeClosedDoorBank(context, originRel, facing);
+
+        BlockPos originAbs = context.absolutePos(originRel);
+        if (!(context.getLevel().getBlockEntity(originAbs) instanceof TardisInteriorDoorBlockEntity originDoor)) {
+            throw new AssertionError("Expected origin TardisInteriorDoorBlockEntity");
+        }
+        originDoor.setTardisId(model.uuid);
+
+        TardisLogic.toggleDoor(model.uuid);
+        if (!model.doorState.isOpen) {
+            throw new AssertionError("Expected exterior toggle to open shared door state");
+        }
+        if (context.getLevel().getBlockState(originAbs).getValue(TardisInteriorDoorBlock.OPEN)) {
+            throw new AssertionError("Interior OPEN should still be closed before origin tick");
+        }
+
+        originDoor.tick(context.getLevel(), originAbs, context.getLevel().getBlockState(originAbs), originDoor);
+        assertBankOpen(context, originRel, facing, true);
+
+        context.succeed();
+    }
+
+    private static void placeClosedDoorBank(GameTestHelper context, BlockPos originRel, Direction facing) {
+        for (DoubleBlockHalf half : DoubleBlockHalf.values()) {
+            for (int slot = 0; slot < TardisInteriorDoorBlock.BANK_WIDTH; slot++) {
+                BlockPos cellRel = TardisInteriorDoorBlock.cellPos(originRel, facing, half, slot);
+                context.setBlock(
+                        cellRel.getX(), cellRel.getY(), cellRel.getZ(),
+                        TardisInteriorDoorBlock.bankCellState(facing, half, slot, false));
+            }
+        }
+    }
+
+    private static void assertBankOpen(
+            GameTestHelper context,
+            BlockPos originRel,
+            Direction facing,
+            boolean expectedOpen
+    ) {
+        for (DoubleBlockHalf half : DoubleBlockHalf.values()) {
+            for (int slot = 0; slot < TardisInteriorDoorBlock.BANK_WIDTH; slot++) {
+                BlockPos cellAbs = context.absolutePos(
+                        TardisInteriorDoorBlock.cellPos(originRel, facing, half, slot));
+                BlockState cellState = context.getLevel().getBlockState(cellAbs);
+                if (cellState.getValue(TardisInteriorDoorBlock.OPEN) != expectedOpen) {
+                    throw new AssertionError(
+                            "Expected OPEN=" + expectedOpen + " at " + cellAbs
+                                    + " but was " + cellState.getValue(TardisInteriorDoorBlock.OPEN));
+                }
+            }
+        }
     }
 }

--- a/src/main/java/com/adamkali/dwm/tardis/data/model/TardisDataModel.java
+++ b/src/main/java/com/adamkali/dwm/tardis/data/model/TardisDataModel.java
@@ -101,6 +101,12 @@ public class TardisDataModel {
 
     private transient boolean needsSaving = false;
 
+    /**
+     * Last server tick that advanced {@link #doorState} swing. Not persisted; used so exterior and
+     * interior block entities do not double-step animation in the same tick.
+     */
+    public transient int lastDoorSwingServerTick = Integer.MIN_VALUE;
+
     public TardisDataModel() {
         this.uuid = UUID.randomUUID();
         this.doorState = new TardisDoorState();

--- a/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -4,6 +4,8 @@ import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.TardisInteriorDoorBlock;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.block.entities.TardisInteriorDoorBlockEntity;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.logic.FirstDoctorConsoleSync;
 import com.mojang.logging.LogUtils;
 import java.util.Optional;
@@ -58,6 +60,7 @@ public final class FirstDoctorConsoleRoomPlacer {
 
         completeInteriorDoorBank(world, origin);
         stampInteriorEntities(world, origin, tardisId);
+        applyDoorOpenFromModel(world, origin, tardisId);
         FirstDoctorConsoleSync.syncFromModel(world.getServer(), tardisId);
 
         return origin.offset(LOCAL_ENTRANCE);
@@ -112,6 +115,20 @@ public final class FirstDoctorConsoleRoomPlacer {
                         Block.UPDATE_CLIENTS
                 );
             }
+        }
+    }
+
+    private static void applyDoorOpenFromModel(ServerLevel world, BlockPos origin, UUID tardisId) {
+        TardisDataModel model = TardisDataLoader.get(tardisId);
+        boolean open = model != null && model.doorState.isOpen;
+        BlockPos doorOrigin = origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_DOOR_ORIGIN);
+        BlockState originState = world.getBlockState(doorOrigin);
+        if (!originState.is(DWMBlocks.TARDIS_INTERIOR_DOOR)) {
+            return;
+        }
+        TardisInteriorDoorBlock.setOpen(world, doorOrigin, originState, open, true);
+        if (world.getBlockEntity(doorOrigin) instanceof TardisInteriorDoorBlockEntity door) {
+            door.setOpen(open, true);
         }
     }
 

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
@@ -53,9 +53,26 @@ public class TardisLogic {
     }
 
     public static void updateDoorState(UUID tardisId) {
+        updateDoorState(tardisId, null);
+    }
+
+    /**
+     * Advances door swing toward the current open/closed target.
+     * When {@code world} has a server, at most one step runs per server tick so exterior and
+     * interior tickers cannot double-speed the shared animation.
+     */
+    public static void updateDoorState(UUID tardisId, @Nullable Level world) {
         TardisDataModel tardis = TardisDataLoader.get(tardisId);
         if (tardis == null) {
             return;
+        }
+        MinecraftServer server = world == null ? null : world.getServer();
+        if (server != null) {
+            int tick = server.getTickCount();
+            if (tardis.lastDoorSwingServerTick == tick) {
+                return;
+            }
+            tardis.lastDoorSwingServerTick = tick;
         }
         float doorSwing = tardis.doorState.doorSwing;
         if (tardis.doorState.isOpen) {

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
@@ -432,13 +432,13 @@ public final class TardisTravelService {
         }
 
         // Door-close prelude before the configurable demat/vworp window.
-        TardisLogic.updateDoorState(tardisId);
+        ServerLevel exteriorWorld = getExteriorWorld(server, model);
+        TardisLogic.updateDoorState(tardisId, exteriorWorld);
         if (model.doorState.doorSwing > 0.0f) {
             PortalStreamSyncService.setMetaChanged(tardisId);
             return;
         }
 
-        ServerLevel exteriorWorld = getExteriorWorld(server, model);
         if (exteriorWorld == null) {
             abortToIdle(server, tardisId, model);
             return;
@@ -474,7 +474,7 @@ public final class TardisTravelService {
     }
 
     private static void tickMaterialising(MinecraftServer server, UUID tardisId, TardisDataModel model) {
-        TardisLogic.updateDoorState(tardisId);
+        TardisLogic.updateDoorState(tardisId, getExteriorWorld(server, model));
         PortalStreamSyncService.setMetaChanged(tardisId);
         boolean finished = advanceMaterialisingHold(model);
         if (!finished) {


### PR DESCRIPTION
## Why this matters

- Exterior and interior doors were independent, so opening one side did not open the other and the shared swing could advance twice in the same tick.
- Players expect one TARDIS door: click either side and both should match.

## Proposed Implementation

- Interior door use now calls `TardisLogic.toggleDoor` and plays the existing open/close sounds; unlinked banks still toggle locally.
- `updateDoorState` steps at most once per server tick (`lastDoorSwingServerTick`) and is called from both the exterior and interior origin block entities.
- Interior `OPEN` mirrors `TardisDataModel.doorState` on tick and after console-room placement.
- GameTests cover linked interior use, exterior-to-interior mirror on tick, and placed interiors starting closed.

## Problems Encountered / Decisions Made

- Travel demat/mat door ticks pass the exterior world into `updateDoorState` so the once-per-tick guard works during flight; auto-open-on-materialise is unchanged here.

Made with [Cursor](https://cursor.com)