### PR TITLE
chore(docs): point AGENTS.md at the GitHub backlog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 - Avoid touching large generated/resource surfaces unless the task requires it.
 - When fixing bugs, prefer the smallest change that addresses root cause and add regression coverage.
 - If a requested behavior cannot be fully automated/tested, document the limitation and propose follow-up automation.
-- Local product backlog (gitignored) lives in `tickets/` when present — start from `tickets/BOARD.md`; status is the folder (`open/` / `in-progress/` / `done/`). See `tickets/README.md`.
+- Product backlog lives on GitHub: issues in [adam-k-ali/DWM](https://github.com/adam-k-ali/DWM/issues) and the [DWM project board](https://github.com/users/adam-k-ali/projects/7/views/1). Titles keep stable IDs (`DWM-NNN — …`, `E-NNN — …`). Status is Project Status (`Backlog` / `In progress` / `Done`) plus issue state; priority is the project Priority field (`P0`–`P3`). Epics are parent issues with ticket sub-issues. A local `tickets/` folder may exist as a gitignored archive — do not use it as the live board.
 
 ## Fabric-Specific Development Rules
 - Keep Java 25 compatibility.


### PR DESCRIPTION
## Why this matters

- Agents and contributors were still pointed at a local `tickets/` archive; the live backlog is GitHub issues and the DWM project board.

## Proposed Implementation

- Update `AGENTS.md` so product status, IDs (`DWM-NNN` / `E-NNN`), and priority come from GitHub rather than gitignored folders.

## Problems Encountered / Decisions Made

- None

Made with [Cursor](https://cursor.com)