### PR TITLE
chore(version): prepare v26.2-1.4.0 release notes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version=26.2
 loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 # Mod Properties
-mod_version=1.3.0
+mod_version=1.4.0
 maven_group=com.adamkali.dwm
 archives_base_name=dwm
 # Dependencies

--- a/metadata/modrinth-body.md
+++ b/metadata/modrinth-body.md
@@ -7,8 +7,11 @@ Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — 
 - Search the overworld for a TARDIS, open the doors, and walk into a First Doctor–style console room
 - Look through open exterior doors for a bigger-on-the-inside preview of the console room
 - Look back out through open interior doors to see the world outside
-- Set a destination at the First Doctor console with biome/planet dials, saved waypoints, or an online player
-- Pull the materialisation lever to dematerialise, fly, and land — with travel and ambient sound
+- Bind a TARDIS Key to lock and unlock the doors
+- Sneak-use a Stattenheim Remote to summon your TARDIS to a clicked block
+- Set a destination at the First Doctor console with biome/planet dials, saved waypoints, an online player, fast return through previous landings, or the telepathic circuit (home bed or world spawn)
+- Cloak the exterior shell, lock the doors, pin X/Y/Z with coordinate lock, toggle stabilisers for precise vs scattered landing, and read exterior atmosphere and artron reserves
+- Pull the materialisation lever to dematerialise, fly, and land.
 - Use the chameleon circuit dial to pick First–Seventh Doctor boxes or the TT Capsule, with a spinning shell hologram
 
 ## Explore Gallifrey
@@ -26,6 +29,7 @@ Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — 
 - Orange sand and orange sandstone (stairs, slabs, walls, cut, chiseled, and smooth)
 - Flower of Remembrance, Moonlight Bloom, and Saccharine Cane
 - Chronoplasm powder, colored TARDIS walls, and roundels for console-room builds
+- Craftable decor: sittable chairs, Decorational Column, TARDIS Globe, Compact and Full TARDIS Scanners, and TARDIS Ceiling Vent
 
 ## Azbantium
 
@@ -43,6 +47,7 @@ Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — 
 2. Walk in once the doors are fully open.
 3. At the console, set planet and biome, then pull the materialisation lever.
 4. Pull again in flight to land — try Gallifrey for a first trip.
+5. Craft a TARDIS Key to lock the doors, or a Stattenheim Remote to summon the ship.
 
 ## Community
 

--- a/metadata/modrinth.json
+++ b/metadata/modrinth.json
@@ -1,5 +1,5 @@
 {
-  "description": "Fly a working TARDIS, explore Gallifrey, and build with Doctor Who tools and materials in Minecraft.",
+  "description": "Claim and fly a working TARDIS, explore Gallifrey, and build with Doctor Who tools and materials in Minecraft.",
   "categories": [
     "adventure",
     "equipment",
@@ -8,7 +8,8 @@
   "additional_categories": [
     "mobs",
     "technology",
-    "worldgen"
+    "worldgen",
+    "decoration"
   ],
   "discord_url": "https://discord.gg/pGdRYBh"
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,45 @@
 {
   "26.2": {
+    "1.4.0": {
+      "summary": "Claim and summon your TARDIS — key, Stattenheim remote, and a fuller First Doctor console, plus interior decor, lighting, and shell fade.",
+      "added": [
+        "Block: Decorational Column",
+        "Block: TARDIS Ceiling Vent",
+        "Block: Large TARDIS Chair",
+        "Block: Small TARDIS Chair",
+        "Block: TARDIS Globe",
+        "Block: Compact TARDIS Scanner",
+        "Block: Full TARDIS Scanner",
+        "Item: TARDIS Key",
+        "Item: Stattenheim Remote",
+        "Misc: TARDIS ownership (auto-claim on first interior entry; one TARDIS per player)",
+        "Misc: First Doctor console cloak lever (hides the exterior shell)",
+        "Misc: First Doctor console door lock",
+        "Misc: First Doctor console coordinate lock (pin X/Y/Z after landing)",
+        "Misc: First Doctor console telepathic circuit (home bed or world spawn)",
+        "Misc: First Doctor console environment readers and refueler",
+        "Misc: First Doctor console fast-return switch (previous landings)",
+        "Misc: First Doctor console stabilisers toggle (precise vs scattered landing)",
+        "Misc: /tardis rebuild to restore the console room",
+        "Misc: Ops /tardis claim to assign TARDIS ownership"
+      ],
+      "changed": [
+        "Misc: Interior and exterior TARDIS doors share one door state",
+        "Misc: First Doctor console room placed from the 11x7x17 structure template",
+        "Misc: Exterior shell fades during dematerialisation and materialisation",
+        "Misc: First Doctor console Time_middle rotor spins while travelling",
+        "Misc: Roundels, First Doctor console, and ceiling vents emit light",
+        "Misc: TARDIS chairs are sittable (empty-hand sit; dismount onto the open side)",
+        "Misc: Planet locator shows readable dimension names when translations are missing",
+        "Misc: Ash, Dark Ash, and Cardinal doors render as 3D items",
+        "Misc: Ash, Dark Ash, and Cardinal hanging signs use baked models and distinct textures",
+        "Misc: Dark Ash and Cardinal boats use distinct hull textures",
+        "Misc: Closed TARDIS exterior no longer shows a white entity outline",
+        "Misc: Door leaves draw over bigger-on-the-inside / smaller-on-the-outside previews; BOTI stays aligned while strafing",
+        "Misc: Portal aperture depth aligned for later Doctor chameleon boxes"
+      ],
+      "removed": []
+    },
     "1.3.0": {
       "summary": "Gallifrey survival depth — Azbantium gear, Gallifrey ores and plants, orange sand and badlands, plus console waypoints, player locator, and chameleon hologram.",
       "added": [
@@ -286,7 +326,7 @@
     }
   },
   "promos": {
-    "latest": "26.2-1.3.0",
-    "recommended": "26.2-1.3.0"
+    "latest": "26.2-1.4.0",
+    "recommended": "26.2-1.4.0"
   }
 }


### PR DESCRIPTION
## Why this matters

- Player-facing GitHub/Modrinth/CurseForge/Discord notes need a filled `version.json` entry before tagging `v26.2-1.4.0`.
- The Modrinth project listing should describe claim, key, Stattenheim remote, console instruments, and interior decor that shipped since 1.3.0.

## Proposed Implementation

- Bump `mod_version` to `1.4.0` and add a `26.2` / `1.4.0` changelog plus matching `promos`.
- Update `metadata/modrinth.json` description and add the `decoration` category; expand `metadata/modrinth-body.md` for shipped 1.4.0 TARDIS and build features.
- Validated with `./gradlew test --tests com.adamkali.dwm.VersionJsonSyncTest checkVersionSync`.

## Problems Encountered / Decisions Made

- Notes prep only: this PR does not create the git tag or run Release / Sync Modrinth Project.

Made with [Cursor](https://cursor.com)