### PR TITLE
feat(console): spin Time_middle on First Doctor rotor (DWM-004)

### DIFF
--- a/docs/feature-tardis-block.md
+++ b/docs/feature-tardis-block.md
@@ -51,7 +51,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 - Stattenheim remote: sneak-right-click the ground to summon the owner's TARDIS to that cell (precise landing, door facing the player). Parked shells dematerialise then auto-materialise; an in-flight TARDIS materialises at the click. Exterior fade-out/fade-in during demat/mat. Summon slams the doors shut immediately; they stay closed on landing.
 - Panel2 telepathic circuit arms `DestinationMode.TELEPATHIC` onto the using player's bed/respawn, or world spawn if none. Overlay: locked onto your home / world spawn.
 - Panel3 coordinate lock is not a destination mode: X/Y/Z toggles pin those axes to the current exterior after landing resolve + scatter, then re-validate. Invalid pin fails materialise with the existing invalid-landing overlay. HUD: `X axis locked` / `unlocked` (same for Y/Z).
-- First Doctor console time rotor bobbles vertically while the TARDIS is traveling (`DEMATERIALISING` / `IN_FLIGHT` / `MATERIALISING`) and rests when idle.
+- First Doctor console time rotor bobbles vertically while the TARDIS is traveling (`DEMATERIALISING` / `IN_FLIGHT` / `MATERIALISING`) and rests when idle; `Time_middle` spins on Y during those same phases (faster with stabilisers off) and is still when idle.
 - Demat/mat/in-flight play loopable travel SFX (seamless loops) for code-configured phase lengths (`DEMATERIALISING_DURATION_TICKS` / `MATERIALISING_DURATION_TICKS` in `TardisTravelService`); shell vanishes mid-demat at `DEMATERIALISING_SHELL_REMOVE_AT_TICK`; `IN_FLIGHT` uses a higher-pitched demat/mat-derived loop in the interior; materialisation ends with a landing thud. Travel does not auto-close or auto-open doors.
 
 ## How It Works In-Game

