### PR TITLE
fix(tardis): restore BOTI doorway preview after overlay merge

### DIFF
--- a/src/client/java/com/adamkali/dwm/DWMClient.java
+++ b/src/client/java/com/adamkali/dwm/DWMClient.java
@@ -7,6 +7,7 @@ import com.adamkali.dwm.render.ConsoleHitboxDebugRenderer;
 import com.adamkali.dwm.render.TardisCompactScannerSpecialRenderer;
 import com.adamkali.dwm.render.TardisFullScannerSpecialRenderer;
 import com.adamkali.dwm.render.TardisGlobeSpecialRenderer;
+import com.adamkali.dwm.render.portal.PortalDoorRenderer;
 import com.adamkali.dwm.render.portal.PortalPerfDebugHud;
 import com.adamkali.dwm.render.portal.PortalPerfDebugLog;
 import com.adamkali.dwm.render.portal.PortalSupport;
@@ -39,6 +40,9 @@ public class DWMClient implements ClientModInitializer {
         ConsoleHitboxDebugRenderer.initialize();
         PortalPerfDebugHud.initialize();
         PortalPerfDebugLog.resetForSession();
+        // ShaderManager compiles RenderPipelines.getStaticPipelines() during the first
+        // resource reload, which is after client init. Register before that snapshot.
+        PortalDoorRenderer.ensurePipelineRegistered();
         PortalSupport.initialize();
         ClientTickEvents.END_CLIENT_TICK.register(client -> PortalSceneStore.clientTick());
     }

--- a/src/client/java/com/adamkali/dwm/mixin/client/RenderPipelinesMixin.java
+++ b/src/client/java/com/adamkali/dwm/mixin/client/RenderPipelinesMixin.java
@@ -7,6 +7,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
+import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.renderer.RenderPipelines;
 
@@ -16,8 +17,15 @@ import net.minecraft.client.renderer.RenderPipelines;
  */
 @Mixin(RenderPipelines.class)
 public class RenderPipelinesMixin {
-    @Inject(method = "getStaticPipelines", at = @At("HEAD"))
+    @Inject(method = "getStaticPipelines", at = @At("RETURN"), cancellable = true)
     private static void dwm$ensurePortalCompositePipeline(CallbackInfoReturnable<List<RenderPipeline>> cir) {
         PortalDoorRenderer.ensurePipelineRegistered();
+        List<RenderPipeline> list = cir.getReturnValue();
+        if (list != null && list.contains(PortalDoorRenderer.PORTAL_COMPOSITE_PIPELINE)) {
+            return;
+        }
+        List<RenderPipeline> copy = new ArrayList<>(list == null ? List.of() : list);
+        copy.add(PortalDoorRenderer.PORTAL_COMPOSITE_PIPELINE);
+        cir.setReturnValue(List.copyOf(copy));
     }
 }

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalDoorRenderer.java
@@ -5,8 +5,11 @@ import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.tardis.data.model.PortalAperture;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
 import com.adamkali.dwm.tardis.interior.TardisPortalGate;
+import com.mojang.blaze3d.pipeline.BlendFunction;
+import com.mojang.blaze3d.pipeline.ColorTargetState;
 import com.mojang.blaze3d.pipeline.DepthStencilState;
 import com.mojang.blaze3d.pipeline.RenderPipeline;
+import com.mojang.blaze3d.platform.BlendFactor;
 import com.mojang.blaze3d.platform.CompareOp;
 import com.mojang.blaze3d.vertex.PoseStack;
 
