### PR TITLE
fix(tardis): render globe as 3D item instead of missing sprite

### DIFF
--- a/src/client/java/com/adamkali/dwm/DWMClient.java
+++ b/src/client/java/com/adamkali/dwm/DWMClient.java
@@ -6,6 +6,7 @@ import com.adamkali.dwm.render.ConsoleControlHud;
 import com.adamkali.dwm.render.ConsoleHitboxDebugRenderer;
 import com.adamkali.dwm.render.TardisCompactScannerSpecialRenderer;
 import com.adamkali.dwm.render.TardisFullScannerSpecialRenderer;
+import com.adamkali.dwm.render.TardisGlobeSpecialRenderer;
 import com.adamkali.dwm.render.portal.PortalPerfDebugHud;
 import com.adamkali.dwm.render.portal.PortalPerfDebugLog;
 import com.adamkali.dwm.render.portal.PortalSupport;
@@ -25,6 +26,9 @@ public class DWMClient implements ClientModInitializer {
         SpecialModelRenderers.ID_MAPPER.put(
                 Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "tardis_compact_scanner"),
                 TardisCompactScannerSpecialRenderer.Unbaked.MAP_CODEC);
+        SpecialModelRenderers.ID_MAPPER.put(
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "tardis_globe"),
+                TardisGlobeSpecialRenderer.Unbaked.MAP_CODEC);
         DWMRenderLayerManager.initialize();
         DWMEntityRenderers.initialize();
         ClientAnalyticsManager.initialize();

--- a/src/client/java/com/adamkali/dwm/render/TardisGlobeSpecialRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisGlobeSpecialRenderer.java
@@ -1,0 +1,111 @@
+package com.adamkali.dwm.render;
+
+import com.adamkali.dwm.block.TardisDecorShapes;
+import com.adamkali.dwm.model.tileentity.TardisGlobeModel;
+import com.adamkali.dwm.render.state.TardisRenderState;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.math.Axis;
+import com.mojang.serialization.MapCodec;
+import java.util.function.Consumer;
+import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.client.renderer.special.NoDataSpecialModelRenderer;
+import net.minecraft.client.renderer.special.SpecialModelRenderer;
+import net.minecraft.world.phys.AABB;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+
+/**
+ * Item special renderer for the TARDIS globe — reuses the BER EntityModel mesh
+ * so GUI / ground / hand show the 3D prop instead of the flat (missing) block atlas sprite.
+ */
+public class TardisGlobeSpecialRenderer implements NoDataSpecialModelRenderer {
+    private final TardisGlobeModel model;
+    private final TardisRenderState animState = new TardisRenderState();
+
+    public TardisGlobeSpecialRenderer(TardisGlobeModel model) {
+        this.model = model;
+    }
+
+    @Override
+    public void submit(
+            PoseStack poseStack,
+            SubmitNodeCollector submitNodeCollector,
+            int lightCoords,
+            int overlayCoords,
+            boolean hasFoil,
+            int outlineColor
+    ) {
+        poseStack.pushPose();
+        // JSON item space: corner origin with XZ centered via +0.5; 180° Y so the
+        // ring face (thin Z profile) presents to vanilla GUI [30, 225, 0].
+        poseStack.translate(0.5, 0.0, 0.5);
+        poseStack.mulPose(Axis.YP.rotationDegrees(180.0F));
+        submitNodeCollector.order(0).submitModel(
+                this.model,
+                this.animState,
+                poseStack,
+                TardisGlobeModel.TEXTURE_LOCATION,
+                lightCoords,
+                overlayCoords,
+                outlineColor,
+                null);
+        if (hasFoil) {
+            submitNodeCollector.order(1).submitModel(
+                    this.model,
+                    this.animState,
+                    poseStack,
+                    RenderTypes.entityGlint(),
+                    lightCoords,
+                    overlayCoords,
+                    outlineColor,
+                    null);
+        }
+        poseStack.popPose();
+    }
+
+    @Override
+    public void getExtents(Consumer<Vector3fc> output) {
+        emitExtents(output);
+    }
+
+    /**
+     * Emits the eight corners of {@link TardisDecorShapes#GLOBE} in JSON
+     * corner-origin item space so {@code base} display can use vanilla block-like
+     * rotations. Must match {@link #submit} after the +0.5 XZ translate.
+     * Pure helper for unit tests.
+     */
+    public static void emitExtents(Consumer<Vector3fc> output) {
+        AABB box = TardisDecorShapes.GLOBE.bounds();
+        float minX = (float) box.minX;
+        float minY = (float) box.minY;
+        float minZ = (float) box.minZ;
+        float maxX = (float) box.maxX;
+        float maxY = (float) box.maxY;
+        float maxZ = (float) box.maxZ;
+        output.accept(new Vector3f(minX, minY, minZ));
+        output.accept(new Vector3f(minX, minY, maxZ));
+        output.accept(new Vector3f(minX, maxY, minZ));
+        output.accept(new Vector3f(minX, maxY, maxZ));
+        output.accept(new Vector3f(maxX, minY, minZ));
+        output.accept(new Vector3f(maxX, minY, maxZ));
+        output.accept(new Vector3f(maxX, maxY, minZ));
+        output.accept(new Vector3f(maxX, maxY, maxZ));
+    }
+
+    public record Unbaked() implements NoDataSpecialModelRenderer.Unbaked {
+        public static final MapCodec<TardisGlobeSpecialRenderer.Unbaked> MAP_CODEC =
+                MapCodec.unit(new TardisGlobeSpecialRenderer.Unbaked());
+
+        @Override
+        public MapCodec<TardisGlobeSpecialRenderer.Unbaked> type() {
+            return MAP_CODEC;
+        }
+
+        @Override
+        public TardisGlobeSpecialRenderer bake(SpecialModelRenderer.BakingContext context) {
+            return new TardisGlobeSpecialRenderer(
+                    new TardisGlobeModel(context.entityModelSet().bakeLayer(TardisGlobeModel.LAYER_LOCATION)));
+        }
+    }
+}

