### PR TITLE
fix(tardis): draw door leaves over BOTI and SOTO previews

### DIFF
--- a/src/client/java/com/adamkali/dwm/mixin/client/RenderPipelinesMixin.java
+++ b/src/client/java/com/adamkali/dwm/mixin/client/RenderPipelinesMixin.java
@@ -1,0 +1,23 @@
+package com.adamkali.dwm.mixin.client;
+
+import com.adamkali.dwm.render.portal.PortalDoorRenderer;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
+import net.minecraft.client.renderer.RenderPipelines;
+
+/**
+ * Registers the opaque no-depth-write portal composite pipeline before vanilla
+ * compiles {@link RenderPipelines#getStaticPipelines()}.
+ */
+@Mixin(RenderPipelines.class)
+public class RenderPipelinesMixin {
+    @Inject(method = "getStaticPipelines", at = @At("HEAD"))
+    private static void dwm$ensurePortalCompositePipeline(CallbackInfoReturnable<List<RenderPipeline>> cir) {
+        PortalDoorRenderer.ensurePipelineRegistered();
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
@@ -12,6 +12,7 @@ import com.adamkali.dwm.model.tileentity.TTCapsuleModel;
 import com.adamkali.dwm.model.tileentity.TardisModel;
 import com.adamkali.dwm.model.tileentity.ThirdDoctorTardisModel;
 import com.adamkali.dwm.render.boti.TardisBotiRenderer;
+import com.adamkali.dwm.render.portal.PortalDoorRenderer;
 import com.adamkali.dwm.render.state.TardisBlockEntityRenderState;
 import com.adamkali.dwm.render.state.TardisRenderState;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
@@ -208,9 +209,9 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         applyExteriorTransforms(poseStack, state.rotationDegrees);
         int light = state.lightCoords;
         int color = shellColor(state);
-        submitNodeCollector.submitCustomGeometry(
+        submitNodeCollector.order(PortalDoorRenderer.DOOR_OVERLAY_ORDER).submitCustomGeometry(
                 poseStack,
-                shellRenderType(texture, state),
+                PortalDoorRenderer.doorOverlayRenderType(texture),
                 (pose, consumer) -> {
                     PoseStack local = new PoseStack();
                     local.last().set(pose);

--- a/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisBlockEntityRenderer.java
@@ -12,12 +12,14 @@ import com.adamkali.dwm.model.tileentity.TTCapsuleModel;
 import com.adamkali.dwm.model.tileentity.TardisModel;
 import com.adamkali.dwm.model.tileentity.ThirdDoctorTardisModel;
 import com.adamkali.dwm.render.boti.TardisBotiRenderer;
+import com.adamkali.dwm.render.portal.PortalApertureComposite;
 import com.adamkali.dwm.render.portal.PortalDoorRenderer;
 import com.adamkali.dwm.render.state.TardisBlockEntityRenderState;
 import com.adamkali.dwm.render.state.TardisRenderState;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
+import com.adamkali.dwm.tardis.TardisExteriorFacing;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.adamkali.dwm.tardis.logic.TardisShellOpacity;
 import com.mojang.blaze3d.vertex.PoseStack;
@@ -32,6 +34,7 @@ import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.Direction;
 import net.minecraft.resources.Identifier;
 import net.minecraft.util.ARGB;
 import net.minecraft.world.level.block.state.BlockState;
@@ -80,6 +83,7 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
         state.variant = Objects.requireNonNullElse(TardisLogic.getVariant(entity.getTardisId()), TardisChameleonVariant.TT_CAPSULE);
         state.doorSwing = doorState.doorSwing;
         state.rotationDegrees = RotationSegment.convertToDegrees(rotation);
+        state.facingRotation = rotation;
         state.partialTicks = partialTicks;
         state.tardisId = entity.getTardisId();
         state.shouldRenderBoti = TardisBotiRenderer.shouldRender(doorState);
@@ -119,12 +123,20 @@ public class TardisBlockEntityRenderer implements BlockEntityRenderer<TardisBloc
 
             poseStack.pushPose();
             applyExteriorTransforms(poseStack, state.rotationDegrees);
+            Vec3 exteriorDoorCenter = new Vec3(
+                    state.blockPos.getX() + 0.5,
+                    state.blockPos.getY() + 1.0,
+                    state.blockPos.getZ() + 0.5
+            );
+            Direction exteriorOutward = TardisExteriorFacing.doorDirection(state.facingRotation);
+            float viewPanU = PortalApertureComposite.viewPanU(camera.pos, exteriorDoorCenter, exteriorOutward);
             TardisBotiRenderer.render(
                     poseStack,
                     submitNodeCollector,
                     state.partialTicks,
                     state.tardisId,
-                    state.variant
+                    state.variant,
+                    viewPanU
             );
             poseStack.popPose();
 

--- a/src/client/java/com/adamkali/dwm/render/TardisInteriorDoorBlockEntityRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/TardisInteriorDoorBlockEntityRenderer.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.render;
 import com.adamkali.dwm.block.TardisInteriorDoorBlock;
 import com.adamkali.dwm.block.entities.TardisInteriorDoorBlockEntity;
 import com.adamkali.dwm.model.tileentity.TardisClassicInteriorDoorModel;
+import com.adamkali.dwm.render.portal.PortalDoorRenderer;
 import com.adamkali.dwm.render.soto.TardisSotoRenderer;
 import com.adamkali.dwm.render.state.TardisInteriorDoorBlockEntityRenderState;
 import com.adamkali.dwm.render.state.TardisRenderState;
@@ -144,9 +145,9 @@ public class TardisInteriorDoorBlockEntityRenderer
             TardisInteriorDoorBlockEntityRenderState state
     ) {
         int light = state.lightCoords;
-        submitNodeCollector.submitCustomGeometry(
+        submitNodeCollector.order(PortalDoorRenderer.DOOR_OVERLAY_ORDER).submitCustomGeometry(
                 poseStack,
-                RenderTypes.entityCutout(TardisClassicInteriorDoorModel.TEXTURE_LOCATION),
+                PortalDoorRenderer.doorOverlayRenderType(TardisClassicInteriorDoorModel.TEXTURE_LOCATION),
                 (pose, consumer) -> {
                     PoseStack local = new PoseStack();
                     local.last().set(pose);

--- a/src/client/java/com/adamkali/dwm/render/boti/TardisBotiRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/boti/TardisBotiRenderer.java
@@ -16,8 +16,8 @@ import net.minecraft.client.renderer.SubmitNodeCollector;
  * Exterior BOTI: thin facade that builds an interior look-in {@link PortalScene} and
  * delegates schedule/composite to {@link PortalDoorRenderer}.
  * <p>
- * Hitch-fixed camera at the interior door plane looking into the console room; composite UV
- * crop uses each chameleon's {@link PortalAperture}.
+ * Hitch-fixed camera at the interior door plane looking into the console room. Composite UV
+ * crop uses each chameleon's {@link PortalAperture} and can pan with the viewer.
  */
 public final class TardisBotiRenderer {
     /** Interior door opening center (local structure coords). */
@@ -43,7 +43,8 @@ public final class TardisBotiRenderer {
             SubmitNodeCollector submitNodeCollector,
             float tickDelta,
             UUID tardisId,
-            TardisChameleonVariant variant
+            TardisChameleonVariant variant,
+            float viewPanU
     ) {
         if (tardisId == null || variant == null) {
             return;
@@ -54,7 +55,7 @@ public final class TardisBotiRenderer {
                 tickDelta,
                 new BotiPortalContent(tardisId)
         );
-        PortalDoorRenderer.render(matrices, submitNodeCollector, scene, aperture);
+        PortalDoorRenderer.render(matrices, submitNodeCollector, scene, aperture, viewPanU, 0.0f);
     }
 
     /** Expose layout size for tests / debug. */

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalApertureComposite.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalApertureComposite.java
@@ -8,7 +8,10 @@ import org.joml.Matrix4f;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.renderer.texture.OverlayTexture;
+import net.minecraft.core.Direction;
 import net.minecraft.util.LightCoordsUtil;
+import net.minecraft.util.Mth;
+import net.minecraft.world.phys.Vec3;
 
 /**
  * Shared aperture compositing: aspect-matched portal UV crop and placeholder quads.
@@ -18,6 +21,12 @@ import net.minecraft.util.LightCoordsUtil;
  */
 public final class PortalApertureComposite {
     private static final int FULLBRIGHT = LightCoordsUtil.FULL_BRIGHT;
+
+    /**
+     * How hard the hitch-fixed FBO crop tracks viewer azimuth. 1.0 would use the full
+     * leftover letterbox; keep below that so side walls stay out of the doorway.
+     */
+    static final float VIEW_PAN_GAIN = 0.22f;
 
     /** Placeholder ARGB while waiting for the first END_MAIN portal texture. */
     public static final int PLACEHOLDER_ARGB = 0xFF203040;
@@ -30,6 +39,17 @@ public final class PortalApertureComposite {
             SubmitNodeCollector submitNodeCollector,
             PortalAperture aperture,
             PortalRenderer.PortalTexture portalTexture
+    ) {
+        drawPortalComposite(matrices, submitNodeCollector, aperture, portalTexture, 0.0f, 0.0f);
+    }
+
+    public static void drawPortalComposite(
+            PoseStack matrices,
+            SubmitNodeCollector submitNodeCollector,
+            PortalAperture aperture,
+            PortalRenderer.PortalTexture portalTexture,
+            float viewPanU,
+            float viewPanV
     ) {
         PortalSamplingTexture.bindPortalColor(PortalRenderTarget.getInstance());
 
@@ -56,10 +76,15 @@ public final class PortalApertureComposite {
             cropV = fbAspect / doorAspect;
         }
 
-        float uMin = 0.5f - cropU * 0.5f;
-        float uMax = 0.5f + cropU * 0.5f;
-        float vMin = 0.5f - cropV * 0.5f;
-        float vMax = 0.5f + cropV * 0.5f;
+        float maxShiftU = (1.0f - cropU) * 0.5f;
+        float maxShiftV = (1.0f - cropV) * 0.5f;
+        float shiftU = Mth.clamp(viewPanU * VIEW_PAN_GAIN, -maxShiftU, maxShiftU);
+        float shiftV = Mth.clamp(viewPanV * VIEW_PAN_GAIN, -maxShiftV, maxShiftV);
+
+        float uMin = 0.5f - cropU * 0.5f - shiftU;
+        float uMax = 0.5f + cropU * 0.5f - shiftU;
+        float vMin = 0.5f - cropV * 0.5f - shiftV;
+        float vMax = 0.5f + cropV * 0.5f - shiftV;
         // y0/bottom → vMax; BER X-180 already flips the quad in model space.
         float[] us = {uMin, uMin, uMax, uMax};
         float[] vs = {vMax, vMin, vMin, vMax};
@@ -81,6 +106,25 @@ public final class PortalApertureComposite {
                     }
                 }
         );
+    }
+
+    /**
+     * Signed doorway pan from the viewer: positive when the player is to the door's right.
+     * Composite UVs subtract this so strafing right reveals more of the left interior.
+     */
+    public static float viewPanU(Vec3 playerEye, Vec3 exteriorDoorCenter, Direction exteriorOutward) {
+        if (playerEye == null || exteriorDoorCenter == null || exteriorOutward == null) {
+            return 0.0f;
+        }
+        Vec3 outward = new Vec3(
+                exteriorOutward.getStepX(),
+                exteriorOutward.getStepY(),
+                exteriorOutward.getStepZ()
+        );
+        Vec3 right = new Vec3(outward.z, 0.0, -outward.x);
+        Vec3 delta = playerEye.subtract(exteriorDoorCenter);
+        double localOut = Math.max(delta.dot(outward), 0.25);
+        return (float) (delta.dot(right) / localOut);
     }
 
     public static void drawApertureQuad(

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalApertureComposite.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalApertureComposite.java
@@ -68,7 +68,7 @@ public final class PortalApertureComposite {
 
         submitNodeCollector.submitCustomGeometry(
                 matrices,
-                RenderTypes.entityCutout(PortalSamplingTexture.ID),
+                PortalDoorRenderer.portalCompositeRenderType(),
                 (PoseStack.Pose pose, VertexConsumer consumer) -> {
                     Matrix4f matrix = pose.pose();
                     for (int i = 0; i < 4; i++) {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalCameraTransform.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalCameraTransform.java
@@ -10,7 +10,7 @@ import net.minecraft.world.phys.Vec3;
 /**
  * Pure geometry for hitch-fixed portal cameras.
  * <p>
- * BER facades supply eye + look; interior player motion does not dolly or pan the view.
+ * BER facades supply eye + look; interior player motion does not dolly or pan the hitch.
  */
 public final class PortalCameraTransform {
 

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
@@ -1,15 +1,24 @@
 package com.adamkali.dwm.render.portal;
 
+import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.tardis.data.model.PortalAperture;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
 import com.adamkali.dwm.tardis.interior.TardisPortalGate;
+import com.mojang.blaze3d.pipeline.DepthStencilState;
+import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.platform.CompareOp;
 import com.mojang.blaze3d.vertex.PoseStack;
 
+import java.util.function.Function;
+import net.minecraft.client.renderer.BindGroupLayouts;
+import net.minecraft.client.renderer.RenderPipelines;
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.rendertype.RenderSetup;
 import net.minecraft.client.renderer.rendertype.RenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.resources.Identifier;
+import net.minecraft.util.Util;
 
 /**
  * Shared BER loop: schedule portal work, peek last texture, composite or placeholder.
@@ -21,7 +30,45 @@ public final class PortalDoorRenderer {
      */
     public static final int DOOR_OVERLAY_ORDER = 1;
 
+    /**
+     * Opaque entity-cutout clone with {@code writeDepth=false}. Covers world color in the
+     * doorway (no translucent blend) so strafing cannot parallax terrain through the
+     * preview, while inward-swinging leaves can still pass the leftover depth.
+     * <p>
+     * Uses vanilla {@code core/entity} shaders from {@link RenderPipelines#ENTITY_SNIPPET}.
+     * Must be {@link RenderPipelines#register}ed before {@link RenderPipelines#getStaticPipelines()}
+     * compiles GPU programs — see client mixin.
+     */
+    public static final RenderPipeline PORTAL_COMPOSITE_PIPELINE = RenderPipelines.register(
+            RenderPipeline.builder(RenderPipelines.ENTITY_SNIPPET)
+                    .withLocation(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "pipeline/portal_composite"))
+                    .withShaderDefine("ALPHA_CUTOUT", 0.1F)
+                    .withShaderDefine("PER_FACE_LIGHTING")
+                    .withBindGroupLayout(BindGroupLayouts.SAMPLER1)
+                    .withCull(false)
+                    .withDepthStencilState(new DepthStencilState(CompareOp.GREATER_THAN_OR_EQUAL, false))
+                    .build()
+    );
+
+    private static final Function<Identifier, RenderType> PORTAL_COMPOSITE = Util.memoize(
+            texture -> RenderType.create(
+                    "dwm_portal_composite",
+                    RenderSetup.builder(PORTAL_COMPOSITE_PIPELINE)
+                            .withTexture("Sampler0", texture)
+                            .useLightmap()
+                            .useOverlay()
+                            .createRenderSetup()
+            )
+    );
+
     private PortalDoorRenderer() {
+    }
+
+    /** Touch the pipeline field so {@link RenderPipelines#register} runs before shader compile. */
+    public static void ensurePipelineRegistered() {
+        if (PORTAL_COMPOSITE_PIPELINE == null) {
+            throw new IllegalStateException("Portal composite pipeline failed to register");
+        }
     }
 
     public static boolean shouldRender(float doorSwing) {
@@ -46,12 +93,11 @@ public final class PortalDoorRenderer {
     }
 
     /**
-     * Vanilla emissive translucent pipeline: compiled with the game shaders and
-     * {@code writeDepth=false}, so inward-swinging leaves are not depth-rejected
-     * by the aperture quad.
+     * Opaque doorway stamp: no blend (covers world), {@code writeDepth=false} so
+     * inward-swinging leaves are not depth-rejected by the aperture quad.
      */
     public static RenderType portalCompositeRenderType() {
-        return RenderTypes.entityTranslucentEmissive(PortalSamplingTexture.ID);
+        return PORTAL_COMPOSITE.apply(PortalSamplingTexture.ID);
     }
 
     /**
@@ -63,6 +109,17 @@ public final class PortalDoorRenderer {
             SubmitNodeCollector submitNodeCollector,
             PortalScene scene,
             PortalAperture aperture
+    ) {
+        render(matrices, submitNodeCollector, scene, aperture, 0.0f, 0.0f);
+    }
+
+    public static void render(
+            PoseStack matrices,
+            SubmitNodeCollector submitNodeCollector,
+            PortalScene scene,
+            PortalAperture aperture,
+            float viewPanU,
+            float viewPanV
     ) {
         if (matrices == null || submitNodeCollector == null || scene == null || aperture == null) {
             return;
@@ -79,7 +136,9 @@ public final class PortalDoorRenderer {
                         matrices,
                         submitNodeCollector,
                         aperture,
-                        portalTexture
+                        portalTexture,
+                        viewPanU,
+                        viewPanV
                 );
             } else {
                 PortalApertureComposite.drawPlaceholder(matrices, submitNodeCollector, aperture);

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
@@ -7,11 +7,20 @@ import com.adamkali.dwm.tardis.interior.TardisPortalGate;
 import com.mojang.blaze3d.vertex.PoseStack;
 
 import net.minecraft.client.renderer.SubmitNodeCollector;
+import net.minecraft.client.renderer.rendertype.RenderType;
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.resources.Identifier;
 
 /**
  * Shared BER loop: schedule portal work, peek last texture, composite or placeholder.
  */
 public final class PortalDoorRenderer {
+    /**
+     * Door leaves flush on a later {@link SubmitNodeCollector#order(int)} than the
+     * aperture preview so they composite after the portal color stamp.
+     */
+    public static final int DOOR_OVERLAY_ORDER = 1;
+
     private PortalDoorRenderer() {
     }
 
@@ -25,6 +34,24 @@ public final class PortalDoorRenderer {
         return DWMConfig.getBoolean(DWMConfig.ENABLE_DOOR_PORTALS)
                 && PortalSupport.isAvailable()
                 && TardisPortalGate.shouldShow(doorState);
+    }
+
+    /**
+     * Later pass than the aperture preview so swung leaves composite over it.
+     * Minecraft flushes {@code submitCustomGeometry} by RenderType, so doors must
+     * not share the shell's {@code entityCutout} bucket.
+     */
+    public static RenderType doorOverlayRenderType(Identifier texture) {
+        return RenderTypes.entityTranslucent(texture);
+    }
+
+    /**
+     * Vanilla emissive translucent pipeline: compiled with the game shaders and
+     * {@code writeDepth=false}, so inward-swinging leaves are not depth-rejected
+     * by the aperture quad.
+     */
+    public static RenderType portalCompositeRenderType() {
+        return RenderTypes.entityTranslucentEmissive(PortalSamplingTexture.ID);
     }
 
     /**

--- a/src/client/java/com/adamkali/dwm/render/state/TardisBlockEntityRenderState.java
+++ b/src/client/java/com/adamkali/dwm/render/state/TardisBlockEntityRenderState.java
@@ -11,6 +11,7 @@ public class TardisBlockEntityRenderState extends BlockEntityRenderState {
     public TardisChameleonVariant variant = TardisChameleonVariant.TT_CAPSULE;
     public float doorSwing;
     public float rotationDegrees;
+    public int facingRotation;
     public float partialTicks;
     public boolean shouldRenderBoti;
     public boolean cloaked;

--- a/src/client/resources/dwm.client.mixins.json
+++ b/src/client/resources/dwm.client.mixins.json
@@ -4,6 +4,7 @@
   "package": "com.adamkali.dwm.mixin.client",
   "compatibilityLevel": "JAVA_21",
   "client": [
+    "RenderPipelinesMixin"
   ],
   "injectors": {
     "defaultRequire": 1

--- a/src/test/java/com/adamkali/dwm/render/boti/TardisBotiRendererAlignmentTest.java
+++ b/src/test/java/com/adamkali/dwm/render/boti/TardisBotiRendererAlignmentTest.java
@@ -58,4 +58,19 @@ class TardisBotiRendererAlignmentTest {
         // Looking along +Z: a point further into the room should be in front of the camera (-Z in view space).
         assertTrue(deeper.z < 0.0f, "Room depth should project in front of hitch camera");
     }
+
+    @Test
+    void viewPanU_onAxisIsZero() {
+        Vec3 door = new Vec3(0.5, 1.0, 0.5);
+        Vec3 player = new Vec3(0.5, 1.62, 0.5 + 3.0);
+        assertEquals(0.0f, PortalApertureComposite.viewPanU(player, door, Direction.SOUTH), EPSILON);
+    }
+
+    @Test
+    void viewPanU_playerOnDoorRight_isPositive() {
+        Vec3 door = new Vec3(0.5, 1.0, 0.5);
+        Vec3 player = new Vec3(0.5 + 4.0, 1.62, 0.5 + 3.5);
+        float pan = PortalApertureComposite.viewPanU(player, door, Direction.SOUTH);
+        assertTrue(pan > 1.0f, "Strafing right of a south door should pan U positive");
+    }
 }

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalDoorRendererTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalDoorRendererTest.java
@@ -1,0 +1,69 @@
+package com.adamkali.dwm.render.portal;
+
+import net.minecraft.client.renderer.rendertype.RenderTypes;
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalDoorRendererTest {
+    private static final Identifier TEXTURE = Identifier.fromNamespaceAndPath("dwm", "textures/entity/first_doctor_box.png");
+
+    @Test
+    void doorOverlay_usesTranslucentPass() {
+        assertEquals(
+                RenderTypes.entityTranslucent(TEXTURE),
+                PortalDoorRenderer.doorOverlayRenderType(TEXTURE)
+        );
+    }
+
+    @Test
+    void doorOverlay_isNotShellCutoutBucket() {
+        assertNotEquals(
+                RenderTypes.entityCutout(TEXTURE),
+                PortalDoorRenderer.doorOverlayRenderType(TEXTURE)
+        );
+    }
+
+    @Test
+    void doorOverlay_isNotPortalCutoutBucket() {
+        assertNotEquals(
+                RenderTypes.entityCutout(PortalSamplingTexture.ID),
+                PortalDoorRenderer.doorOverlayRenderType(TEXTURE)
+        );
+    }
+
+    @Test
+    void portalComposite_usesVanillaEmissivePipeline() {
+        assertEquals(
+                RenderTypes.entityTranslucentEmissive(PortalSamplingTexture.ID),
+                PortalDoorRenderer.portalCompositeRenderType()
+        );
+    }
+
+    @Test
+    void portalComposite_isNotEntityCutoutBucket() {
+        assertNotEquals(
+                RenderTypes.entityCutout(PortalSamplingTexture.ID),
+                PortalDoorRenderer.portalCompositeRenderType()
+        );
+    }
+
+    @Test
+    void portalComposite_doesNotWriteDepth() {
+        var depth = PortalDoorRenderer.portalCompositeRenderType().pipeline().getDepthStencilState();
+        assertNotNull(depth);
+        assertFalse(depth.writeDepth());
+    }
+
+    @Test
+    void doorOverlay_stillWritesDepth() {
+        var depth = PortalDoorRenderer.doorOverlayRenderType(TEXTURE).pipeline().getDepthStencilState();
+        assertNotNull(depth);
+        assertTrue(depth.writeDepth());
+    }
+}

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalDoorRendererTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalDoorRendererTest.java
@@ -38,8 +38,8 @@ class PortalDoorRendererTest {
     }
 
     @Test
-    void portalComposite_usesVanillaEmissivePipeline() {
-        assertEquals(
+    void portalComposite_isNotEmissiveTranslucent() {
+        assertNotEquals(
                 RenderTypes.entityTranslucentEmissive(PortalSamplingTexture.ID),
                 PortalDoorRenderer.portalCompositeRenderType()
         );
@@ -58,6 +58,11 @@ class PortalDoorRendererTest {
         var depth = PortalDoorRenderer.portalCompositeRenderType().pipeline().getDepthStencilState();
         assertNotNull(depth);
         assertFalse(depth.writeDepth());
+    }
+
+    @Test
+    void portalComposite_doesNotBlend() {
+        assertFalse(PortalDoorRenderer.portalCompositeRenderType().hasBlending());
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Open TARDIS doors were clipped by the BOTI (bigger-on-the-inside) and SOTO (smaller-on-the-outside) doorway previews, so swung leaves vanished behind the portal instead of sitting in front of it.
- After drawing doors on top, the hitch-fixed interior stamp sheared against the 3D leaves when strafing, which made the preview look like it was sliding out of the doorway.

## Proposed Implementation

- Submit exterior and interior door leaves with `entityTranslucent` on a later `SubmitNodeCollector` order than the aperture composite.
- Stamp the portal quad with an opaque no-depth-write `RenderPipeline` (`dwm:pipeline/portal_composite`) so the doorway covers world color without depth-rejecting inward-swinging leaves.
- Pan the hitch-fixed FBO crop with viewer azimuth so interior features stay aligned with the door frame while strafing.
- Add tests for overlay vs cutout buckets, portal depth-write/blend, and `viewPanU` sign.

## Problems Encountered / Decisions Made

- A first custom pipeline used a non-existent shader location and made the preview vanish; the working pipeline clones entity-cutout via `RenderPipelines.ENTITY_SNIPPET` and is registered before `getStaticPipelines()` compiles GPU programs.
- Vanilla `entityTranslucentEmissive` kept doors on top but let world terrain blend through the doorway; the opaque pipeline covers that without restoring depth write.
- Moving the interior hitch to the mapped player eye looked into void behind the console-room wall; the hitch stays on the door plane and only the composite UVs pan.