### PR TITLE
fix(tardis): disable entity outline on closed exterior

### DIFF
--- a/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
@@ -159,7 +159,7 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
                     RenderTypes.entityCutout(texture),
                     state.lightCoords,
                     OverlayTexture.NO_OVERLAY,
-                    -1,
+                    0,
                     state.breakProgress);
         }
         poseStack.popPose();


### PR DESCRIPTION
## Why this matters

- Closed TARDIS exteriors were drawing a glowing white silhouette, which reads as a visual bug and is inconsistent with open-door rendering.

## Proposed Implementation

- In `TardisBlockEntityRenderer.submitExterior`, pass `0` (no outline) to `submitModel` instead of `-1` (`0xFFFFFFFF` white glow).
- Matches interior door, console, and decor BERs. Open-door path already uses `submitCustomGeometry` and was unaffected.
- Validated with `./gradlew compileClientJava`.

## Problems Encountered / Decisions Made

- None

Made with [Cursor](https://cursor.com)