--- a/src/client/java/com/adamkali/dwm/model/tileentity/FirstDoctorConsoleModel.java
+++ b/src/client/java/com/adamkali/dwm/model/tileentity/FirstDoctorConsoleModel.java
@@ -29,11 +29,16 @@ public class FirstDoctorConsoleModel extends EntityModel<TardisRenderState> {
     /** Speed multiplier while traveling with stabilisers off. Amplitude is unchanged. */
     public static final float ROTOR_BOB_UNSTABILISED_SPEED_FACTOR = 1.5f;
 
+    /** Radians per tick for {@code Time_middle} Y-spin (~2 seconds per revolution at 20 TPS). */
+    public static final float ROTOR_SPIN_SPEED = (float) (Math.PI * 2.0 / 40.0);
+
     private final ModelPart timeRotor;
+    private final ModelPart timeMiddle;
 
     public FirstDoctorConsoleModel(ModelPart root) {
         super(root);
         this.timeRotor = root.getChild("time_rotor");
+        this.timeMiddle = this.timeRotor.getChild("Time_middle");
     }
 
     /**
@@ -68,6 +73,31 @@ public class FirstDoctorConsoleModel extends EntityModel<TardisRenderState> {
 
     public static float rotorPivotY(float bobOffset) {
         return bobOffset;
+    }
+
+    /**
+     * Y-axis spin for {@code Time_middle} in radians. Returns 0 when inactive.
+     *
+     * @param timeTicks age + tickDelta (or any continuous time base)
+     * @param active    whether the TARDIS is traveling
+     */
+    public static float rotorSpinRadians(float timeTicks, boolean active) {
+        return rotorSpinRadians(timeTicks, active, true);
+    }
+
+    /**
+     * Like {@link #rotorSpinRadians(float, boolean)} with optional unstabilised speed boost.
+     * Uses the same {@link #ROTOR_BOB_UNSTABILISED_SPEED_FACTOR} as the bob.
+     */
+    public static float rotorSpinRadians(float timeTicks, boolean active, boolean stabilisersEnabled) {
+        if (!active) {
+            return 0.0f;
+        }
+        float speed = ROTOR_SPIN_SPEED;
+        if (!stabilisersEnabled) {
+            speed *= ROTOR_BOB_UNSTABILISED_SPEED_FACTOR;
+        }
+        return timeTicks * speed;
     }
 
     public static LayerDefinition getTexturedModelData() {
@@ -424,5 +454,7 @@ public class FirstDoctorConsoleModel extends EntityModel<TardisRenderState> {
     public void setupAnim(TardisRenderState state) {
         this.timeRotor.resetPose();
         this.timeRotor.y = rotorPivotY(state.getRotorBobOffset());
+        this.timeMiddle.resetPose();
+        this.timeMiddle.yRot = state.getRotorSpinRadians();
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/FirstDoctorConsoleBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/FirstDoctorConsoleBlockEntityRenderer.java
@@ -208,6 +208,8 @@ public class FirstDoctorConsoleBlockEntityRenderer
         state.traveling = phase.isTraveling();
         state.rotorBobOffset = FirstDoctorConsoleModel.rotorBobOffset(
                 timeTicks, phase.isTraveling(), display.stabilisersEnabled());
+        state.rotorSpinRadians = FirstDoctorConsoleModel.rotorSpinRadians(
+                timeTicks, phase.isTraveling(), display.stabilisersEnabled());
         state.hologramYawDegrees = hologramYawDegrees(timeTicks);
         state.hologramBobOffset = hologramBobOffset(timeTicks);
 
@@ -255,6 +257,7 @@ public class FirstDoctorConsoleBlockEntityRenderer
     ) {
         TardisRenderState animState = new TardisRenderState();
         animState.setRotorBobOffset(state.rotorBobOffset);
+        animState.setRotorSpinRadians(state.rotorSpinRadians);
         applyDisplay(animState, state.display);
 
         poseStack.pushPose();

--- a/src/client/java/com/adamkali/dwm/render/state/FirstDoctorConsoleBlockEntityRenderState.java
+++ b/src/client/java/com/adamkali/dwm/render/state/FirstDoctorConsoleBlockEntityRenderState.java
@@ -10,6 +10,8 @@ import com.adamkali.dwm.tardis.logic.ConsoleDisplayState;
 public class FirstDoctorConsoleBlockEntityRenderState extends BlockEntityRenderState {
     public Direction facing = Direction.NORTH;
     public float rotorBobOffset;
+    /** {@code Time_middle} Y-spin in radians (0 when landed). */
+    public float rotorSpinRadians;
     /** Synced console instruments (variant, toggles, environment readout). */
     public ConsoleDisplayState display = ConsoleDisplayState.defaults();
     /** Whether the TARDIS is currently traveling (for rotor smoke FX). */

--- a/src/client/java/com/adamkali/dwm/render/state/TardisRenderState.java
+++ b/src/client/java/com/adamkali/dwm/render/state/TardisRenderState.java
@@ -7,6 +7,8 @@ public class TardisRenderState extends EntityRenderState {
     private float doorSwingProgress;
     /** Vertical time-rotor bob offset in model units (0 when landed). */
     private float rotorBobOffset;
+    /** {@code Time_middle} Y-spin in radians (0 when landed). */
+    private float rotorSpinRadians;
     /** Console stabilisers toggle (default on). Used by {@code StabilisersModel}. */
     private boolean stabilisersEnabled = true;
     /** 0–1 needle pose for the currently submitted reader / refueler. */
@@ -20,6 +22,7 @@ public class TardisRenderState extends EntityRenderState {
     public TardisRenderState() {
         this.doorSwingProgress = 0.0f;
         this.rotorBobOffset = 0.0f;
+        this.rotorSpinRadians = 0.0f;
         this.stabilisersEnabled = true;
     }
 
@@ -37,6 +40,14 @@ public class TardisRenderState extends EntityRenderState {
 
     public float getRotorBobOffset() {
         return this.rotorBobOffset;
+    }
+
+    public void setRotorSpinRadians(float rotorSpinRadians) {
+        this.rotorSpinRadians = rotorSpinRadians;
+    }
+
+    public float getRotorSpinRadians() {
+        return this.rotorSpinRadians;
     }
 
     public void setStabilisersEnabled(boolean stabilisersEnabled) {

--- a/src/test/java/com/adamkali/dwm/model/tileentity/FirstDoctorConsoleModelTest.java
+++ b/src/test/java/com/adamkali/dwm/model/tileentity/FirstDoctorConsoleModelTest.java
@@ -84,6 +84,43 @@ class FirstDoctorConsoleModelTest {
     }
 
     @Test
+    void rotorSpinRadians_zeroWhenInactive() {
+        assertEquals(0.0f, FirstDoctorConsoleModel.rotorSpinRadians(12.5f, false), EPSILON);
+        assertEquals(0.0f, FirstDoctorConsoleModel.rotorSpinRadians(0.0f, false), EPSILON);
+        assertEquals(0.0f, FirstDoctorConsoleModel.rotorSpinRadians(40.0f, false, false), EPSILON);
+    }
+
+    @Test
+    void rotorSpinRadians_scalesWithTimeWhenActive() {
+        assertEquals(0.0f, FirstDoctorConsoleModel.rotorSpinRadians(0.0f, true), EPSILON);
+        assertEquals(
+                12.5f * FirstDoctorConsoleModel.ROTOR_SPIN_SPEED,
+                FirstDoctorConsoleModel.rotorSpinRadians(12.5f, true),
+                EPSILON
+        );
+        assertEquals(
+                (float) (Math.PI * 2.0),
+                FirstDoctorConsoleModel.rotorSpinRadians(40.0f, true),
+                EPSILON
+        );
+    }
+
+    @Test
+    void rotorSpinRadians_unstabilisedAdvancesFaster() {
+        float t = 20.0f;
+        float stable = FirstDoctorConsoleModel.rotorSpinRadians(t, true, true);
+        float unstable = FirstDoctorConsoleModel.rotorSpinRadians(t, true, false);
+        assertEquals(t * FirstDoctorConsoleModel.ROTOR_SPIN_SPEED, stable, EPSILON);
+        assertEquals(
+                t * FirstDoctorConsoleModel.ROTOR_SPIN_SPEED
+                        * FirstDoctorConsoleModel.ROTOR_BOB_UNSTABILISED_SPEED_FACTOR,
+                unstable,
+                EPSILON
+        );
+        assertTrue(unstable > stable + EPSILON, "unstabilised spin should advance further at the same tick");
+    }
+
+    @Test
     void setAngles_movesTimeRotorPivotY() {
         ModelPart root = FirstDoctorConsoleModel.getTexturedModelData().bakeRoot();
         FirstDoctorConsoleModel model = new FirstDoctorConsoleModel(root);
@@ -97,5 +134,25 @@ class FirstDoctorConsoleModelTest {
         state.setRotorBobOffset(0.0f);
         model.setupAnim(state);
         assertEquals(0.0f, timeRotor.y, EPSILON);
+    }
+
+    @Test
+    void setAngles_spinsTimeMiddleWithoutChangingBob() {
+        ModelPart root = FirstDoctorConsoleModel.getTexturedModelData().bakeRoot();
+        FirstDoctorConsoleModel model = new FirstDoctorConsoleModel(root);
+        ModelPart timeRotor = root.getChild("time_rotor");
+        ModelPart timeMiddle = timeRotor.getChild("Time_middle");
+
+        TardisRenderState state = new TardisRenderState();
+        state.setRotorBobOffset(-2.5f);
+        state.setRotorSpinRadians(1.25f);
+        model.setupAnim(state);
+        assertEquals(-2.5f, timeRotor.y, EPSILON);
+        assertEquals(1.25f, timeMiddle.yRot, EPSILON);
+
+        state.setRotorSpinRadians(0.0f);
+        model.setupAnim(state);
+        assertEquals(-2.5f, timeRotor.y, EPSILON);
+        assertEquals(0.0f, timeMiddle.yRot, EPSILON);
     }
 }


### PR DESCRIPTION
## Why this matters

- Artist spec calls for `Time_Middle` to spin while the First Doctor console rotor bobs during travel; idle consoles should stay still. Closes #131.

## Proposed Implementation

- Compute travel-gated `rotorSpinRadians` on `FirstDoctorConsoleModel` (idle = 0; ~2s/rev; 1.5× when unstabilised) and apply it to `Time_middle.yRot` in `setupAnim`.
- Plumb the value through `FirstDoctorConsoleBlockEntityRenderState` and `TardisRenderState` in the existing BER extract/submit path so the parent `time_rotor` bob is unchanged.
- Unit tests cover idle, active, unstabilised speed, and bob regression; `docs/feature-tardis-block.md` notes the spin.

## Problems Encountered / Decisions Made

- None

Made with [Cursor](https://cursor.com)