--- a/src/client/resources/assets/dwm/items/tardis_globe.json
+++ b/src/client/resources/assets/dwm/items/tardis_globe.json
@@ -1,6 +1,9 @@
 {
   "model": {
-    "type": "minecraft:model",
-    "model": "dwm:item/tardis_globe"
+    "type": "minecraft:special",
+    "base": "dwm:item/tardis_globe",
+    "model": {
+      "type": "dwm:tardis_globe"
+    }
   }
 }

--- a/src/client/resources/assets/dwm/models/item/tardis_globe.json
+++ b/src/client/resources/assets/dwm/models/item/tardis_globe.json
@@ -1,6 +1,39 @@
 {
-  "parent": "minecraft:item/generated",
+  "parent": "minecraft:builtin/entity",
+  "gui_light": "side",
   "textures": {
-    "layer0": "dwm:block/tardis_globe"
+    "particle": "dwm:entity/tardis_globe"
+  },
+  "display": {
+    "gui": {
+      "rotation": [30, 225, 0],
+      "translation": [0, -2.2, 0],
+      "scale": [0.30, 0.30, 0.30]
+    },
+    "ground": {
+      "rotation": [0, 0, 0],
+      "translation": [0, 3, 0],
+      "scale": [0.15, 0.15, 0.15]
+    },
+    "fixed": {
+      "rotation": [0, 0, 0],
+      "translation": [0, -2.2, 0],
+      "scale": [0.24, 0.24, 0.24]
+    },
+    "thirdperson_righthand": {
+      "rotation": [75, 45, 0],
+      "translation": [0, 2.5, 0],
+      "scale": [0.18, 0.18, 0.18]
+    },
+    "firstperson_righthand": {
+      "rotation": [0, 45, 0],
+      "translation": [0, 0, 0],
+      "scale": [0.19, 0.19, 0.19]
+    },
+    "firstperson_lefthand": {
+      "rotation": [0, 225, 0],
+      "translation": [0, 0, 0],
+      "scale": [0.19, 0.19, 0.19]
+    }
   }
 }

--- a/src/test/java/com/adamkali/dwm/ResourceValidationTests.java
+++ b/src/test/java/com/adamkali/dwm/ResourceValidationTests.java
@@ -307,6 +307,27 @@ public class ResourceValidationTests {
         }
     }
 
