### PR TITLE
feat(tardis): fade the exterior shell during demat and mat

### DIFF
--- a/docs/feature-tardis-block.md
+++ b/docs/feature-tardis-block.md
@@ -51,7 +51,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 - Panel2 telepathic circuit arms `DestinationMode.TELEPATHIC` onto the using player's bed/respawn, or world spawn if none. Overlay: locked onto your home / world spawn.
 - Panel3 coordinate lock is not a destination mode: X/Y/Z toggles pin those axes to the current exterior after landing resolve + scatter, then re-validate. Invalid pin fails materialise with the existing invalid-landing overlay. HUD: `X axis locked` / `unlocked` (same for Y/Z).
 - First Doctor console time rotor bobbles vertically while the TARDIS is traveling (`DEMATERIALISING` / `IN_FLIGHT` / `MATERIALISING`) and rests when idle.
-- Demat/mat/in-flight play loopable travel SFX (seamless loops) for code-configured phase lengths (`DEMATERIALISING_DURATION_TICKS` / `MATERIALISING_DURATION_TICKS` in `TardisTravelService`); shell vanishes mid-demat at `DEMATERIALISING_SHELL_REMOVE_AT_TICK`; `IN_FLIGHT` uses a higher-pitched demat/mat-derived loop in the interior; materialisation ends with a landing thud. Demat forces doors closed; materialise auto-opens them unless they are locked.
+- Demat/mat/in-flight play loopable travel SFX (seamless loops) for code-configured phase lengths (`DEMATERIALISING_DURATION_TICKS` / `MATERIALISING_DURATION_TICKS` in `TardisTravelService`); shell vanishes mid-demat at `DEMATERIALISING_SHELL_REMOVE_AT_TICK`; `IN_FLIGHT` uses a higher-pitched demat/mat-derived loop in the interior; materialisation ends with a landing thud. Exterior shell fades out during dematerialisation and fades in during materialisation. Demat forces doors closed; materialise auto-opens them unless they are locked.
 
 ## How It Works In-Game
 1. Place the TARDIS block.