@@ -31,13 +34,21 @@ public final class PortalDoorRenderer {
     public static final int DOOR_OVERLAY_ORDER = 1;
 
     /**
-     * Opaque entity-cutout clone with {@code writeDepth=false}. Covers world color in the
-     * doorway (no translucent blend) so strafing cannot parallax terrain through the
-     * preview, while inward-swinging leaves can still pass the leftover depth.
+     * Opaque overwrite ({@code src=ONE, dst=ZERO}). {@link RenderType#hasBlending()} must be
+     * true so {@code submitCustomGeometry} routes to {@code translucentCustomGeometry}
+     * (after the shell's solid pass). The blend itself replaces dest, so world color
+     * cannot show through while strafing.
+     */
+    static final BlendFunction PORTAL_COMPOSITE_BLEND = new BlendFunction(BlendFactor.ONE, BlendFactor.ZERO);
+
+    /**
+     * Entity-cutout clone with {@code writeDepth=false} and opaque overwrite blend.
+     * Flushes after the shell (blending flag) without mixing world color, and does not
+     * depth-reject inward-swinging leaves.
      * <p>
      * Uses vanilla {@code core/entity} shaders from {@link RenderPipelines#ENTITY_SNIPPET}.
      * Must be {@link RenderPipelines#register}ed before {@link RenderPipelines#getStaticPipelines()}
-     * compiles GPU programs — see client mixin.
+     * compiles GPU programs — see client mixin and {@link com.adamkali.dwm.DWMClient}.
      */
     public static final RenderPipeline PORTAL_COMPOSITE_PIPELINE = RenderPipelines.register(
             RenderPipeline.builder(RenderPipelines.ENTITY_SNIPPET)
@@ -46,6 +57,7 @@ public final class PortalDoorRenderer {
                     .withShaderDefine("PER_FACE_LIGHTING")
                     .withBindGroupLayout(BindGroupLayouts.SAMPLER1)
                     .withCull(false)
+                    .withColorTargetState(new ColorTargetState(PORTAL_COMPOSITE_BLEND))
                     .withDepthStencilState(new DepthStencilState(CompareOp.GREATER_THAN_OR_EQUAL, false))
                     .build()
     );
@@ -93,8 +105,8 @@ public final class PortalDoorRenderer {
     }
 
     /**
-     * Opaque doorway stamp: no blend (covers world), {@code writeDepth=false} so
-     * inward-swinging leaves are not depth-rejected by the aperture quad.
+     * Opaque doorway stamp: overwrite blend (late pass, covers world), {@code writeDepth=false}
+     * so inward-swinging leaves are not depth-rejected by the aperture quad.
      */
     public static RenderType portalCompositeRenderType() {
         return PORTAL_COMPOSITE.apply(PortalSamplingTexture.ID);

--- a/src/test/java/com/adamkali/dwm/render/portal/PortalDoorRendererTest.java
+++ b/src/test/java/com/adamkali/dwm/render/portal/PortalDoorRendererTest.java
@@ -2,6 +2,7 @@ package com.adamkali.dwm.render.portal;
 
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.resources.Identifier;
+import com.mojang.blaze3d.platform.BlendFactor;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -61,8 +62,12 @@ class PortalDoorRendererTest {
     }
 
     @Test
-    void portalComposite_doesNotBlend() {
-        assertFalse(PortalDoorRenderer.portalCompositeRenderType().hasBlending());
+    void portalComposite_usesOverwriteBlendForLatePass() {
+        var type = PortalDoorRenderer.portalCompositeRenderType();
+        assertTrue(type.hasBlending(), "blending flag routes submitCustomGeometry after the shell");
+        var blend = type.pipeline().getColorTargetState().blendFunction().orElseThrow();
+        assertEquals(BlendFactor.ONE, blend.color().sourceFactor());
+        assertEquals(BlendFactor.ZERO, blend.color().destFactor());
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- After the door-overlay work landed on main, the bigger-on-the-inside doorway preview stopped drawing, so open TARDIS doors showed the overworld through the opening instead of the interior.

## Proposed Implementation

- Register `dwm:pipeline/portal_composite` during client init (and append it on `getStaticPipelines` return) so ShaderManager compiles it on the first resource reload.
- Give the doorway stamp an opaque overwrite blend (`src=ONE`, `dst=ZERO`) so `submitCustomGeometry` flushes it in the late pass after the shell, without mixing world color.
- Update `PortalDoorRendererTest` to lock the overwrite blend and late-pass routing.

## Problems Encountered / Decisions Made

- A no-blend pipeline is routed into the solid custom-geometry pass with the shell, so the stamp never appeared even after the GPU program compiled. The blending *flag* is required for the late pass; the blend equation itself stays opaque so strafing does not bring terrain back.


Made with [Cursor](https://cursor.com)