+    /**
+     * Globe is a BER EntityModel prop; inventory must use the special renderer, not a
+     * {@code minecraft:model} sprite pointing at the missing block atlas.
+     */
+    @Test
+    public void tardisGlobeItemModelIsSpecialRenderer() throws Exception {
+        Path itemDef = Path.of("src/client/resources/assets/dwm/items/tardis_globe.json");
+        JSONObject def = readJson(itemDef);
+        JSONObject model = def.getJSONObject("model");
+        assertEquals("minecraft:special", model.getString("type"));
+        assertEquals("dwm:item/tardis_globe", model.getString("base"));
+        assertEquals("dwm:tardis_globe", model.getJSONObject("model").getString("type"));
+
+        Path baseModel = Path.of("src/client/resources/assets/dwm/models/item/tardis_globe.json");
+        JSONObject base = readJson(baseModel);
+        assertEquals("minecraft:builtin/entity", base.getString("parent"));
+        assertEquals("side", base.getString("gui_light"));
+        assertEquals("dwm:entity/tardis_globe", base.getJSONObject("textures").getString("particle"));
+        assertFalse(base.getJSONObject("display").has("thirdperson_lefthand"));
+    }
+
     private static JSONObject readJson(Path path) throws Exception {
         return new JSONObject(new JSONTokener(Files.readString(path)));
     }

--- a/src/test/java/com/adamkali/dwm/render/TardisGlobeSpecialRendererTest.java
+++ b/src/test/java/com/adamkali/dwm/render/TardisGlobeSpecialRendererTest.java
@@ -1,0 +1,60 @@
+package com.adamkali.dwm.render;
+
+import com.adamkali.dwm.block.TardisDecorShapes;
+import java.util.ArrayList;
+import java.util.List;
+import org.joml.Vector3fc;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TardisGlobeSpecialRendererTest {
+    private static final float EPSILON = 1e-4f;
+
+    @Test
+    void unbakedCodec_isIdentityType() {
+        TardisGlobeSpecialRenderer.Unbaked unbaked = new TardisGlobeSpecialRenderer.Unbaked();
+        assertSame(TardisGlobeSpecialRenderer.Unbaked.MAP_CODEC, unbaked.type());
+    }
+
+    @Test
+    void emitExtents_matchesGlobeJsonCornerOrigin() {
+        List<Vector3fc> corners = new ArrayList<>();
+        TardisGlobeSpecialRenderer.emitExtents(corners::add);
+        assertEquals(8, corners.size());
+
+        float minX = Float.POSITIVE_INFINITY;
+        float minY = Float.POSITIVE_INFINITY;
+        float minZ = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY;
+        float maxY = Float.NEGATIVE_INFINITY;
+        float maxZ = Float.NEGATIVE_INFINITY;
+        for (Vector3fc corner : corners) {
+            minX = Math.min(minX, corner.x());
+            minY = Math.min(minY, corner.y());
+            minZ = Math.min(minZ, corner.z());
+            maxX = Math.max(maxX, corner.x());
+            maxY = Math.max(maxY, corner.y());
+            maxZ = Math.max(maxZ, corner.z());
+        }
+
+        var box = TardisDecorShapes.GLOBE.bounds();
+        assertEquals((float) box.minX, minX, EPSILON);
+        assertEquals((float) box.minY, minY, EPSILON);
+        assertEquals((float) box.minZ, minZ, EPSILON);
+        assertEquals((float) box.maxX, maxX, EPSILON);
+        assertEquals((float) box.maxY, maxY, EPSILON);
+        assertEquals((float) box.maxZ, maxZ, EPSILON);
+
+        // Regression: must span ~9×4×33.5 px in JSON corner space, taller than one block.
+        assertEquals(0.21875f, minX, EPSILON);
+        assertEquals(0.0f, minY, EPSILON);
+        assertEquals(0.375f, minZ, EPSILON);
+        assertEquals(0.78125f, maxX, EPSILON);
+        assertEquals(2.09375f, maxY, EPSILON);
+        assertEquals(0.625f, maxZ, EPSILON);
+        assertTrue(maxY - minY > 2.0f);
+    }
+}


### PR DESCRIPTION
## Why this matters

- The TARDIS globe item used a 2D `item/generated` sprite pointing at a missing block atlas, so inventory, hands, frames, and drops did not match the 3D BER mesh.

## Proposed Implementation

- Added `TardisGlobeSpecialRenderer` (compact-scanner pattern) that submits the existing `TardisGlobeModel` with entity texture, registered as `dwm:tardis_globe`.
- Item definition is now `minecraft:special`; the base model uses `builtin/entity` with block-like display transforms for a 33.5px mesh (`gui_light: side`).
- Renderer extent tests plus `ResourceValidationTests.tardisGlobeItemModelIsSpecialRenderer` cover identity. Targeted `./gradlew test` passed.

## Problems Encountered / Decisions Made

- The globe is a BER EntityModel with rotated rings, so a JSON block parent like the column would still be a cube. Special renderer reuses the in-world mesh instead.


Made with [Cursor](https://cursor.com)