--- a/src/client/java/com/adamkali/dwm/model/tileentity/TardisModel.java
+++ b/src/client/java/com/adamkali/dwm/model/tileentity/TardisModel.java
@@ -52,12 +52,16 @@ public abstract class TardisModel extends EntityModel<TardisRenderState> {
      * Renders the exterior shell without door meshes (for BOTI to fill the aperture first).
      */
     public void renderShell(PoseStack matrices, VertexConsumer vertices, int light, int overlay) {
+        renderShell(matrices, vertices, light, overlay, -1);
+    }
+
+    public void renderShell(PoseStack matrices, VertexConsumer vertices, int light, int overlay, int color) {
         List<ModelPart> doors = getDoorParts();
         for (ModelPart door : doors) {
             door.visible = false;
         }
         try {
-            this.renderToBuffer(matrices, vertices, light, overlay, -1);
+            this.renderToBuffer(matrices, vertices, light, overlay, color);
         } finally {
             for (ModelPart door : doors) {
                 door.visible = true;
@@ -69,13 +73,17 @@ public abstract class TardisModel extends EntityModel<TardisRenderState> {
      * Renders only door meshes, applying ancestor transforms so nested doors stay aligned.
      */
     public void renderDoors(PoseStack matrices, VertexConsumer vertices, int light, int overlay) {
+        renderDoors(matrices, vertices, light, overlay, -1);
+    }
+
+    public void renderDoors(PoseStack matrices, VertexConsumer vertices, int light, int overlay, int color) {
         matrices.pushPose();
         try {
             root.translateAndRotate(matrices);
 
             for (String name : DOOR_PART_NAMES) {
                 if (root.hasChild(name)) {
-                    root.getChild(name).render(matrices, vertices, light, overlay);
+                    root.getChild(name).render(matrices, vertices, light, overlay, color);
                 }
             }
 
@@ -85,7 +93,7 @@ public abstract class TardisModel extends EntityModel<TardisRenderState> {
                 main.translateAndRotate(matrices);
                 for (String name : DOOR_PART_NAMES) {
                     if (main.hasChild(name)) {
-                        main.getChild(name).render(matrices, vertices, light, overlay);
+                        main.getChild(name).render(matrices, vertices, light, overlay, color);
                     }
                 }
                 matrices.popPose();
@@ -96,7 +104,7 @@ public abstract class TardisModel extends EntityModel<TardisRenderState> {
                 ModelPart bone = root.getChild("bone");
                 bone.translateAndRotate(matrices);
                 if (bone.hasChild("door")) {
-                    bone.getChild("door").render(matrices, vertices, light, overlay);
+                    bone.getChild("door").render(matrices, vertices, light, overlay, color);
                 }
                 matrices.popPose();
             }

--- a/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
@@ -16,7 +16,9 @@ import com.adamkali.dwm.render.state.TardisBlockEntityRenderState;
 import com.adamkali.dwm.render.state.TardisRenderState;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
+import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
+import com.adamkali.dwm.tardis.logic.TardisShellOpacity;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
 import java.util.HashMap;
@@ -25,10 +27,12 @@ import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.blockentity.BlockEntityRenderer;
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
 import net.minecraft.client.renderer.feature.ModelFeatureRenderer;
+import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.ARGB;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.RotationSegment;
 import net.minecraft.world.phys.Vec3;
@@ -80,6 +84,13 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         state.shouldRenderBoti = TardisBotiRenderer.shouldRender(doorState);
         state.cloaked = entity.isSyncedCloaked()
                 || (entity.getTardisIdOrNull() != null && TardisLogic.isCloaked(entity.getTardisIdOrNull()));
+        TardisTravelPhase phase = entity.getSyncedTravelPhase();
+        float elapsed = 0.0f;
+        var world = entity.getLevel();
+        if (world != null && phase.isTraveling()) {
+            elapsed = (world.getGameTime() - entity.getSyncedPhaseGameTime()) + partialTicks;
+        }
+        state.shellAlpha = TardisShellOpacity.alpha(phase, elapsed);
     }
 
     @Override
@@ -101,7 +112,7 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         TardisRenderState animState = new TardisRenderState();
         animState.setDoorSwingProgress(state.doorSwing);
 
-        if (state.shouldRenderBoti && state.tardisId != null) {
+        if (state.shouldRenderBoti && state.tardisId != null && state.shellAlpha >= 0.999f) {
             // Shell → BOTI → doors so swung doors draw over the interior preview.
             submitShell(model, animState, poseStack, submitNodeCollector, texture, state);
 
@@ -138,15 +149,19 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
     ) {
         poseStack.pushPose();
         applyExteriorTransforms(poseStack, state.rotationDegrees);
-        submitNodeCollector.submitModel(
-                model,
-                animState,
-                poseStack,
-                RenderTypes.entityCutout(texture),
-                state.lightCoords,
-                OverlayTexture.NO_OVERLAY,
-                -1,
-                state.breakProgress);
+        if (state.shellAlpha < 0.999f) {
+            submitTranslucentModel(model, animState, poseStack, submitNodeCollector, texture, state);
+        } else {
+            submitNodeCollector.submitModel(
+                    model,
+                    animState,
+                    poseStack,
+                    RenderTypes.entityCutout(texture),
+                    state.lightCoords,
+                    OverlayTexture.NO_OVERLAY,
+                    -1,
+                    state.breakProgress);
+        }
         poseStack.popPose();
     }
 
@@ -165,14 +180,15 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         poseStack.pushPose();
         applyExteriorTransforms(poseStack, state.rotationDegrees);
         int light = state.lightCoords;
+        int color = shellColor(state);
         submitNodeCollector.submitCustomGeometry(
                 poseStack,
-                RenderTypes.entityCutout(texture),
+                shellRenderType(texture, state),
                 (pose, consumer) -> {
                     PoseStack local = new PoseStack();
                     local.last().set(pose);
                     model.setupAnim(animState);
-                    model.renderShell(local, consumer, light, OverlayTexture.NO_OVERLAY);
+                    model.renderShell(local, consumer, light, OverlayTexture.NO_OVERLAY, color);
                 });
         poseStack.popPose();
     }
@@ -191,14 +207,15 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         poseStack.pushPose();
         applyExteriorTransforms(poseStack, state.rotationDegrees);
         int light = state.lightCoords;
+        int color = shellColor(state);
         submitNodeCollector.submitCustomGeometry(
                 poseStack,
-                RenderTypes.entityCutout(texture),
+                shellRenderType(texture, state),
                 (pose, consumer) -> {
                     PoseStack local = new PoseStack();
                     local.last().set(pose);
                     model.setupAnim(animState);
-                    model.renderDoors(local, consumer, light, OverlayTexture.NO_OVERLAY);
+                    model.renderDoors(local, consumer, light, OverlayTexture.NO_OVERLAY, color);
                 });
         poseStack.popPose();
     }
@@ -208,5 +225,46 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         matrices.mulPose(Axis.XP.rotationDegrees(180.0f));
         matrices.translate(0.25D, -1.5D, -0.25D);
         matrices.mulPose(Axis.YP.rotationDegrees(rotationDegrees - 180.0f));
+    }
+
+    private static void submitTranslucentModel(
+            TardisModel model,
+            TardisRenderState animState,
+            PoseStack poseStack,
+            SubmitNodeCollector submitNodeCollector,
+            Identifier texture,
+            TardisBlockEntityRenderState state
+    ) {
+        int light = state.lightCoords;
+        int color = shellColor(state);
+        submitNodeCollector.submitCustomGeometry(
+                poseStack,
+                RenderTypes.entityTranslucent(texture),
+                (pose, consumer) -> {
+                    PoseStack local = new PoseStack();
+                    local.last().set(pose);
+                    model.setupAnim(animState);
+                    model.renderToBuffer(local, consumer, light, OverlayTexture.NO_OVERLAY, color);
+                });
+    }
+
+    private static boolean isTranslucent(TardisBlockEntityRenderState state) {
+        return state.shellAlpha < 0.999f;
+    }
+
+    private static int shellColor(TardisBlockEntityRenderState state) {
+        if (!isTranslucent(state)) {
+            return -1;
+        }
+        return ARGB.colorFromFloat(state.shellAlpha, 1.0f, 1.0f, 1.0f);
+    }
+
+    private static RenderType shellRenderType(
+            Identifier texture,
+            TardisBlockEntityRenderState state
+    ) {
+        return isTranslucent(state)
+                ? RenderTypes.entityTranslucent(texture)
+                : RenderTypes.entityCutout(texture);
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/state/TardisBlockEntityRenderState.java
+++ b/src/client/java/com/adamkali/dwm/render/state/TardisBlockEntityRenderState.java
@@ -14,5 +14,6 @@ public class TardisBlockEntityRenderState extends BlockEntityRenderState {
     public float partialTicks;
     public boolean shouldRenderBoti;
     public boolean cloaked;
+    public float shellAlpha = 1.0f;
     public UUID tardisId;
 }

--- a/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.block.entities;
 import com.adamkali.dwm.sound.DWMSounds;
 import com.adamkali.dwm.tardis.boti.BotiPlotIndex;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,6 +31,8 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
     private @Nullable BlockPos interiorEntrance;
     private boolean interiorGenerated;
     private boolean syncedCloaked;
+    private String syncedTravelPhase = TardisTravelPhase.IDLE.name();
+    private long syncedPhaseGameTime;
 
     public TardisBlockEntity(UUID tardisId, BlockPos pos, BlockState state) {
         super(DWMBlockEntities.TARDIS_BLOCK_ENTITY, pos, state);
@@ -78,6 +81,8 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
         output.store("tardisId", UUIDUtil.CODEC, this.tardisId);
         output.putBoolean("interiorGenerated", this.interiorGenerated);
         output.putBoolean("syncedCloaked", this.syncedCloaked);
+        output.putString("syncedTravelPhase", this.syncedTravelPhase);
+        output.putLong("syncedPhaseGameTime", this.syncedPhaseGameTime);
         if (this.interiorEntrance != null) {
             output.putInt("interiorEntranceX", this.interiorEntrance.getX());
             output.putInt("interiorEntranceY", this.interiorEntrance.getY());
@@ -94,6 +99,8 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
         this.tardisId = input.read("tardisId", UUIDUtil.CODEC).orElse(null);
         this.interiorGenerated = input.getBooleanOr("interiorGenerated", false);
         this.syncedCloaked = input.getBooleanOr("syncedCloaked", false);
+        this.syncedTravelPhase = input.getStringOr("syncedTravelPhase", TardisTravelPhase.IDLE.name());
+        this.syncedPhaseGameTime = input.getLongOr("syncedPhaseGameTime", 0L);
         if (input.getInt("interiorEntranceX").isPresent()) {
             this.interiorEntrance = new BlockPos(
                     input.getIntOr("interiorEntranceX", 0),
@@ -133,6 +140,25 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
     public void setSyncedCloaked(boolean cloaked) {
         this.syncedCloaked = cloaked;
         setChanged();
+        sendClientUpdate();
+    }
+
+    public TardisTravelPhase getSyncedTravelPhase() {
+        return TardisTravelPhase.fromString(syncedTravelPhase);
+    }
+
+    public long getSyncedPhaseGameTime() {
+        return syncedPhaseGameTime;
+    }
+
+    public void setSyncedTravelPhase(TardisTravelPhase phase, long gameTime) {
+        this.syncedTravelPhase = phase == null ? TardisTravelPhase.IDLE.name() : phase.name();
+        this.syncedPhaseGameTime = gameTime;
+        setChanged();
+        sendClientUpdate();
+    }
+
+    private void sendClientUpdate() {
         if (level != null && !level.isClientSide()) {
             BlockState state = getBlockState();
             level.sendBlockUpdated(worldPosition, state, state, net.minecraft.world.level.block.Block.UPDATE_CLIENTS);

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisShellOpacity.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisShellOpacity.java
@@ -1,0 +1,33 @@
+package com.adamkali.dwm.tardis.logic;
+
+import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Exterior shell alpha during dematerialise / materialise. Elapsed ticks are measured from
+ * phase start (countdown start for demat, shell place for mat).
+ */
+public final class TardisShellOpacity {
+    private TardisShellOpacity() {
+    }
+
+    public static float alpha(@Nullable TardisTravelPhase phase, float elapsedTicks) {
+        if (phase == TardisTravelPhase.MATERIALISING) {
+            return clamp01(elapsedTicks / TardisTravelService.MATERIALISING_DURATION_TICKS);
+        }
+        if (phase == TardisTravelPhase.DEMATERIALISING) {
+            return clamp01(1.0f - elapsedTicks / TardisTravelService.DEMATERIALISING_SHELL_REMOVE_AT_TICK);
+        }
+        return 1.0f;
+    }
+
+    private static float clamp01(float value) {
+        if (value < 0.0f) {
+            return 0.0f;
+        }
+        if (value > 1.0f) {
+            return 1.0f;
+        }
+        return value;
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
@@ -302,6 +302,9 @@ public final class TardisTravelService {
 
         FastReturnLogic.pushDeparted(model);
         placeShell(destinationWorld, landing, snapshot, facingRotation);
+        if (destinationWorld.getBlockEntity(landing) instanceof TardisBlockEntity be) {
+            be.setSyncedTravelPhase(TardisTravelPhase.MATERIALISING, destinationWorld.getGameTime());
+        }
         model.setExteriorLocation(
                 destinationWorld.dimension().identifier().toString(),
                 landing.getX(),
@@ -457,6 +460,7 @@ public final class TardisTravelService {
         SHELL_REMOVED.remove(tardisId);
         model.travelPhaseTicks = DEMATERIALISING_DURATION_TICKS;
         model.setChanged();
+        be.setSyncedTravelPhase(TardisTravelPhase.DEMATERIALISING, exteriorWorld.getGameTime());
         TardisTravelAudio.startDemat(server, tardisId, exteriorWorld, exteriorPos);
     }
 
@@ -485,6 +489,9 @@ public final class TardisTravelService {
         ACTIVE.remove(tardisId);
         ServerLevel exteriorWorld = getExteriorWorld(server, model);
         BlockPos exteriorPos = new BlockPos(model.exteriorX, model.exteriorY, model.exteriorZ);
+        if (exteriorWorld != null && exteriorWorld.getBlockEntity(exteriorPos) instanceof TardisBlockEntity be) {
+            be.setSyncedTravelPhase(TardisTravelPhase.IDLE, exteriorWorld.getGameTime());
+        }
         TardisTravelAudio.stop(server, tardisId, exteriorWorld, exteriorPos);
         playMaterialiseThud(server, tardisId, exteriorWorld, exteriorPos);
     }

--- a/src/test/java/com/adamkali/dwm/tardis/logic/TardisShellOpacityTest.java
+++ b/src/test/java/com/adamkali/dwm/tardis/logic/TardisShellOpacityTest.java
@@ -1,0 +1,63 @@
+package com.adamkali.dwm.tardis.logic;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class TardisShellOpacityTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+    }
+
+    @Test
+    void idleAndInFlightAreOpaque() {
+        assertEquals(1.0f, TardisShellOpacity.alpha(TardisTravelPhase.IDLE, 0.0f));
+        assertEquals(1.0f, TardisShellOpacity.alpha(TardisTravelPhase.IN_FLIGHT, 40.0f));
+        assertEquals(1.0f, TardisShellOpacity.alpha(null, 10.0f));
+    }
+
+    @Test
+    void materialisingFadesIn() {
+        assertEquals(0.0f, TardisShellOpacity.alpha(TardisTravelPhase.MATERIALISING, 0.0f));
+        assertEquals(
+                0.5f,
+                TardisShellOpacity.alpha(
+                        TardisTravelPhase.MATERIALISING,
+                        TardisTravelService.MATERIALISING_DURATION_TICKS / 2.0f
+                )
+        );
+        assertEquals(
+                1.0f,
+                TardisShellOpacity.alpha(
+                        TardisTravelPhase.MATERIALISING,
+                        TardisTravelService.MATERIALISING_DURATION_TICKS
+                )
+        );
+        assertEquals(1.0f, TardisShellOpacity.alpha(TardisTravelPhase.MATERIALISING, 10_000.0f));
+    }
+
+    @Test
+    void dematerialisingFadesOutUntilShellRemoved() {
+        assertEquals(1.0f, TardisShellOpacity.alpha(TardisTravelPhase.DEMATERIALISING, 0.0f));
+        assertEquals(
+                0.5f,
+                TardisShellOpacity.alpha(
+                        TardisTravelPhase.DEMATERIALISING,
+                        TardisTravelService.DEMATERIALISING_SHELL_REMOVE_AT_TICK / 2.0f
+                )
+        );
+        assertEquals(
+                0.0f,
+                TardisShellOpacity.alpha(
+                        TardisTravelPhase.DEMATERIALISING,
+                        TardisTravelService.DEMATERIALISING_SHELL_REMOVE_AT_TICK
+                )
+        );
+        assertEquals(0.0f, TardisShellOpacity.alpha(TardisTravelPhase.DEMATERIALISING, 10_000.0f));
+    }
+}


### PR DESCRIPTION
## Why this matters

- Console travel currently pops the parked box in and out. A fade makes dematerialisation and materialisation readable from outside.

## Proposed Implementation

- Sync travel phase and phase-start game time on the exterior block entity.
- Client BER uses `TardisShellOpacity` to drive translucent shell/door alpha; BOTI is skipped while translucent.
- Unit tests cover fade curves for demat/mat/idle.
- `docs/feature-tardis-block.md` notes the fade. Stattenheim summon lands in a stacked follow-up.

## Problems Encountered / Decisions Made

- Collision stays solid during the fade (visual-only). BOTI is skipped while the shell is translucent so the interior preview does not draw through a ghost box.

Made with [Cursor](https://cursor.com)