### PR TITLE
feat(scenario-test): add YAML-driven real-client UI test harness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,12 +6,19 @@
 - Current target stack is defined in `gradle.properties` and `build.gradle` (Minecraft, Yarn mappings, Fabric Loader, Fabric API).
 - Objective: maximize safe, repeatable AI-agent-driven development with strong automated verification.
 
-## Codebase Structure
-- `src/main/java`: Common logic that must remain safe on both logical client and logical server.
-- `src/client/java`: Client-only logic (rendering, client integration, client UI/state).
-- `src/test/java`: Automated tests (JUnit and related support code).
-- `src/main/resources`: Common resources (`fabric.mod.json`, data, tags, recipes, structures, lang, worldgen).
-- `src/client/resources`: Client assets (models, blockstates, textures, sounds, item models).
+## Repository Map
+- `src/main/java`: Common logic safe on both logical client and logical server (`com.adamkali.dwm.*`).
+- `src/client/java`: Client-only logic (rendering, HUD, client integration).
+- `src/test/java`: JUnit 5 unit tests and scenario compiler/primitive tests.
+- `src/scenarioTest/`: Local-only Fabric test mod — YAML-driven real-client scenarios (not shipped in the mod jar).
+- `src/main/resources`: Common resources (`fabric.mod.json`, data, tags, recipes, lang, worldgen).
+- `src/main/generated/`: Datagen output — commit intentional changes; delete `.cache/` before commit.
+- `src/client/resources`: Hand-maintained client assets (models, blockstates, textures, sounds).
+- `docs/`: Product-facing feature docs and release policy — read before changing player-visible behaviour.
+- `tools/`: Offline Python scripts (TARDIS SFX generation/analysis); not part of Gradle build.
+- `metadata/`: Modrinth listing (`modrinth.json`, `modrinth-body.md`).
+- `.cursor/skills/`: Agent skills for GameTests, asset import, Blockbench models, MCP verify, etc.
+- `version.json`: Release changelog and Modrinth/CurseForge promos — synced via `./gradlew syncVersionJson`.
 
 ## Agent-First Engineering Principles
 - Prefer small, focused, reviewable diffs over broad rewrites.
@@ -58,9 +65,9 @@
 - If no automated test is added, explicitly state why and what test should be added later.
 
 ## Testing Expectations
-- Unit tests: use JUnit 5 (`fabric-loader-junit` already configured) for core logic and utility behavior.
-- Integration-style tests: use for cross-component behavior where pure unit tests are insufficient.
-- GameTests: use for world/gameplay interactions that require real game context.
+- **Unit tests** (`./gradlew test`): JUnit 5 via `fabric-loader-junit` for logic, codecs, datagen helpers, and scenario compiler/primitives. Included in `./gradlew build` and CI.
+- **GameTests** (`./gradlew runGametest`): Headless dedicated-server in-world tests in `src/main/java/.../gametest/`. Not run by CI today — run locally when GameTest code changes. See `.cursor/skills/fabric-gametest/SKILL.md`.
+- **YAML scenario tests** (`./gradlew runScenarioTest -Pscenario=<id>`): Real Minecraft client driven from YAML in `src/scenarioTest/resources/tests/`. Requires a display; not in CI. See `src/scenarioTest/AGENTS.md`.
 - Keep test runs reproducible and suitable for unattended agent execution.
 
 ## Automation Pipeline For Agents
@@ -74,9 +81,12 @@
 
 ## Build/Test/Validation
 - Main automated commands:
-  - `./gradlew test`
-  - `./gradlew build`
-  - `./gradlew runDatagen` (only when data-driven assets/providers are touched)
+  - `./gradlew test` — JUnit suite
+  - `./gradlew build` — compile all source sets + JUnit (CI gate)
+  - `./gradlew runDatagen` — regenerate `src/main/generated/` (only when datagen providers or promoted assets change); finalized by `pruneDatagenItemModels`
+  - `./gradlew runGametest` — headless GameTests → `build/gametest/report.xml`
+  - `./gradlew runScenarioTest -Pscenario=<yaml-stem>` — client YAML scenarios → `build/scenario-test/report.xml` (display required)
+  - `./gradlew syncVersionJson` / `checkVersionSync` — keep `version.json` aligned with `gradle.properties`
 - If a command fails, surface the failure clearly and fix root causes before handoff where possible.
 
 ## Releases / CI
@@ -126,6 +136,13 @@ After creating or updating a pull request, apply the appropriate label(s) using 
 - **`bug`** — the PR fixes a defect / unintended behaviour
 
 A single PR may carry more than one label if it touches multiple categories.
+
+## Nested Context
+- `src/scenarioTest/AGENTS.md` — YAML client scenario framework (primitives, composite commands, Gradle properties).
+- `src/main/java/com/adamkali/dwm/tardis/AGENTS.md` — TARDIS domain layout (logic vs data vs interior vs portal rendering).
+- `tools/AGENTS.md` — offline Python audio tooling and fixture rules.
+- `.cursor/skills/fabric-gametest/SKILL.md` — authoring and registering Fabric GameTests.
+- `.cursor/skills/asset-import-pipeline/SKILL.md` — promoting archive textures and wiring datagen.
 
 ## Cursor Cloud specific instructions
 

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ repositories {
     }
 }
 
+sourceSets {
+    scenarioTest
+}
+
 loom {
     splitEnvironmentSourceSets()
 
@@ -38,6 +42,9 @@ loom {
         "dwm" {
             sourceSet sourceSets.main
             sourceSet sourceSets.client
+        }
+        "dwm-scenario-test" {
+            sourceSet sourceSets.scenarioTest
         }
     }
 
@@ -49,7 +56,46 @@ loom {
             vmArg "-Dfabric-api.gametest.report-file=${layout.buildDirectory.get()}/gametest/report.xml"
             runDir "build/gametest"
         }
+        scenarioTest {
+            client()
+            name "Scenario Test"
+            source = sourceSets.scenarioTest
+            property "dwm.scenario", providers.gradleProperty("scenario").orElse("createWorld").get()
+            property "dwm.scenario.step-timeout-seconds",
+                    providers.gradleProperty("scenarioTimeout").orElse("30").get()
+            property "dwm.scenario.report-file",
+                    layout.buildDirectory.file("scenario-test/report.xml").get().asFile.absolutePath
+            runDir "build/scenario-test/run"
+        }
     }
+}
+
+sourceSets.scenarioTest {
+    compileClasspath += sourceSets.main.output
+    compileClasspath += sourceSets.client.output
+    compileClasspath += sourceSets.client.compileClasspath
+    runtimeClasspath += sourceSets.main.output
+    runtimeClasspath += sourceSets.client.output
+    runtimeClasspath += sourceSets.client.runtimeClasspath
+}
+
+tasks.register("prepareScenarioTestRun") {
+    def optionsFile = layout.buildDirectory.file("scenario-test/run/options.txt")
+    outputs.file(optionsFile)
+    outputs.upToDateWhen { false }
+    doLast {
+        delete(layout.buildDirectory.dir("scenario-test/run/saves"))
+        optionsFile.get().asFile.parentFile.mkdirs()
+        optionsFile.get().asFile.text = """\
+lang:en_us
+skipMultiplayerWarning:true
+onboardAccessibility:false
+"""
+    }
+}
+
+tasks.named("runScenarioTest").configure {
+    dependsOn("prepareScenarioTestRun")
 }
 
 dependencies {
@@ -63,6 +109,9 @@ dependencies {
     testImplementation "net.fabricmc:fabric-loader-junit:${project.loader_version}"
     // 5.18+ bundles Byte Buddy with Java 25 classfile support (mockStatic / inline mocks)
     testImplementation "org.mockito:mockito-core:5.20.0"
+    testImplementation sourceSets.scenarioTest.output
+    testImplementation "org.yaml:snakeyaml:2.6"
+    scenarioTestImplementation "org.yaml:snakeyaml:2.6"
 
     implementation "org.json:json:20240303"
     implementation "com.github.erosb:everit-json-schema:1.14.4"

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ loom {
                     providers.gradleProperty("scenarioTimeout").orElse("30").get()
             property "dwm.scenario.report-file",
                     layout.buildDirectory.file("scenario-test/report.xml").get().asFile.absolutePath
+            property "dwm.scenario.vanilla-server-dir",
+                    layout.buildDirectory.dir("scenario-test/vanilla-server").get().asFile.absolutePath
             runDir "build/scenario-test/run"
         }
     }
@@ -81,16 +83,24 @@ sourceSets.scenarioTest {
 
 tasks.register("prepareScenarioTestRun") {
     def optionsFile = layout.buildDirectory.file("scenario-test/run/options.txt")
+    def vanillaServerDir = layout.buildDirectory.dir("scenario-test/vanilla-server")
+    def jarPathFile = layout.buildDirectory.file("scenario-test/vanilla-server/server-jar.path")
     outputs.file(optionsFile)
+    outputs.file(jarPathFile)
     outputs.upToDateWhen { false }
     doLast {
         delete(layout.buildDirectory.dir("scenario-test/run/saves"))
+        delete(layout.buildDirectory.dir("scenario-test/vanilla-server/world"))
         optionsFile.get().asFile.parentFile.mkdirs()
         optionsFile.get().asFile.text = """\
 lang:en_us
 skipMultiplayerWarning:true
 onboardAccessibility:false
 """
+        def serverDir = vanillaServerDir.get().asFile
+        serverDir.mkdirs()
+        def serverJar = net.fabricmc.loom.LoomGradleExtension.get(project).minecraftProvider.minecraftServerJar
+        jarPathFile.get().asFile.text = serverJar.absolutePath
     }
 }
 

--- a/src/main/java/com/adamkali/dwm/tardis/AGENTS.md
+++ b/src/main/java/com/adamkali/dwm/tardis/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Scope
+This file applies to `com.adamkali.dwm.tardis` and its subpackages — the TARDIS exterior, interior dimension, console, travel, and portal systems.
+
+## Local Context
+TARDIS gameplay spans persistence, server-authoritative logic, world placement, and heavy client rendering. Product behaviour is documented in `docs/feature-tardis-block.md`, `docs/feature-tardis-door-button.md`, and `docs/feature-chameleon-system.md` (experimental, config-gated).
+
+### Package layout
+| Package | Responsibility |
+|---------|----------------|
+| `tardis.logic` | Server-side rules and orchestration (`TardisLogic`, travel, locks, circuits, landing). Prefer extracting testable pure logic here. |
+| `tardis.data` / `data.model` | Persistence (`TardisDataLoader`, JSON on disk) and immutable-ish state models (`TardisDataModel`, waypoints, door/travel phase). |
+| `tardis.interior` | Interior dimension layout, plot allocation, room placement (`TardisInteriorService`, `FirstDoctorConsoleRoomLayout`). |
+| `tardis.portal` | Portal stream sampling/sync between exterior aperture and interior view (`PortalStreamSyncService`). |
+| `tardis.boti` | Bigger-on-the-inside interior mesh sampling and relative position codec (shared data for client BOTI renderer). |
+| `tardis.soto` | Scanning-the-outside exterior sampling and atmosphere (chameleon/SOTO path). |
+| `block` / `block.entities` (outside package) | Block types and BEs that TARDIS logic drives — keep block interaction thin, delegate to logic. |
+| `src/client/java/.../render/` | Client renderers (`TardisBlockEntityRenderer`, `PortalDoorRenderer`, `TardisBotiRenderer`, console HUD). No gameplay state changes. |
+
+Entry orchestration for doors/travel generally flows: block/BE interaction → `TardisLogic` / feature `*Logic` → `TardisDataLoader` persist → optional `PortalStreamSyncService` or interior services.
+
+## Commands
+- Unit tests: `./gradlew test --tests "com.adamkali.dwm.tardis.*"`
+- GameTests (door/interior/landing/console): `./gradlew runGametest`
+- YAML client flows (UI/world creation): `./gradlew runScenarioTest -Pscenario=placeAndOpenTardis` (see `src/scenarioTest/AGENTS.md`)
+
+## Conventions
+- **Server authoritative** — mutate `TardisDataModel` on the server; sync to clients via existing payloads/render state, not client-side persistence.
+- **Logic extraction** — new rules belong in focused `*Logic` classes with JUnit tests under `src/test/java/.../tardis/logic/`.
+- **GameTests** — redirect TARDIS saves in tests: `TardisDataLoader.tardisSaveDirectory = context.getWorld().getServer().getSavePath(WorldSavePath.ROOT).resolve("gametest_tardis_data");`
+- **Rendering** — portal/BOTI changes stay in `src/client/java`; keep mesh/cache logic testable where possible (`BotiInteriorMeshCacheTest`, etc.).
+- Blocks register in `DWMBlocks`; TARDIS-specific blocks often pair with dedicated BEs and datagen in `com.adamkali.dwm.datagen`.
+
+## Common Pitfalls
+- Do not reference client render classes from `tardis.logic` or `tardis.data`.
+- Door swing/travel phase timing — use `waitTicks` in scenario tests; unit-test phase transitions in logic tests.
+- Chameleon/SOTO paths are config-gated and off by default — do not assume enabled in tests without setting config.
+- Interior rebuild/plot allocation is order-sensitive — check `TardisInteriorGameTests` before changing placement rules.
+- Travel audio assets may be regenerated via `tools/` scripts — commit resulting OGGs under client resources, not fixture WAVs.

--- a/src/main/resources/dwm.accesswidener
+++ b/src/main/resources/dwm.accesswidener
@@ -4,3 +4,4 @@ accessible	method	net/minecraft/client/Camera	setPosition	(DDD)V
 accessible	method	net/minecraft/client/Camera	setPosition	(Lnet/minecraft/world/phys/Vec3;)V
 accessible	method	net/minecraft/client/Camera	setRotation	(FF)V
 accessible	field	net/minecraft/client/gui/screens/ConnectScreen	status	Lnet/minecraft/network/chat/Component;
+accessible	method	net/minecraft/client/gui/screens/worldselection/CreateWorldScreen	onCreate	()V

--- a/src/main/resources/dwm.accesswidener
+++ b/src/main/resources/dwm.accesswidener
@@ -3,3 +3,4 @@ accessible	method	net/minecraft/world/level/levelgen/NoiseRouterData	overworld	(
 accessible	method	net/minecraft/client/Camera	setPosition	(DDD)V
 accessible	method	net/minecraft/client/Camera	setPosition	(Lnet/minecraft/world/phys/Vec3;)V
 accessible	method	net/minecraft/client/Camera	setRotation	(FF)V
+accessible	field	net/minecraft/client/gui/screens/ConnectScreen	status	Lnet/minecraft/network/chat/Component;

--- a/src/scenarioTest/AGENTS.md
+++ b/src/scenarioTest/AGENTS.md
@@ -1,0 +1,31 @@
+# AGENTS.md
+
+## Scope
+This file applies to `src/scenarioTest/` — a separate Loom source set and Fabric mod (`dwm-scenario-test`) that is **not** bundled into the production mod jar.
+
+## Local Context
+YAML scenarios drive the **real Minecraft client** by dispatching widget clicks, keyboard input, and in-world actions. The compiler (`ScenarioCompiler`) validates documents at load time; primitives live under `com.adamkali.dwm.scenariotest.primitive`. Unit tests for compiler/primitives are in `src/test/java/.../scenariotest/` and run with `./gradlew test`.
+
+Full step/selector reference: `README.md` in this directory.
+
+## Commands
+- Run a scenario: `./gradlew runScenarioTest -Pscenario=<yaml-filename-stem>`
+- Override step timeout (seconds): `-PscenarioTimeout=60`
+- Reports: `build/scenario-test/report.xml`, `build/scenario-test/diagnostics.txt`
+- Screenshots: `build/scenario-test/run/screenshots/`
+- Vanilla server harness dir: `build/scenario-test/vanilla-server/`
+
+## Conventions
+- YAML files live recursively under `resources/tests/`. Role is set by frontmatter `type`: `test` (runnable) or `command` (composite).
+- Stable ID is the **filename stem** (e.g. `subflows/assertAndClick.yaml` → `assertAndClick`). Duplicate IDs across directories are rejected.
+- Add new behaviour as a `ScenarioPrimitive` in `primitive/`, register it in `ScenarioPrimitives`, and add JUnit coverage in `src/test/java/.../scenariotest/`.
+- Composite commands use `{{ parameter }}` templating; cycles and unknown steps fail at compile time.
+- Selectors match exact widget `name` + `type` (`button`, `cycle`, `tab`, `editbox`, `label`, `screen`).
+
+## Common Pitfalls
+- **Display required** — unlike GameTests, this harness boots the client; it will not run headless in Cursor Cloud.
+- **Not in CI** — `./gradlew build` compiles this source set but does not execute scenarios.
+- Each run deletes saved worlds under `build/scenario-test/run/saves` and clears `build/scenario-test/vanilla-server/world`.
+- `startVanillaServer` and `createWorld` use a 120s timeout floor; `-PscenarioTimeout` only raises it.
+- `runCommand` sends packets immediately — pair with `waitUntil` for inventory/world assertions.
+- Quote relative coords in YAML: `"~"` not bare `~` (YAML null).

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -87,13 +87,32 @@ The MVP primitives are:
 - `keyboardInput` — waits until a focused, editable text field can consume
   input, then types the given string once via real `charTyped` events. It does
   not click or select the field; click the matching `editbox` first.
-- `waitUntil` — polls until a nested selector is `visible` or `notVisible`.
-  Exactly one condition is required. `visible` is equivalent to `assertVisible`.
+- `waitUntil` — polls until exactly one condition is true: a nested selector is
+  `visible` or `notVisible`, the main hand is `holding` an item id, or a
+  `block` id is at `x`/`y`/`z`. `visible` is equivalent to `assertVisible`.
   `notVisible` succeeds as soon as the selector does not match on the current
-  tick, including if it has not appeared yet.
+  tick, including if it has not appeared yet. Item and block ids may omit
+  `minecraft:`. Block coordinates use the same relative/absolute rules as
+  `lookAt`.
 - `openInventory` — waits until a local player exists, then opens the survival
   or creative inventory GUI. It takes no arguments. If the inventory is already
   showing, the step succeeds without reopening it.
+- `closeScreen` — waits until a local player exists, then closes the current
+  GUI (`setScreen(null)` / `closeContainer()`). If no screen is open, the step
+  succeeds without changing anything. World actions such as `useItem` wait
+  until the screen is gone.
+- `selectHotbar` — waits until a local player and play connection exist, then
+  selects hotbar slot `0`–`8` and syncs that slot to the server. A scalar
+  integer is accepted.
+- `lookAt` — waits until a local player exists, then aims the camera. Supply
+  either `yaw` and `pitch`, or block coordinates `x`, `y`, and `z`. Coordinate
+  components may be absolute integers or relative (`"~"`, `"~1"`, `"~-1"`).
+  Quote `"~"` in YAML; a bare `~` is YAML null. Relative values use the
+  player's block position. Pitch must be between `-90` and `90`.
+- `useItem` — waits until a local player, game mode, no open screen, and a
+  block crosshair hit exist, then uses the main-hand item on that block (the
+  same path as right-click place/interact). It succeeds as soon as the use is
+  sent; it does not wait for the world to update. Pair with `waitUntil.block`.
 - `runCommand` — waits until a local player and play connection exist, then
   sends an in-game slash command as that player (the same path as typing `/give`
   in chat, without opening the chat GUI). The step succeeds as soon as the
@@ -111,6 +130,29 @@ The MVP primitives are:
     notVisible:
       type: screen
       name: LevelLoadingScreen
+- waitUntil:
+    holding: minecraft:dirt
+- waitUntil:
+    block:
+      id: minecraft:dirt
+      x: "~1"
+      y: "~"
+      z: "~"
+```
+
+```yaml
+- closeScreen
+- selectHotbar: 0
+- selectHotbar:
+    slot: 3
+- lookAt:
+    x: "~1"
+    y: "~-1"
+    z: "~"
+- lookAt:
+    yaw: 90
+    pitch: 45
+- useItem
 ```
 
 ```yaml

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -1,0 +1,115 @@
+# YAML client scenarios
+
+This source set contains a local-only Fabric test mod that starts the real
+Minecraft client and drives its widgets from YAML scenarios. It is not included
+in the production mod jar.
+
+## Running a scenario
+
+Run a test by its YAML filename without the extension:
+
+```bash
+./gradlew runScenarioTest -Pscenario=createWorld
+```
+
+The client uses an isolated directory under `build/scenario-test/run`. Before
+each run, the harness removes its saved worlds and writes deterministic English
+client options. A display is required.
+
+The default per-step timeout is 30 seconds. Override it when debugging:
+
+```bash
+./gradlew runScenarioTest -Pscenario=createWorld -PscenarioTimeout=60
+```
+
+Results are written to:
+
+- `build/scenario-test/report.xml` — JUnit XML
+- `build/scenario-test/diagnostics.txt` — current screen and visible widgets
+
+The Gradle process exits non-zero when loading, validation, or execution fails.
+
+## Files and discovery
+
+YAML definitions live recursively under `resources/tests/`. Their directory
+does not determine their role; the frontmatter `type` does:
+
+```yaml
+---
+name: Create World
+type: test
+---
+steps:
+  - launchGame
+```
+
+Supported frontmatter types are:
+
+- `test` — an executable scenario selected with `-Pscenario`.
+- `command` — a reusable composite command.
+
+The filename stem is the stable ID. For example,
+`subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test or
+command IDs are rejected even when the files are in different directories.
+
+## Steps and selectors
+
+The MVP primitives are:
+
+- `launchGame` — waits until the title screen is ready.
+- `assertVisible` — waits for a visible matching widget.
+- `click` — waits for an active matching widget and dispatches a real screen
+  mouse click at its center.
+
+Selectors require an exact rendered `name` and one of these types:
+
+- `button`
+- `cycle`
+- `tab`
+
+```yaml
+steps:
+  - assertVisible:
+    - type: tab
+      name: "World"
+  - click:
+    - type: tab
+      name: "World"
+```
+
+The single-item list form above and a direct object are both accepted.
+
+## Composite commands
+
+A command declares string parameters and can use them in nested steps:
+
+```yaml
+---
+name: Assert and Click
+type: command
+---
+parameters:
+  - name: type
+    type: string
+  - name: name
+    type: string
+steps:
+  - assertVisible:
+    - type: "{{ type }}"
+      name: "{{ name }}"
+  - click:
+    - type: "{{ type }}"
+      name: "{{ name }}"
+```
+
+Invoke it by filename ID:
+
+```yaml
+- assertAndClick:
+  - type: button
+    name: "Singleplayer"
+```
+
+Unknown steps, missing or extra parameters, unsupported parameter/selector
+types, malformed documents, and recursive command cycles fail before the client
+flow begins.

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -78,6 +78,9 @@ The MVP primitives are:
   process when the scenario finishes. This step does **not** connect the client.
   It uses a 120 second timeout floor; `-PscenarioTimeout` still raises that
   floor when set higher.
+- `keyboardInput` — waits until a focused, editable text field can consume
+  input, then types the given string once via real `charTyped` events. It does
+  not click or select the field; click the matching `editbox` first.
 
 ```yaml
 - startVanillaServer
@@ -86,16 +89,26 @@ The MVP primitives are:
 ```
 
 ```yaml
+- keyboardInput: "localhost:25565"
+- keyboardInput:
+    text: "localhost:25565"
+```
+
+```yaml
 - captureScreenshot
 - captureScreenshot:
     name: after-world-tab
 ```
 
-Selectors require an exact rendered `name` and one of these types:
+Selectors require an exact `name` and one of these types:
 
 - `button`
 - `cycle`
 - `tab`
+- `editbox`
+
+For `editbox`, `name` is the accessibility narration label (`getMessage()`),
+not the current field value. Direct Connection’s IP field is `"Server Address"`.
 
 ```yaml
 steps:
@@ -105,6 +118,10 @@ steps:
   - click:
     - type: tab
       name: "World"
+  - assertAndClick:
+    - type: editbox
+      name: "Server Address"
+  - keyboardInput: "localhost:25565"
 ```
 
 The single-item list form above and a direct object are both accepted.

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -85,6 +85,9 @@ The MVP primitives are:
   Exactly one condition is required. `visible` is equivalent to `assertVisible`.
   `notVisible` succeeds as soon as the selector does not match on the current
   tick, including if it has not appeared yet.
+- `openInventory` — waits until a local player exists, then opens the survival
+  or creative inventory GUI. It takes no arguments. If the inventory is already
+  showing, the step succeeds without reopening it.
 
 ```yaml
 - waitUntil:

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -94,6 +94,10 @@ The MVP primitives are:
   tick, including if it has not appeared yet. Item and block ids may omit
   `minecraft:`. Block coordinates use the same relative/absolute rules as
   `lookAt`.
+- `waitTicks` — waits until the client world's game time has advanced by the
+  given number of ticks. A scalar positive integer is accepted
+  (`waitTicks: 25`), or an object with `ticks`. Use this for short animations
+  that have no `waitUntil` condition (for example door swing).
 - `openInventory` — waits until a local player exists, then opens the survival
   or creative inventory GUI. It takes no arguments. If the inventory is already
   showing, the step succeeds without reopening it.
@@ -153,6 +157,9 @@ The MVP primitives are:
     yaw: 90
     pitch: 45
 - useItem
+- waitTicks: 25
+- waitTicks:
+    ticks: 25
 ```
 
 ```yaml

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -13,7 +13,8 @@ Run a test by its YAML filename without the extension:
 ```
 
 The client uses an isolated directory under `build/scenario-test/run`. Before
-each run, the harness removes its saved worlds and writes deterministic English
+each run, the harness removes its saved worlds, clears
+`build/scenario-test/vanilla-server/world`, and writes deterministic English
 client options. A display is required.
 
 The default per-step timeout is 30 seconds. Override it when debugging:
@@ -27,6 +28,9 @@ Results are written to:
 - `build/scenario-test/report.xml` — JUnit XML
 - `build/scenario-test/diagnostics.txt` — current screen and visible widgets
 - `build/scenario-test/run/screenshots/` — PNGs from `captureScreenshot`
+- `build/scenario-test/vanilla-server/` — official dedicated-server run dir from
+  `startVanillaServer` (`server-jar.path`, `eula.txt`, `server.properties`,
+  `world/`, `logs/harness.log`)
 
 The Gradle process exits non-zero when loading, validation, or execution fails.
 
@@ -68,6 +72,18 @@ The MVP primitives are:
   `build/scenario-test/run/screenshots/`. With no arguments it uses a vanilla
   timestamped filename. An optional `name` sets the PNG stem. The step waits
   until the file has been written before succeeding.
+- `startVanillaServer` — launches Mojang’s official dedicated-server jar as a
+  child process (no Fabric/DWM on the server). It writes offline-mode superflat
+  settings, waits until `127.0.0.1` accepts TCP connections, and stops the
+  process when the scenario finishes. This step does **not** connect the client.
+  It uses a 120 second timeout floor; `-PscenarioTimeout` still raises that
+  floor when set higher.
+
+```yaml
+- startVanillaServer
+- startVanillaServer:
+    port: 25565
+```
 
 ```yaml
 - captureScreenshot

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -78,6 +78,12 @@ The MVP primitives are:
   process when the scenario finishes. This step does **not** connect the client.
   It uses a 120 second timeout floor; `-PscenarioTimeout` still raises that
   floor when set higher.
+- `createWorld` — opens vanilla Create World, applies the given settings, and
+  waits until the local player is in the loaded world. Omitted keys use
+  test-friendly defaults: superflat, creative, peaceful, commands on. An
+  optional `name` overrides vanilla’s “New World”. This step does **not** click
+  through the Create World tabs. It uses a 120 second timeout floor;
+  `-PscenarioTimeout` still raises that floor when set higher.
 - `keyboardInput` — waits until a focused, editable text field can consume
   input, then types the given string once via real `charTyped` events. It does
   not click or select the field; click the matching `editbox` first.
@@ -104,6 +110,16 @@ The MVP primitives are:
 - startVanillaServer
 - startVanillaServer:
     port: 25565
+```
+
+```yaml
+- createWorld
+- createWorld:
+    worldType: superflat
+    gameMode: creative
+    difficulty: peaceful
+    allowCommands: true
+    name: Scenario World
 ```
 
 ```yaml

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -81,6 +81,21 @@ The MVP primitives are:
 - `keyboardInput` — waits until a focused, editable text field can consume
   input, then types the given string once via real `charTyped` events. It does
   not click or select the field; click the matching `editbox` first.
+- `waitUntil` — polls until a nested selector is `visible` or `notVisible`.
+  Exactly one condition is required. `visible` is equivalent to `assertVisible`.
+  `notVisible` succeeds as soon as the selector does not match on the current
+  tick, including if it has not appeared yet.
+
+```yaml
+- waitUntil:
+    visible:
+      type: button
+      name: "Singleplayer"
+- waitUntil:
+    notVisible:
+      type: screen
+      name: LevelLoadingScreen
+```
 
 ```yaml
 - startVanillaServer
@@ -106,9 +121,20 @@ Selectors require an exact `name` and one of these types:
 - `cycle`
 - `tab`
 - `editbox`
+- `label`
+- `screen`
 
 For `editbox`, `name` is the accessibility narration label (`getMessage()`),
 not the current field value. Direct Connection’s IP field is `"Server Address"`.
+
+For `label`, `name` is a `StringWidget` message, or the painted status text on
+the vanilla connect screen (for example `"Connecting to the server..."`).
+`click` only targets widgets, so it cannot activate painted connect-screen
+status text.
+
+For `screen`, `name` is the Java simple class name of the current GUI
+(`LevelLoadingScreen`, not the fully qualified name). It matches when that
+screen is open. `click` cannot target `type: screen`.
 
 ```yaml
 steps:

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -60,6 +60,9 @@ The MVP primitives are:
 - `assertVisible` — waits for a visible matching widget.
 - `click` — waits for an active matching widget and dispatches a real screen
   mouse click at its center.
+- `debugScreen` — immediately logs the current screen class and every visible
+  widget (type, name, active, bounds). It takes no arguments and always
+  succeeds on the tick it runs.
 
 Selectors require an exact rendered `name` and one of these types:
 

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -94,6 +94,13 @@ The MVP primitives are:
 - `openInventory` — waits until a local player exists, then opens the survival
   or creative inventory GUI. It takes no arguments. If the inventory is already
   showing, the step succeeds without reopening it.
+- `runCommand` — waits until a local player and play connection exist, then
+  sends an in-game slash command as that player (the same path as typing `/give`
+  in chat, without opening the chat GUI). The step succeeds as soon as the
+  command packet is sent; it does not wait for success chat or inventory
+  updates. Cheats (singleplayer) or operator (dedicated server) are required
+  for privileged commands such as `/give`. `startVanillaServer` does not OP
+  the player.
 
 ```yaml
 - waitUntil:
@@ -126,6 +133,12 @@ The MVP primitives are:
 - keyboardInput: "localhost:25565"
 - keyboardInput:
     text: "localhost:25565"
+```
+
+```yaml
+- runCommand: "/give @s minecraft:diamond 1"
+- runCommand:
+    command: "/give @s minecraft:diamond 1"
 ```
 
 ```yaml

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -26,6 +26,7 @@ Results are written to:
 
 - `build/scenario-test/report.xml` — JUnit XML
 - `build/scenario-test/diagnostics.txt` — current screen and visible widgets
+- `build/scenario-test/run/screenshots/` — PNGs from `captureScreenshot`
 
 The Gradle process exits non-zero when loading, validation, or execution fails.
 
@@ -63,6 +64,16 @@ The MVP primitives are:
 - `debugScreen` — immediately logs the current screen class and every visible
   widget (type, name, active, bounds). It takes no arguments and always
   succeeds on the tick it runs.
+- `captureScreenshot` — captures the current framebuffer (world and GUI) to
+  `build/scenario-test/run/screenshots/`. With no arguments it uses a vanilla
+  timestamped filename. An optional `name` sets the PNG stem. The step waits
+  until the file has been written before succeeding.
+
+```yaml
+- captureScreenshot
+- captureScreenshot:
+    name: after-world-tab
+```
 
 Selectors require an exact rendered `name` and one of these types:
 

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/CreateWorldProcess.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/CreateWorldProcess.java
@@ -1,0 +1,247 @@
+package com.adamkali.dwm.scenariotest;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.LevelLoadingScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
+import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.Difficulty;
+import net.minecraft.world.level.levelgen.presets.WorldPreset;
+import org.slf4j.Logger;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+public final class CreateWorldProcess {
+    static final String DEFAULT_WORLD_TYPE = "flat";
+    static final String DEFAULT_GAME_MODE = "creative";
+    static final String DEFAULT_DIFFICULTY = "peaceful";
+    static final boolean DEFAULT_ALLOW_COMMANDS = true;
+
+    private static final Set<String> KEYS = Set.of(
+            "worldType", "gameMode", "difficulty", "allowCommands", "name");
+    private static final Set<String> GAME_MODES = Set.of("survival", "hardcore", "creative");
+    private static final Set<String> DIFFICULTIES = Set.of("peaceful", "easy", "normal", "hard");
+
+    private final Logger logger;
+
+    private boolean opened;
+    private boolean created;
+    private boolean completed;
+
+    CreateWorldProcess(Logger logger) {
+        this.logger = logger;
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw new ScenarioException("createWorld does not accept '" + key + "'");
+            }
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("worldType", parseWorldType(arguments.get("worldType")));
+        normalized.put("gameMode", parseGameMode(arguments.get("gameMode")));
+        normalized.put("difficulty", parseDifficulty(arguments.get("difficulty")));
+        normalized.put("allowCommands", parseAllowCommands(arguments.get("allowCommands")));
+        if (arguments.containsKey("name")) {
+            normalized.put("name", parseName(arguments.get("name")));
+        }
+        return normalized;
+    }
+
+    public static String parseWorldType(Object value) {
+        if (value == null) {
+            return DEFAULT_WORLD_TYPE;
+        }
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException("createWorld worldType must be a non-empty string");
+        }
+        String lower = string.trim().toLowerCase(Locale.ROOT);
+        String path = lower.startsWith("minecraft:") ? lower.substring("minecraft:".length()) : lower;
+        if (path.contains(":")) {
+            return lower;
+        }
+        return switch (path) {
+            case "default", "normal" -> "normal";
+            case "superflat", "flat" -> "flat";
+            case "largebiomes", "large_biomes" -> "large_biomes";
+            case "amplified" -> "amplified";
+            case "singlebiome", "single_biome", "single_biome_surface" -> "single_biome_surface";
+            default -> path;
+        };
+    }
+
+    public static String parseGameMode(Object value) {
+        if (value == null) {
+            return DEFAULT_GAME_MODE;
+        }
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException("createWorld gameMode must be one of " + GAME_MODES);
+        }
+        String gameMode = string.trim().toLowerCase(Locale.ROOT);
+        if (!GAME_MODES.contains(gameMode)) {
+            throw new ScenarioException("createWorld gameMode must be one of " + GAME_MODES);
+        }
+        return gameMode;
+    }
+
+    public static String parseDifficulty(Object value) {
+        if (value == null) {
+            return DEFAULT_DIFFICULTY;
+        }
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException("createWorld difficulty must be one of " + DIFFICULTIES);
+        }
+        String difficulty = string.trim().toLowerCase(Locale.ROOT);
+        if (!DIFFICULTIES.contains(difficulty)) {
+            throw new ScenarioException("createWorld difficulty must be one of " + DIFFICULTIES);
+        }
+        return difficulty;
+    }
+
+    public static boolean parseAllowCommands(Object value) {
+        if (value == null) {
+            return DEFAULT_ALLOW_COMMANDS;
+        }
+        if (!(value instanceof Boolean allowCommands)) {
+            throw new ScenarioException("createWorld allowCommands must be a boolean");
+        }
+        return allowCommands;
+    }
+
+    public static String parseName(Object value) {
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException("createWorld name must be a non-empty string");
+        }
+        return string;
+    }
+
+    public boolean tick(Minecraft client, Map<String, Object> arguments) {
+        if (completed) {
+            throw new ScenarioException("createWorld can only run once per scenario");
+        }
+        if (!opened) {
+            CreateWorldScreen.openFresh(client, () -> client.gui.setScreen(new TitleScreen()));
+            opened = true;
+            logger.info("Opened Create World");
+            return false;
+        }
+        if (!created) {
+            Screen screen = client.gui.screen();
+            if (!(screen instanceof CreateWorldScreen createWorldScreen)) {
+                return false;
+            }
+            applySettings(createWorldScreen.getUiState(), arguments);
+            logger.info("Creating world type={} gameMode={} difficulty={} allowCommands={} name={}",
+                    arguments.get("worldType"),
+                    arguments.get("gameMode"),
+                    arguments.get("difficulty"),
+                    arguments.get("allowCommands"),
+                    arguments.getOrDefault("name", "<vanilla>"));
+            createWorldScreen.onCreate();
+            created = true;
+            return false;
+        }
+        if (isWorldReady(client)) {
+            logger.info("World is ready");
+            completed = true;
+            return true;
+        }
+        return false;
+    }
+
+    private static void applySettings(WorldCreationUiState uiState, Map<String, Object> arguments) {
+        uiState.setWorldType(findWorldType(uiState, (String) arguments.get("worldType")));
+        uiState.setGameMode(toGameMode((String) arguments.get("gameMode")));
+        uiState.setDifficulty(toDifficulty((String) arguments.get("difficulty")));
+        uiState.setAllowCommands((Boolean) arguments.get("allowCommands"));
+        Object name = arguments.get("name");
+        if (name instanceof String worldName) {
+            uiState.setName(worldName);
+        }
+    }
+
+    private static WorldCreationUiState.WorldTypeEntry findWorldType(
+            WorldCreationUiState uiState,
+            String requested
+    ) {
+        List<WorldCreationUiState.WorldTypeEntry> entries = new ArrayList<>();
+        entries.addAll(uiState.getNormalPresetList());
+        entries.addAll(uiState.getAltPresetList());
+        Set<String> available = new TreeSet<>();
+        for (WorldCreationUiState.WorldTypeEntry entry : entries) {
+            Identifier id = presetId(entry);
+            if (id == null) {
+                continue;
+            }
+            available.add(id.toString());
+            if (matchesPreset(id, requested)) {
+                return entry;
+            }
+        }
+        throw new ScenarioException("createWorld worldType '" + requested
+                + "' was not found. Available: " + available);
+    }
+
+    private static Identifier presetId(WorldCreationUiState.WorldTypeEntry entry) {
+        Holder<WorldPreset> preset = entry.preset();
+        if (preset == null) {
+            return null;
+        }
+        return preset.unwrapKey().map(ResourceKey::identifier).orElse(null);
+    }
+
+    private static boolean matchesPreset(Identifier id, String requested) {
+        if (requested.contains(":")) {
+            return id.toString().equals(requested);
+        }
+        return id.getPath().equals(requested) || id.toString().equals("minecraft:" + requested);
+    }
+
+    private static WorldCreationUiState.SelectedGameMode toGameMode(String gameMode) {
+        return switch (gameMode) {
+            case "survival" -> WorldCreationUiState.SelectedGameMode.SURVIVAL;
+            case "hardcore" -> WorldCreationUiState.SelectedGameMode.HARDCORE;
+            case "creative" -> WorldCreationUiState.SelectedGameMode.CREATIVE;
+            default -> throw new ScenarioException("createWorld gameMode must be one of " + GAME_MODES);
+        };
+    }
+
+    private static Difficulty toDifficulty(String difficulty) {
+        return switch (difficulty) {
+            case "peaceful" -> Difficulty.PEACEFUL;
+            case "easy" -> Difficulty.EASY;
+            case "normal" -> Difficulty.NORMAL;
+            case "hard" -> Difficulty.HARD;
+            default -> throw new ScenarioException("createWorld difficulty must be one of " + DIFFICULTIES);
+        };
+    }
+
+    private static boolean isWorldReady(Minecraft client) {
+        if (client.player == null || client.level == null) {
+            return false;
+        }
+        return !isLoadingGui(client.gui.screen());
+    }
+
+    private static boolean isLoadingGui(Screen screen) {
+        if (screen == null) {
+            return false;
+        }
+        if (screen instanceof CreateWorldScreen || screen instanceof LevelLoadingScreen) {
+            return true;
+        }
+        String simpleName = screen.getClass().getSimpleName();
+        return simpleName.contains("Loading") || simpleName.contains("Receiving") || simpleName.contains("Progress");
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCatalog.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCatalog.java
@@ -1,0 +1,249 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public final class ScenarioCatalog {
+    private final Map<String, ScenarioDocument> tests;
+    private final Map<String, ScenarioDocument> commands;
+
+    private ScenarioCatalog(Map<String, ScenarioDocument> tests, Map<String, ScenarioDocument> commands) {
+        this.tests = Map.copyOf(tests);
+        this.commands = Map.copyOf(commands);
+    }
+
+    public static ScenarioCatalog loadFromResources(ClassLoader classLoader) {
+        URL root = classLoader.getResource("tests");
+        if (root == null) {
+            throw new ScenarioException("Could not find the scenario resource directory 'tests'");
+        }
+        if (!"file".equals(root.getProtocol())) {
+            throw new ScenarioException("Scenario resources must be available as files, but found: " + root);
+        }
+        try {
+            return load(Path.of(root.toURI()));
+        } catch (URISyntaxException exception) {
+            throw new ScenarioException("Invalid scenario resource URL: " + root, exception);
+        }
+    }
+
+    public static ScenarioCatalog load(Path root) {
+        if (!Files.isDirectory(root)) {
+            throw new ScenarioException("Scenario root is not a directory: " + root);
+        }
+
+        Map<String, ScenarioDocument> tests = new LinkedHashMap<>();
+        Map<String, ScenarioDocument> commands = new LinkedHashMap<>();
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(ScenarioCatalog::isYaml)
+                    .sorted()
+                    .map(path -> parse(root, path))
+                    .forEach(document -> {
+                        Map<String, ScenarioDocument> target =
+                                document.type() == ScenarioDocument.Type.TEST ? tests : commands;
+                        ScenarioDocument previous = target.putIfAbsent(document.id(), document);
+                        if (previous != null) {
+                            throw new ScenarioException("Duplicate " + document.type().name().toLowerCase(Locale.ROOT)
+                                    + " id '" + document.id() + "' in " + previous.source()
+                                    + " and " + document.source());
+                        }
+                    });
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not scan scenario resources under " + root, exception);
+        }
+        return new ScenarioCatalog(tests, commands);
+    }
+
+    public ScenarioDocument requireTest(String id) {
+        ScenarioDocument test = tests.get(normalizeId(id));
+        if (test == null) {
+            throw new ScenarioException("Unknown test '" + id + "'. Available tests: " + tests.keySet());
+        }
+        return test;
+    }
+
+    public ScenarioDocument command(String id) {
+        return commands.get(id);
+    }
+
+    public Map<String, ScenarioDocument> tests() {
+        return tests;
+    }
+
+    public Map<String, ScenarioDocument> commands() {
+        return commands;
+    }
+
+    private static ScenarioDocument parse(Path root, Path path) {
+        String source = root.relativize(path).toString().replace('\\', '/');
+        String content;
+        try {
+            content = Files.readString(path, StandardCharsets.UTF_8).replace("\r\n", "\n");
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not read " + source, exception);
+        }
+
+        if (!content.startsWith("---\n")) {
+            throw new ScenarioException(source + ": expected YAML frontmatter opening '---'");
+        }
+        int closing = content.indexOf("\n---\n", 4);
+        if (closing < 0) {
+            throw new ScenarioException(source + ": expected YAML frontmatter closing '---'");
+        }
+
+        Map<String, Object> frontmatter = loadMap(content.substring(4, closing), source + " frontmatter");
+        Map<String, Object> body = loadMap(content.substring(closing + 5), source + " body");
+        String id = filenameStem(path);
+        String name = requireString(frontmatter, "name", source);
+        String rawType = requireString(frontmatter, "type", source);
+        ScenarioDocument.Type type = switch (rawType) {
+            case "test" -> ScenarioDocument.Type.TEST;
+            case "command" -> ScenarioDocument.Type.COMMAND;
+            default -> throw new ScenarioException(source + ": unsupported frontmatter type '" + rawType + "'");
+        };
+
+        List<ScenarioDocument.Parameter> parameters = parseParameters(body.get("parameters"), source, type);
+        List<ScenarioDocument.Invocation> steps = parseSteps(body.get("steps"), source);
+        return new ScenarioDocument(id, name, type, parameters, steps, source);
+    }
+
+    private static List<ScenarioDocument.Parameter> parseParameters(
+            Object value,
+            String source,
+            ScenarioDocument.Type type
+    ) {
+        if (value == null) {
+            return List.of();
+        }
+        if (type != ScenarioDocument.Type.COMMAND) {
+            throw new ScenarioException(source + ": only command documents may declare parameters");
+        }
+        if (!(value instanceof List<?> values)) {
+            throw new ScenarioException(source + ": 'parameters' must be a list");
+        }
+
+        List<ScenarioDocument.Parameter> parameters = new ArrayList<>();
+        for (Object entry : values) {
+            Map<String, Object> parameter = requireMap(entry, source + " parameter");
+            String name = requireString(parameter, "name", source + " parameter");
+            String parameterType = requireString(parameter, "type", source + " parameter");
+            if (!"string".equals(parameterType)) {
+                throw new ScenarioException(source + ": unsupported parameter type '" + parameterType
+                        + "' for '" + name + "'");
+            }
+            if (parameters.stream().anyMatch(existing -> existing.name().equals(name))) {
+                throw new ScenarioException(source + ": duplicate parameter '" + name + "'");
+            }
+            parameters.add(new ScenarioDocument.Parameter(name, parameterType));
+        }
+        return List.copyOf(parameters);
+    }
+
+    private static List<ScenarioDocument.Invocation> parseSteps(Object value, String source) {
+        if (!(value instanceof List<?> values) || values.isEmpty()) {
+            throw new ScenarioException(source + ": 'steps' must be a non-empty list");
+        }
+        List<ScenarioDocument.Invocation> steps = new ArrayList<>();
+        for (Object entry : values) {
+            if (entry instanceof String name) {
+                steps.add(new ScenarioDocument.Invocation(name, Map.of()));
+                continue;
+            }
+            Map<String, Object> invocation = requireMap(entry, source + " step");
+            if (invocation.size() != 1) {
+                throw new ScenarioException(source + ": each step must contain exactly one command");
+            }
+            Map.Entry<String, Object> command = invocation.entrySet().iterator().next();
+            steps.add(new ScenarioDocument.Invocation(
+                    command.getKey(),
+                    normalizeArguments(command.getValue(), source, command.getKey())
+            ));
+        }
+        return List.copyOf(steps);
+    }
+
+    private static Map<String, Object> normalizeArguments(Object value, String source, String step) {
+        if (value == null) {
+            return Map.of();
+        }
+        if (value instanceof List<?> list) {
+            if (list.size() != 1) {
+                throw new ScenarioException(source + ": step '" + step
+                        + "' expects one argument object, but received " + list.size());
+            }
+            value = list.getFirst();
+        }
+        return Map.copyOf(requireMap(value, source + " step '" + step + "'"));
+    }
+
+    private static Map<String, Object> loadMap(String yaml, String context) {
+        Object value;
+        try {
+            value = new Yaml(new SafeConstructor(new LoaderOptions())).load(yaml);
+        } catch (RuntimeException exception) {
+            throw new ScenarioException(context + ": invalid YAML: " + exception.getMessage(), exception);
+        }
+        if (value == null) {
+            return Map.of();
+        }
+        return requireMap(value, context);
+    }
+
+    private static Map<String, Object> requireMap(Object value, String context) {
+        if (!(value instanceof Map<?, ?> raw)) {
+            throw new ScenarioException(context + ": expected an object");
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        raw.forEach((key, entryValue) -> {
+            if (!(key instanceof String stringKey)) {
+                throw new ScenarioException(context + ": object keys must be strings");
+            }
+            result.put(stringKey, entryValue);
+        });
+        return result;
+    }
+
+    private static String requireString(Map<String, Object> values, String key, String context) {
+        Object value = values.get(key);
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(context + ": '" + key + "' must be a non-empty string");
+        }
+        return string;
+    }
+
+    private static boolean isYaml(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.ROOT);
+        return name.endsWith(".yaml") || name.endsWith(".yml");
+    }
+
+    private static String filenameStem(Path path) {
+        String name = path.getFileName().toString();
+        int extension = name.lastIndexOf('.');
+        return extension < 0 ? name : name.substring(0, extension);
+    }
+
+    private static String normalizeId(String id) {
+        String normalized = id.replace('\\', '/');
+        int slash = normalized.lastIndexOf('/');
+        if (slash >= 0) {
+            normalized = normalized.substring(slash + 1);
+        }
+        int extension = normalized.lastIndexOf('.');
+        return extension < 0 ? normalized : normalized.substring(0, extension);
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCatalog.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCatalog.java
@@ -181,6 +181,9 @@ public final class ScenarioCatalog {
         if (value == null) {
             return Map.of();
         }
+        if (value instanceof String text) {
+            return Map.of("text", text);
+        }
         if (value instanceof List<?> list) {
             if (list.size() != 1) {
                 throw new ScenarioException(source + ": step '" + step

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCatalog.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCatalog.java
@@ -184,6 +184,9 @@ public final class ScenarioCatalog {
         if (value instanceof String text) {
             return Map.of("text", text);
         }
+        if (value instanceof Number number) {
+            return Map.of("text", number.toString());
+        }
         if (value instanceof List<?> list) {
             if (list.size() != 1) {
                 throw new ScenarioException(source + ": step '" + step

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 public final class ScenarioCompiler {
     private static final Set<String> PRIMITIVES = Set.of(
-            "launchGame", "assertVisible", "click", "debugScreen", "captureScreenshot"
+            "launchGame", "assertVisible", "click", "debugScreen", "captureScreenshot", "startVanillaServer"
     );
     private static final Pattern TEMPLATE = Pattern.compile("\\{\\{\\s*([A-Za-z][A-Za-z0-9_]*)\\s*}}");
 
@@ -103,6 +103,10 @@ public final class ScenarioCompiler {
             validateCaptureScreenshot(arguments, source);
             return;
         }
+        if ("startVanillaServer".equals(name)) {
+            validateStartVanillaServer(arguments, source);
+            return;
+        }
 
         for (String key : arguments.keySet()) {
             if (!Set.of("type", "name").contains(key)) {
@@ -114,6 +118,22 @@ public final class ScenarioCompiler {
         if (!Set.of("button", "cycle", "tab").contains(arguments.get("type"))) {
             throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
                     + "'; supported types: [button, cycle, tab]");
+        }
+    }
+
+    private static void validateStartVanillaServer(Map<String, Object> arguments, String source) {
+        if (arguments.isEmpty()) {
+            return;
+        }
+        for (String key : arguments.keySet()) {
+            if (!"port".equals(key)) {
+                throw new ScenarioException(source + ": startVanillaServer does not accept '" + key + "'");
+            }
+        }
+        try {
+            arguments.put("port", VanillaServerProcess.parsePort(arguments.get("port")));
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
         }
     }
 

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
@@ -12,8 +12,10 @@ import java.util.regex.Pattern;
 
 public final class ScenarioCompiler {
     private static final Set<String> PRIMITIVES = Set.of(
-            "launchGame", "assertVisible", "click", "debugScreen", "captureScreenshot", "startVanillaServer"
+            "launchGame", "assertVisible", "click", "debugScreen", "captureScreenshot",
+            "startVanillaServer", "keyboardInput"
     );
+    private static final Set<String> SELECTOR_TYPES = Set.of("button", "cycle", "tab", "editbox");
     private static final Pattern TEMPLATE = Pattern.compile("\\{\\{\\s*([A-Za-z][A-Za-z0-9_]*)\\s*}}");
 
     private final ScenarioCatalog catalog;
@@ -107,6 +109,10 @@ public final class ScenarioCompiler {
             validateStartVanillaServer(arguments, source);
             return;
         }
+        if ("keyboardInput".equals(name)) {
+            validateKeyboardInput(arguments, source);
+            return;
+        }
 
         for (String key : arguments.keySet()) {
             if (!Set.of("type", "name").contains(key)) {
@@ -115,9 +121,21 @@ public final class ScenarioCompiler {
         }
         requireSelectorString(arguments, "type", name, source);
         requireSelectorString(arguments, "name", name, source);
-        if (!Set.of("button", "cycle", "tab").contains(arguments.get("type"))) {
+        if (!SELECTOR_TYPES.contains(arguments.get("type"))) {
             throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
-                    + "'; supported types: [button, cycle, tab]");
+                    + "'; supported types: [button, cycle, tab, editbox]");
+        }
+    }
+
+    private static void validateKeyboardInput(Map<String, Object> arguments, String source) {
+        for (String key : arguments.keySet()) {
+            if (!"text".equals(key)) {
+                throw new ScenarioException(source + ": keyboardInput does not accept '" + key + "'");
+            }
+        }
+        Object value = arguments.get("text");
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(source + ": keyboardInput requires a non-empty string 'text'");
         }
     }
 

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
@@ -1,0 +1,163 @@
+package com.adamkali.dwm.scenariotest;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ScenarioCompiler {
+    private static final Set<String> PRIMITIVES = Set.of("launchGame", "assertVisible", "click");
+    private static final Pattern TEMPLATE = Pattern.compile("\\{\\{\\s*([A-Za-z][A-Za-z0-9_]*)\\s*}}");
+
+    private final ScenarioCatalog catalog;
+
+    public ScenarioCompiler(ScenarioCatalog catalog) {
+        this.catalog = catalog;
+    }
+
+    public ScenarioPlan compile(String testId) {
+        ScenarioDocument test = catalog.requireTest(testId);
+        List<ScenarioPlan.Step> expanded = new ArrayList<>();
+        expand(test.steps(), test.source(), Map.of(), new ArrayDeque<>(), expanded);
+        return new ScenarioPlan(test.id(), test.name(), expanded);
+    }
+
+    private void expand(
+            List<ScenarioDocument.Invocation> invocations,
+            String source,
+            Map<String, Object> bindings,
+            Deque<String> commandStack,
+            List<ScenarioPlan.Step> output
+    ) {
+        for (ScenarioDocument.Invocation invocation : invocations) {
+            Map<String, Object> arguments = substituteMap(invocation.arguments(), bindings, source);
+            if (PRIMITIVES.contains(invocation.name())) {
+                validatePrimitive(invocation.name(), arguments, source);
+                output.add(new ScenarioPlan.Step(invocation.name(), arguments, source));
+                continue;
+            }
+
+            ScenarioDocument command = catalog.command(invocation.name());
+            if (command == null) {
+                throw new ScenarioException(source + ": unknown step or command '" + invocation.name() + "'");
+            }
+            if (commandStack.contains(command.id())) {
+                List<String> cycle = new ArrayList<>(commandStack);
+                cycle.add(command.id());
+                throw new ScenarioException(source + ": recursive command cycle: " + String.join(" -> ", cycle));
+            }
+
+            Map<String, Object> commandBindings = validateCommandArguments(command, arguments, source);
+            commandStack.addLast(command.id());
+            expand(command.steps(), command.source(), commandBindings, commandStack, output);
+            commandStack.removeLast();
+        }
+    }
+
+    private static Map<String, Object> validateCommandArguments(
+            ScenarioDocument command,
+            Map<String, Object> arguments,
+            String callerSource
+    ) {
+        Set<String> expected = command.parameters().stream()
+                .map(ScenarioDocument.Parameter::name)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        for (String supplied : arguments.keySet()) {
+            if (!expected.contains(supplied)) {
+                throw new ScenarioException(callerSource + ": command '" + command.id()
+                        + "' does not declare parameter '" + supplied + "'");
+            }
+        }
+
+        Map<String, Object> bindings = new LinkedHashMap<>();
+        for (ScenarioDocument.Parameter parameter : command.parameters()) {
+            Object value = arguments.get(parameter.name());
+            if (value == null) {
+                throw new ScenarioException(callerSource + ": command '" + command.id()
+                        + "' is missing parameter '" + parameter.name() + "'");
+            }
+            if ("string".equals(parameter.type()) && !(value instanceof String)) {
+                throw new ScenarioException(callerSource + ": parameter '" + parameter.name()
+                        + "' for command '" + command.id() + "' must be a string");
+            }
+            bindings.put(parameter.name(), value);
+        }
+        return bindings;
+    }
+
+    private static void validatePrimitive(String name, Map<String, Object> arguments, String source) {
+        if ("launchGame".equals(name)) {
+            if (!arguments.isEmpty()) {
+                throw new ScenarioException(source + ": launchGame does not accept arguments");
+            }
+            return;
+        }
+
+        for (String key : arguments.keySet()) {
+            if (!Set.of("type", "name").contains(key)) {
+                throw new ScenarioException(source + ": step '" + name + "' has unknown selector field '" + key + "'");
+            }
+        }
+        requireSelectorString(arguments, "type", name, source);
+        requireSelectorString(arguments, "name", name, source);
+        if (!Set.of("button", "cycle", "tab").contains(arguments.get("type"))) {
+            throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
+                    + "'; supported types: [button, cycle, tab]");
+        }
+    }
+
+    private static void requireSelectorString(
+            Map<String, Object> arguments,
+            String key,
+            String step,
+            String source
+    ) {
+        Object value = arguments.get(key);
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(source + ": step '" + step + "' requires a non-empty string '" + key + "'");
+        }
+    }
+
+    private static Map<String, Object> substituteMap(
+            Map<String, Object> values,
+            Map<String, Object> bindings,
+            String source
+    ) {
+        Map<String, Object> substituted = new LinkedHashMap<>();
+        values.forEach((key, value) -> substituted.put(key, substitute(value, bindings, source)));
+        return substituted;
+    }
+
+    private static Object substitute(Object value, Map<String, Object> bindings, String source) {
+        if (value instanceof String string) {
+            Matcher matcher = TEMPLATE.matcher(string);
+            StringBuilder result = new StringBuilder();
+            while (matcher.find()) {
+                String parameter = matcher.group(1);
+                Object replacement = bindings.get(parameter);
+                if (replacement == null) {
+                    throw new ScenarioException(source + ": no value supplied for template parameter '"
+                            + parameter + "'");
+                }
+                matcher.appendReplacement(result, Matcher.quoteReplacement(replacement.toString()));
+            }
+            matcher.appendTail(result);
+            return result.toString();
+        }
+        if (value instanceof Map<?, ?> rawMap) {
+            Map<String, Object> map = new LinkedHashMap<>();
+            rawMap.forEach((key, entryValue) ->
+                    map.put(String.valueOf(key), substitute(entryValue, bindings, source)));
+            return map;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(entry -> substitute(entry, bindings, source)).toList();
+        }
+        return value;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
@@ -11,7 +11,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class ScenarioCompiler {
-    private static final Set<String> PRIMITIVES = Set.of("launchGame", "assertVisible", "click", "debugScreen");
+    private static final Set<String> PRIMITIVES = Set.of(
+            "launchGame", "assertVisible", "click", "debugScreen", "captureScreenshot"
+    );
     private static final Pattern TEMPLATE = Pattern.compile("\\{\\{\\s*([A-Za-z][A-Za-z0-9_]*)\\s*}}");
 
     private final ScenarioCatalog catalog;
@@ -97,6 +99,10 @@ public final class ScenarioCompiler {
             }
             return;
         }
+        if ("captureScreenshot".equals(name)) {
+            validateCaptureScreenshot(arguments, source);
+            return;
+        }
 
         for (String key : arguments.keySet()) {
             if (!Set.of("type", "name").contains(key)) {
@@ -108,6 +114,26 @@ public final class ScenarioCompiler {
         if (!Set.of("button", "cycle", "tab").contains(arguments.get("type"))) {
             throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
                     + "'; supported types: [button, cycle, tab]");
+        }
+    }
+
+    private static void validateCaptureScreenshot(Map<String, Object> arguments, String source) {
+        if (arguments.isEmpty()) {
+            return;
+        }
+        for (String key : arguments.keySet()) {
+            if (!"name".equals(key)) {
+                throw new ScenarioException(source + ": captureScreenshot does not accept '" + key + "'");
+            }
+        }
+        Object value = arguments.get("name");
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(source + ": captureScreenshot requires a non-empty string 'name'");
+        }
+        try {
+            arguments.put("name", ScreenshotCapture.normalizeFileName(string));
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
         }
     }
 

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class ScenarioCompiler {
-    private static final Set<String> PRIMITIVES = Set.of("launchGame", "assertVisible", "click");
+    private static final Set<String> PRIMITIVES = Set.of("launchGame", "assertVisible", "click", "debugScreen");
     private static final Pattern TEMPLATE = Pattern.compile("\\{\\{\\s*([A-Za-z][A-Za-z0-9_]*)\\s*}}");
 
     private final ScenarioCatalog catalog;
@@ -91,9 +91,9 @@ public final class ScenarioCompiler {
     }
 
     private static void validatePrimitive(String name, Map<String, Object> arguments, String source) {
-        if ("launchGame".equals(name)) {
+        if ("launchGame".equals(name) || "debugScreen".equals(name)) {
             if (!arguments.isEmpty()) {
-                throw new ScenarioException(source + ": launchGame does not accept arguments");
+                throw new ScenarioException(source + ": " + name + " does not accept arguments");
             }
             return;
         }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCompiler.java
@@ -1,5 +1,8 @@
 package com.adamkali.dwm.scenariotest;
 
+import com.adamkali.dwm.scenariotest.primitive.ScenarioPrimitive;
+import com.adamkali.dwm.scenariotest.primitive.ScenarioPrimitives;
+
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -11,11 +14,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class ScenarioCompiler {
-    private static final Set<String> PRIMITIVES = Set.of(
-            "launchGame", "assertVisible", "click", "debugScreen", "captureScreenshot",
-            "startVanillaServer", "keyboardInput"
-    );
-    private static final Set<String> SELECTOR_TYPES = Set.of("button", "cycle", "tab", "editbox");
     private static final Pattern TEMPLATE = Pattern.compile("\\{\\{\\s*([A-Za-z][A-Za-z0-9_]*)\\s*}}");
 
     private final ScenarioCatalog catalog;
@@ -40,9 +38,12 @@ public final class ScenarioCompiler {
     ) {
         for (ScenarioDocument.Invocation invocation : invocations) {
             Map<String, Object> arguments = substituteMap(invocation.arguments(), bindings, source);
-            if (PRIMITIVES.contains(invocation.name())) {
-                validatePrimitive(invocation.name(), arguments, source);
-                output.add(new ScenarioPlan.Step(invocation.name(), arguments, source));
+            ScenarioPrimitive primitive = ScenarioPrimitives.find(invocation.name());
+            if (primitive != null) {
+                output.add(new ScenarioPlan.Step(
+                        primitive.name(),
+                        primitive.validate(arguments, source),
+                        source));
                 continue;
             }
 
@@ -92,99 +93,6 @@ public final class ScenarioCompiler {
             bindings.put(parameter.name(), value);
         }
         return bindings;
-    }
-
-    private static void validatePrimitive(String name, Map<String, Object> arguments, String source) {
-        if ("launchGame".equals(name) || "debugScreen".equals(name)) {
-            if (!arguments.isEmpty()) {
-                throw new ScenarioException(source + ": " + name + " does not accept arguments");
-            }
-            return;
-        }
-        if ("captureScreenshot".equals(name)) {
-            validateCaptureScreenshot(arguments, source);
-            return;
-        }
-        if ("startVanillaServer".equals(name)) {
-            validateStartVanillaServer(arguments, source);
-            return;
-        }
-        if ("keyboardInput".equals(name)) {
-            validateKeyboardInput(arguments, source);
-            return;
-        }
-
-        for (String key : arguments.keySet()) {
-            if (!Set.of("type", "name").contains(key)) {
-                throw new ScenarioException(source + ": step '" + name + "' has unknown selector field '" + key + "'");
-            }
-        }
-        requireSelectorString(arguments, "type", name, source);
-        requireSelectorString(arguments, "name", name, source);
-        if (!SELECTOR_TYPES.contains(arguments.get("type"))) {
-            throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
-                    + "'; supported types: [button, cycle, tab, editbox]");
-        }
-    }
-
-    private static void validateKeyboardInput(Map<String, Object> arguments, String source) {
-        for (String key : arguments.keySet()) {
-            if (!"text".equals(key)) {
-                throw new ScenarioException(source + ": keyboardInput does not accept '" + key + "'");
-            }
-        }
-        Object value = arguments.get("text");
-        if (!(value instanceof String string) || string.isBlank()) {
-            throw new ScenarioException(source + ": keyboardInput requires a non-empty string 'text'");
-        }
-    }
-
-    private static void validateStartVanillaServer(Map<String, Object> arguments, String source) {
-        if (arguments.isEmpty()) {
-            return;
-        }
-        for (String key : arguments.keySet()) {
-            if (!"port".equals(key)) {
-                throw new ScenarioException(source + ": startVanillaServer does not accept '" + key + "'");
-            }
-        }
-        try {
-            arguments.put("port", VanillaServerProcess.parsePort(arguments.get("port")));
-        } catch (ScenarioException exception) {
-            throw new ScenarioException(source + ": " + exception.getMessage());
-        }
-    }
-
-    private static void validateCaptureScreenshot(Map<String, Object> arguments, String source) {
-        if (arguments.isEmpty()) {
-            return;
-        }
-        for (String key : arguments.keySet()) {
-            if (!"name".equals(key)) {
-                throw new ScenarioException(source + ": captureScreenshot does not accept '" + key + "'");
-            }
-        }
-        Object value = arguments.get("name");
-        if (!(value instanceof String string) || string.isBlank()) {
-            throw new ScenarioException(source + ": captureScreenshot requires a non-empty string 'name'");
-        }
-        try {
-            arguments.put("name", ScreenshotCapture.normalizeFileName(string));
-        } catch (ScenarioException exception) {
-            throw new ScenarioException(source + ": " + exception.getMessage());
-        }
-    }
-
-    private static void requireSelectorString(
-            Map<String, Object> arguments,
-            String key,
-            String step,
-            String source
-    ) {
-        Object value = arguments.get(key);
-        if (!(value instanceof String string) || string.isBlank()) {
-            throw new ScenarioException(source + ": step '" + step + "' requires a non-empty string '" + key + "'");
-        }
     }
 
     private static Map<String, Object> substituteMap(

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCoordinates.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioCoordinates.java
@@ -1,0 +1,55 @@
+package com.adamkali.dwm.scenariotest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ScenarioCoordinates {
+    private static final Pattern RELATIVE = Pattern.compile("^~([+-]?\\d+)?$");
+    private static final Pattern ABSOLUTE = Pattern.compile("^-?\\d+$");
+
+    private ScenarioCoordinates() {
+    }
+
+    public record Component(boolean relative, int value) {
+        public int resolve(int origin) {
+            return relative ? origin + value : value;
+        }
+
+        public String authored() {
+            if (!relative) {
+                return Integer.toString(value);
+            }
+            return value == 0 ? "~" : "~" + value;
+        }
+    }
+
+    public static Component parse(Object value, String field) {
+        if (value == null) {
+            throw new ScenarioException(field + " must be a relative (~, ~1) or absolute integer; quote \"~\" in YAML");
+        }
+        if (value instanceof Number number) {
+            return absoluteNumber(number, field);
+        }
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(field + " must be a relative (~, ~1) or absolute integer");
+        }
+        String trimmed = string.trim();
+        Matcher relative = RELATIVE.matcher(trimmed);
+        if (relative.matches()) {
+            String offset = relative.group(1);
+            return new Component(true, offset == null ? 0 : Integer.parseInt(offset));
+        }
+        if (ABSOLUTE.matcher(trimmed).matches()) {
+            return new Component(false, Integer.parseInt(trimmed));
+        }
+        throw new ScenarioException(field + " must be a relative (~, ~1) or absolute integer");
+    }
+
+    private static Component absoluteNumber(Number number, String field) {
+        double value = number.doubleValue();
+        if (value != Math.rint(value) || value < Integer.MIN_VALUE || value > Integer.MAX_VALUE) {
+            throw new ScenarioException(field + " must be a relative (~, ~1) or absolute integer");
+        }
+        return new Component(false, number.intValue());
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioDocument.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioDocument.java
@@ -1,0 +1,27 @@
+package com.adamkali.dwm.scenariotest;
+
+import java.util.List;
+import java.util.Map;
+
+public record ScenarioDocument(
+        String id,
+        String name,
+        Type type,
+        List<Parameter> parameters,
+        List<Invocation> steps,
+        String source
+) {
+    public enum Type {
+        TEST,
+        COMMAND
+    }
+
+    public record Parameter(String name, String type) {
+    }
+
+    public record Invocation(String name, Map<String, Object> arguments) {
+        public Invocation {
+            arguments = Map.copyOf(arguments);
+        }
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioException.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioException.java
@@ -1,0 +1,11 @@
+package com.adamkali.dwm.scenariotest;
+
+public final class ScenarioException extends RuntimeException {
+    public ScenarioException(String message) {
+        super(message);
+    }
+
+    public ScenarioException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioIds.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioIds.java
@@ -1,0 +1,23 @@
+package com.adamkali.dwm.scenariotest;
+
+import net.minecraft.resources.Identifier;
+
+public final class ScenarioIds {
+    private ScenarioIds() {
+    }
+
+    public static String normalize(Object value, String field) {
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(field + " requires a non-empty namespaced id");
+        }
+        String trimmed = string.trim();
+        try {
+            Identifier parsed = trimmed.contains(":")
+                    ? Identifier.parse(trimmed)
+                    : Identifier.withDefaultNamespace(trimmed);
+            return parsed.toString();
+        } catch (RuntimeException exception) {
+            throw new ScenarioException(field + " '" + trimmed + "' is not a valid id");
+        }
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -14,8 +14,11 @@ public record ScenarioPlan(String id, String name, List<Step> steps) {
         }
 
         public String displayName() {
-            Object elementName = arguments.get("name");
-            return elementName == null ? name : name + " \"" + elementName + "\"";
+            Object detail = arguments.get("name");
+            if (detail == null) {
+                detail = arguments.get("text");
+            }
+            return detail == null ? name : name + " \"" + detail + "\"";
         }
     }
 }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -1,0 +1,21 @@
+package com.adamkali.dwm.scenariotest;
+
+import java.util.List;
+import java.util.Map;
+
+public record ScenarioPlan(String id, String name, List<Step> steps) {
+    public ScenarioPlan {
+        steps = List.copyOf(steps);
+    }
+
+    public record Step(String name, Map<String, Object> arguments, String source) {
+        public Step {
+            arguments = Map.copyOf(arguments);
+        }
+
+        public String displayName() {
+            Object elementName = arguments.get("name");
+            return elementName == null ? name : name + " \"" + elementName + "\"";
+        }
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -22,6 +22,22 @@ public record ScenarioPlan(String id, String name, List<Step> steps) {
                 detail = arguments.get("command");
             }
             if (detail == null) {
+                detail = arguments.get("slot");
+            }
+            if (arguments.containsKey("holding")) {
+                return name + " holding \"" + arguments.get("holding") + "\"";
+            }
+            if (arguments.get("block") instanceof Map<?, ?> block && block.get("id") != null) {
+                return name + " block \"" + block.get("id") + "\"";
+            }
+            if (arguments.containsKey("x")) {
+                return name + " \"" + arguments.get("x") + " " + arguments.get("y") + " "
+                        + arguments.get("z") + "\"";
+            }
+            if (arguments.containsKey("yaw")) {
+                return name + " \"" + arguments.get("yaw") + " " + arguments.get("pitch") + "\"";
+            }
+            if (detail == null) {
                 for (String condition : List.of("visible", "notVisible")) {
                     Object nested = arguments.get(condition);
                     if (nested instanceof Map<?, ?> selector) {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -18,6 +18,17 @@ public record ScenarioPlan(String id, String name, List<Step> steps) {
             if (detail == null) {
                 detail = arguments.get("text");
             }
+            if (detail == null) {
+                for (String condition : List.of("visible", "notVisible")) {
+                    Object nested = arguments.get(condition);
+                    if (nested instanceof Map<?, ?> selector) {
+                        Object nestedName = selector.get("name");
+                        if (nestedName != null) {
+                            return name + " " + condition + " \"" + nestedName + "\"";
+                        }
+                    }
+                }
+            }
             return detail == null ? name : name + " \"" + detail + "\"";
         }
     }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -19,6 +19,9 @@ public record ScenarioPlan(String id, String name, List<Step> steps) {
                 detail = arguments.get("text");
             }
             if (detail == null) {
+                detail = arguments.get("command");
+            }
+            if (detail == null) {
                 for (String condition : List.of("visible", "notVisible")) {
                     Object nested = arguments.get(condition);
                     if (nested instanceof Map<?, ?> selector) {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -24,6 +24,9 @@ public record ScenarioPlan(String id, String name, List<Step> steps) {
             if (detail == null) {
                 detail = arguments.get("slot");
             }
+            if (detail == null) {
+                detail = arguments.get("ticks");
+            }
             if (arguments.containsKey("holding")) {
                 return name + " holding \"" + arguments.get("holding") + "\"";
             }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioReportWriter.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioReportWriter.java
@@ -1,0 +1,81 @@
+package com.adamkali.dwm.scenariotest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+final class ScenarioReportWriter {
+    private final Path reportFile;
+
+    ScenarioReportWriter(Path reportFile) {
+        this.reportFile = reportFile;
+    }
+
+    void write(ScenarioPlan plan, List<StepResult> results, String failure, String diagnostics) {
+        try {
+            Files.createDirectories(reportFile.getParent());
+            Files.writeString(reportFile, xml(plan, results, failure), StandardCharsets.UTF_8);
+            Files.writeString(
+                    reportFile.resolveSibling("diagnostics.txt"),
+                    diagnostics == null || diagnostics.isBlank() ? "No diagnostics.\n" : diagnostics,
+                    StandardCharsets.UTF_8
+            );
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not write scenario report to " + reportFile, exception);
+        }
+    }
+
+    void writeBootstrapFailure(String scenarioId, Throwable failure) {
+        ScenarioPlan plan = new ScenarioPlan(scenarioId, scenarioId, List.of());
+        write(plan, List.of(), message(failure), message(failure) + "\n");
+    }
+
+    private static String xml(ScenarioPlan plan, List<StepResult> results, String failure) {
+        int failureCount = failure == null ? 0 : 1;
+        double duration = results.stream().mapToLong(StepResult::durationNanos).sum() / 1_000_000_000.0;
+        StringBuilder xml = new StringBuilder();
+        xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+                .append("<testsuite name=\"").append(escape(plan.name())).append("\" tests=\"1\" failures=\"")
+                .append(failureCount).append("\" time=\"").append(String.format(java.util.Locale.ROOT, "%.3f", duration))
+                .append("\">\n")
+                .append("  <testcase classname=\"dwm.scenario\" name=\"").append(escape(plan.id()))
+                .append("\" time=\"").append(String.format(java.util.Locale.ROOT, "%.3f", duration)).append("\">");
+        if (failure != null) {
+            xml.append("\n    <failure message=\"").append(escape(failure)).append("\">")
+                    .append(escape(failure)).append("</failure>\n  ");
+        }
+        xml.append("</testcase>\n")
+                .append("  <system-out>").append(escape(stepSummary(results))).append("</system-out>\n")
+                .append("</testsuite>\n");
+        return xml.toString();
+    }
+
+    private static String stepSummary(List<StepResult> results) {
+        StringBuilder summary = new StringBuilder();
+        for (StepResult result : results) {
+            summary.append(result.passed() ? "PASS " : "FAIL ")
+                    .append(result.name())
+                    .append(" (")
+                    .append(String.format(java.util.Locale.ROOT, "%.3fs", result.durationNanos() / 1_000_000_000.0))
+                    .append(")\n");
+        }
+        return summary.toString();
+    }
+
+    private static String escape(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&apos;");
+    }
+
+    private static String message(Throwable failure) {
+        return failure.getMessage() == null ? failure.getClass().getName() : failure.getMessage();
+    }
+
+    record StepResult(String name, long durationNanos, boolean passed) {
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -1,0 +1,150 @@
+package com.adamkali.dwm.scenariotest;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.MouseButtonInfo;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+final class ScenarioRunner {
+    private final ScenarioPlan plan;
+    private final ScenarioReportWriter reportWriter;
+    private final Duration stepTimeout;
+    private final WidgetFinder widgetFinder = new WidgetFinder();
+    private final Logger logger;
+    private final List<ScenarioReportWriter.StepResult> results = new ArrayList<>();
+
+    private int stepIndex;
+    private long stepStartedNanos;
+    private boolean finished;
+    private boolean executing;
+
+    ScenarioRunner(
+            ScenarioPlan plan,
+            ScenarioReportWriter reportWriter,
+            Duration stepTimeout,
+            Logger logger
+    ) {
+        this.plan = plan;
+        this.reportWriter = reportWriter;
+        this.stepTimeout = stepTimeout;
+        this.logger = logger;
+    }
+
+    void tick(Minecraft client) {
+        if (finished || executing) {
+            return;
+        }
+        if (stepIndex >= plan.steps().size()) {
+            finish(client, null);
+            return;
+        }
+
+        ScenarioPlan.Step step = plan.steps().get(stepIndex);
+        if (stepStartedNanos == 0L) {
+            stepStartedNanos = System.nanoTime();
+            logger.info("Scenario step {}/{}: {}", stepIndex + 1, plan.steps().size(), step.displayName());
+        }
+
+        try {
+            executing = true;
+            boolean completed = execute(step, client);
+            executing = false;
+            if (completed) {
+                results.add(new ScenarioReportWriter.StepResult(
+                        step.displayName(),
+                        System.nanoTime() - stepStartedNanos,
+                        true
+                ));
+                stepIndex++;
+                stepStartedNanos = 0L;
+                return;
+            }
+            if (System.nanoTime() - stepStartedNanos > stepTimeout.toNanos()) {
+                throw new ScenarioException("Timed out after " + stepTimeout.toSeconds()
+                        + "s waiting for " + step.displayName() + " from " + step.source());
+            }
+        } catch (RuntimeException exception) {
+            executing = false;
+            results.add(new ScenarioReportWriter.StepResult(
+                    step.displayName(),
+                    System.nanoTime() - stepStartedNanos,
+                    false
+            ));
+            finish(client, exception);
+        }
+    }
+
+    private boolean execute(ScenarioPlan.Step step, Minecraft client) {
+        Screen screen = client.gui.screen();
+        return switch (step.name()) {
+            case "launchGame" -> screen instanceof TitleScreen;
+            case "assertVisible" -> widgetFinder.find(screen, step.arguments()).isPresent();
+            case "click" -> click(screen, step);
+            default -> throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
+        };
+    }
+
+    private boolean click(Screen screen, ScenarioPlan.Step step) {
+        Optional<AbstractWidget> widget = widgetFinder.find(screen, step.arguments());
+        if (widget.isEmpty() || !widget.get().active) {
+            return false;
+        }
+        AbstractWidget target = widget.get();
+        logger.info("Activating {} on {} (visible widgets: {})",
+                target.getClass().getName(),
+                screen == null ? "<none>" : screen.getClass().getName(),
+                widgetFinder.visibleWidgets(screen));
+        MouseButtonEvent event = new MouseButtonEvent(
+                target.getX() + target.getWidth() / 2.0,
+                target.getY() + target.getHeight() / 2.0,
+                new MouseButtonInfo(0, 0)
+        );
+        return screen.mouseClicked(event, false);
+    }
+
+    private void finish(Minecraft client, RuntimeException failure) {
+        finished = true;
+        String failureMessage = failure == null ? null
+                : failure.getMessage() == null ? failure.getClass().getName() : failure.getMessage();
+        String diagnostics = diagnostics(client, failureMessage);
+        try {
+            reportWriter.write(plan, results, failureMessage, diagnostics);
+        } catch (RuntimeException reportFailure) {
+            logger.error("Could not write scenario report", reportFailure);
+            if (failure == null) {
+                failure = reportFailure;
+            }
+        }
+
+        int exitCode = failure == null ? 0 : 1;
+        if (failure == null) {
+            logger.info("Scenario '{}' passed ({} steps)", plan.id(), results.size());
+        } else {
+            logger.error("Scenario '{}' failed: {}", plan.id(), failureMessage, failure);
+        }
+        System.exit(exitCode);
+    }
+
+    private String diagnostics(Minecraft client, String failure) {
+        StringBuilder diagnostics = new StringBuilder();
+        diagnostics.append("scenario: ").append(plan.id()).append('\n');
+        diagnostics.append("completedSteps: ").append(stepIndex).append('/').append(plan.steps().size()).append('\n');
+        Screen screen = client.gui.screen();
+        diagnostics.append("screen: ")
+                .append(screen == null ? "<none>" : screen.getClass().getName())
+                .append('\n');
+        diagnostics.append("visibleWidgets: ").append(widgetFinder.visibleWidgets(screen)).append('\n');
+        if (failure != null) {
+            diagnostics.append("failure: ").append(failure).append('\n');
+        }
+        return diagnostics.toString();
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -18,6 +18,7 @@ final class ScenarioRunner {
     private final WidgetFinder widgetFinder = new WidgetFinder();
     private final ScreenshotCapture screenshotCapture;
     private final VanillaServerProcess vanillaServer;
+    private final CreateWorldProcess createWorld;
     private final Logger logger;
     private final List<ScenarioReportWriter.StepResult> results = new ArrayList<>();
 
@@ -38,6 +39,7 @@ final class ScenarioRunner {
         this.logger = logger;
         this.screenshotCapture = new ScreenshotCapture(logger);
         this.vanillaServer = new VanillaServerProcess(logger);
+        this.createWorld = new CreateWorldProcess(logger);
     }
 
     void tick(Minecraft client) {
@@ -91,7 +93,7 @@ final class ScenarioRunner {
             throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
         }
         return primitive.execute(new ScenarioPrimitiveContext(
-                client, step, widgetFinder, screenshotCapture, vanillaServer, logger));
+                client, step, widgetFinder, screenshotCapture, vanillaServer, createWorld, logger));
     }
 
     private Duration timeoutFor(ScenarioPlan.Step step) {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -88,6 +88,10 @@ final class ScenarioRunner {
             case "launchGame" -> screen instanceof TitleScreen;
             case "assertVisible" -> widgetFinder.find(screen, step.arguments()).isPresent();
             case "click" -> click(screen, step);
+            case "debugScreen" -> {
+                logger.info("{}", widgetFinder.describeVisibleWidgets(screen));
+                yield true;
+            }
             default -> throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
         };
     }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -18,6 +18,7 @@ final class ScenarioRunner {
     private final ScenarioReportWriter reportWriter;
     private final Duration stepTimeout;
     private final WidgetFinder widgetFinder = new WidgetFinder();
+    private final ScreenshotCapture screenshotCapture;
     private final Logger logger;
     private final List<ScenarioReportWriter.StepResult> results = new ArrayList<>();
 
@@ -36,6 +37,7 @@ final class ScenarioRunner {
         this.reportWriter = reportWriter;
         this.stepTimeout = stepTimeout;
         this.logger = logger;
+        this.screenshotCapture = new ScreenshotCapture(logger);
     }
 
     void tick(Minecraft client) {
@@ -92,6 +94,7 @@ final class ScenarioRunner {
                 logger.info("{}", widgetFinder.describeVisibleWidgets(screen));
                 yield true;
             }
+            case "captureScreenshot" -> screenshotCapture.tick(client, (String) step.arguments().get("name"));
             default -> throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
         };
     }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -14,11 +14,14 @@ import java.util.List;
 import java.util.Optional;
 
 final class ScenarioRunner {
+    private static final Duration VANILLA_SERVER_TIMEOUT_FLOOR = Duration.ofSeconds(120);
+
     private final ScenarioPlan plan;
     private final ScenarioReportWriter reportWriter;
     private final Duration stepTimeout;
     private final WidgetFinder widgetFinder = new WidgetFinder();
     private final ScreenshotCapture screenshotCapture;
+    private final VanillaServerProcess vanillaServer;
     private final Logger logger;
     private final List<ScenarioReportWriter.StepResult> results = new ArrayList<>();
 
@@ -38,6 +41,7 @@ final class ScenarioRunner {
         this.stepTimeout = stepTimeout;
         this.logger = logger;
         this.screenshotCapture = new ScreenshotCapture(logger);
+        this.vanillaServer = new VanillaServerProcess(logger);
     }
 
     void tick(Minecraft client) {
@@ -69,8 +73,9 @@ final class ScenarioRunner {
                 stepStartedNanos = 0L;
                 return;
             }
-            if (System.nanoTime() - stepStartedNanos > stepTimeout.toNanos()) {
-                throw new ScenarioException("Timed out after " + stepTimeout.toSeconds()
+            Duration timeout = timeoutFor(step);
+            if (System.nanoTime() - stepStartedNanos > timeout.toNanos()) {
+                throw new ScenarioException("Timed out after " + timeout.toSeconds()
                         + "s waiting for " + step.displayName() + " from " + step.source());
             }
         } catch (RuntimeException exception) {
@@ -95,6 +100,7 @@ final class ScenarioRunner {
                 yield true;
             }
             case "captureScreenshot" -> screenshotCapture.tick(client, (String) step.arguments().get("name"));
+            case "startVanillaServer" -> vanillaServer.tick(VanillaServerProcess.parsePort(step.arguments().get("port")));
             default -> throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
         };
     }
@@ -117,8 +123,18 @@ final class ScenarioRunner {
         return screen.mouseClicked(event, false);
     }
 
+    private Duration timeoutFor(ScenarioPlan.Step step) {
+        if (!"startVanillaServer".equals(step.name())) {
+            return stepTimeout;
+        }
+        return stepTimeout.compareTo(VANILLA_SERVER_TIMEOUT_FLOOR) >= 0
+                ? stepTimeout
+                : VANILLA_SERVER_TIMEOUT_FLOOR;
+    }
+
     private void finish(Minecraft client, RuntimeException failure) {
         finished = true;
+        vanillaServer.stop();
         String failureMessage = failure == null ? null
                 : failure.getMessage() == null ? failure.getClass().getName() : failure.getMessage();
         String diagnostics = diagnostics(client, failureMessage);

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -2,8 +2,10 @@ package com.adamkali.dwm.scenariotest;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.input.CharacterEvent;
 import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.client.input.MouseButtonInfo;
 import org.slf4j.Logger;
@@ -101,6 +103,7 @@ final class ScenarioRunner {
             }
             case "captureScreenshot" -> screenshotCapture.tick(client, (String) step.arguments().get("name"));
             case "startVanillaServer" -> vanillaServer.tick(VanillaServerProcess.parsePort(step.arguments().get("port")));
+            case "keyboardInput" -> keyboardInput(screen, step);
             default -> throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
         };
     }
@@ -121,6 +124,26 @@ final class ScenarioRunner {
                 new MouseButtonInfo(0, 0)
         );
         return screen.mouseClicked(event, false);
+    }
+
+    private boolean keyboardInput(Screen screen, ScenarioPlan.Step step) {
+        if (screen == null || !(screen.getFocused() instanceof EditBox editBox) || !editBox.canConsumeInput()) {
+            return false;
+        }
+        String text = (String) step.arguments().get("text");
+        logger.info("Typing {} characters into {} on {}",
+                text.length(),
+                editBox.getClass().getName(),
+                screen.getClass().getName());
+        for (int index = 0; index < text.length(); ) {
+            int codepoint = text.codePointAt(index);
+            if (!screen.charTyped(new CharacterEvent(codepoint))) {
+                throw new ScenarioException("keyboardInput rejected codepoint at index " + index
+                        + " in \"" + text + "\" from " + step.source());
+            }
+            index += Character.charCount(codepoint);
+        }
+        return true;
     }
 
     private Duration timeoutFor(ScenarioPlan.Step step) {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioRunner.java
@@ -1,23 +1,17 @@
 package com.adamkali.dwm.scenariotest;
 
+import com.adamkali.dwm.scenariotest.primitive.ScenarioPrimitive;
+import com.adamkali.dwm.scenariotest.primitive.ScenarioPrimitiveContext;
+import com.adamkali.dwm.scenariotest.primitive.ScenarioPrimitives;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.components.AbstractWidget;
-import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.Screen;
-import net.minecraft.client.gui.screens.TitleScreen;
-import net.minecraft.client.input.CharacterEvent;
-import net.minecraft.client.input.MouseButtonEvent;
-import net.minecraft.client.input.MouseButtonInfo;
 import org.slf4j.Logger;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 final class ScenarioRunner {
-    private static final Duration VANILLA_SERVER_TIMEOUT_FLOOR = Duration.ofSeconds(120);
-
     private final ScenarioPlan plan;
     private final ScenarioReportWriter reportWriter;
     private final Duration stepTimeout;
@@ -92,67 +86,17 @@ final class ScenarioRunner {
     }
 
     private boolean execute(ScenarioPlan.Step step, Minecraft client) {
-        Screen screen = client.gui.screen();
-        return switch (step.name()) {
-            case "launchGame" -> screen instanceof TitleScreen;
-            case "assertVisible" -> widgetFinder.find(screen, step.arguments()).isPresent();
-            case "click" -> click(screen, step);
-            case "debugScreen" -> {
-                logger.info("{}", widgetFinder.describeVisibleWidgets(screen));
-                yield true;
-            }
-            case "captureScreenshot" -> screenshotCapture.tick(client, (String) step.arguments().get("name"));
-            case "startVanillaServer" -> vanillaServer.tick(VanillaServerProcess.parsePort(step.arguments().get("port")));
-            case "keyboardInput" -> keyboardInput(screen, step);
-            default -> throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
-        };
-    }
-
-    private boolean click(Screen screen, ScenarioPlan.Step step) {
-        Optional<AbstractWidget> widget = widgetFinder.find(screen, step.arguments());
-        if (widget.isEmpty() || !widget.get().active) {
-            return false;
+        ScenarioPrimitive primitive = ScenarioPrimitives.find(step.name());
+        if (primitive == null) {
+            throw new ScenarioException("Unsupported primitive step '" + step.name() + "'");
         }
-        AbstractWidget target = widget.get();
-        logger.info("Activating {} on {} (visible widgets: {})",
-                target.getClass().getName(),
-                screen == null ? "<none>" : screen.getClass().getName(),
-                widgetFinder.visibleWidgets(screen));
-        MouseButtonEvent event = new MouseButtonEvent(
-                target.getX() + target.getWidth() / 2.0,
-                target.getY() + target.getHeight() / 2.0,
-                new MouseButtonInfo(0, 0)
-        );
-        return screen.mouseClicked(event, false);
-    }
-
-    private boolean keyboardInput(Screen screen, ScenarioPlan.Step step) {
-        if (screen == null || !(screen.getFocused() instanceof EditBox editBox) || !editBox.canConsumeInput()) {
-            return false;
-        }
-        String text = (String) step.arguments().get("text");
-        logger.info("Typing {} characters into {} on {}",
-                text.length(),
-                editBox.getClass().getName(),
-                screen.getClass().getName());
-        for (int index = 0; index < text.length(); ) {
-            int codepoint = text.codePointAt(index);
-            if (!screen.charTyped(new CharacterEvent(codepoint))) {
-                throw new ScenarioException("keyboardInput rejected codepoint at index " + index
-                        + " in \"" + text + "\" from " + step.source());
-            }
-            index += Character.charCount(codepoint);
-        }
-        return true;
+        return primitive.execute(new ScenarioPrimitiveContext(
+                client, step, widgetFinder, screenshotCapture, vanillaServer, logger));
     }
 
     private Duration timeoutFor(ScenarioPlan.Step step) {
-        if (!"startVanillaServer".equals(step.name())) {
-            return stepTimeout;
-        }
-        return stepTimeout.compareTo(VANILLA_SERVER_TIMEOUT_FLOOR) >= 0
-                ? stepTimeout
-                : VANILLA_SERVER_TIMEOUT_FLOOR;
+        ScenarioPrimitive primitive = ScenarioPrimitives.find(step.name());
+        return primitive == null ? stepTimeout : primitive.timeout(stepTimeout);
     }
 
     private void finish(Minecraft client, RuntimeException failure) {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioTestClient.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioTestClient.java
@@ -1,0 +1,57 @@
+package com.adamkali.dwm.scenariotest;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.time.Duration;
+
+public final class ScenarioTestClient implements ClientModInitializer {
+    private static final Logger LOGGER = LoggerFactory.getLogger("DWMScenarioTest");
+    private static final String SCENARIO_PROPERTY = "dwm.scenario";
+    private static final String REPORT_PROPERTY = "dwm.scenario.report-file";
+    private static final String TIMEOUT_PROPERTY = "dwm.scenario.step-timeout-seconds";
+
+    @Override
+    public void onInitializeClient() {
+        String scenarioId = System.getProperty(SCENARIO_PROPERTY, "createWorld");
+        ScenarioReportWriter reportWriter = new ScenarioReportWriter(Path.of(
+                System.getProperty(REPORT_PROPERTY, "build/scenario-test/report.xml")
+        ));
+        try {
+            ScenarioCatalog catalog = ScenarioCatalog.loadFromResources(getClass().getClassLoader());
+            ScenarioPlan plan = new ScenarioCompiler(catalog).compile(scenarioId);
+            Duration timeout = Duration.ofSeconds(readPositiveLong(TIMEOUT_PROPERTY, 30L));
+            ScenarioRunner runner = new ScenarioRunner(plan, reportWriter, timeout, LOGGER);
+            ClientTickEvents.END_CLIENT_TICK.register(runner::tick);
+            LOGGER.info("Loaded scenario '{}' with {} primitive steps", plan.id(), plan.steps().size());
+        } catch (RuntimeException exception) {
+            LOGGER.error("Could not start scenario '{}'", scenarioId, exception);
+            try {
+                reportWriter.writeBootstrapFailure(scenarioId, exception);
+            } catch (RuntimeException reportFailure) {
+                LOGGER.error("Could not write scenario bootstrap failure", reportFailure);
+            }
+            System.exit(1);
+        }
+    }
+
+    private static long readPositiveLong(String property, long defaultValue) {
+        String value = System.getProperty(property);
+        if (value == null) {
+            return defaultValue;
+        }
+        try {
+            long parsed = Long.parseLong(value);
+            if (parsed <= 0) {
+                throw new NumberFormatException("must be positive");
+            }
+            return parsed;
+        } catch (NumberFormatException exception) {
+            throw new ScenarioException("System property '" + property
+                    + "' must be a positive integer, but was '" + value + "'");
+        }
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScreenshotCapture.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScreenshotCapture.java
@@ -10,7 +10,7 @@ import org.slf4j.Logger;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
-final class ScreenshotCapture {
+public final class ScreenshotCapture {
     private static final int NO_DOWNSCALE = 1;
 
     private final Logger logger;
@@ -20,7 +20,7 @@ final class ScreenshotCapture {
         this.logger = logger;
     }
 
-    static String normalizeFileName(String name) {
+    public static String normalizeFileName(String name) {
         if (name == null || name.isBlank()) {
             throw new ScenarioException("captureScreenshot name must be a non-empty string");
         }
@@ -36,7 +36,7 @@ final class ScreenshotCapture {
         return trimmed + ".png";
     }
 
-    boolean tick(Minecraft client, String filename) {
+    public boolean tick(Minecraft client, String filename) {
         Object current = inFlight.get();
         if (current == null) {
             inFlight.set(Pending.INSTANCE);

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScreenshotCapture.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScreenshotCapture.java
@@ -1,0 +1,117 @@
+package com.adamkali.dwm.scenariotest;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.Screenshot;
+import net.minecraft.network.chat.ClickEvent;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.chat.contents.TranslatableContents;
+import org.slf4j.Logger;
+
+import java.util.Locale;
+import java.util.concurrent.atomic.AtomicReference;
+
+final class ScreenshotCapture {
+    private static final int NO_DOWNSCALE = 1;
+
+    private final Logger logger;
+    private final AtomicReference<Object> inFlight = new AtomicReference<>();
+
+    ScreenshotCapture(Logger logger) {
+        this.logger = logger;
+    }
+
+    static String normalizeFileName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new ScenarioException("captureScreenshot name must be a non-empty string");
+        }
+        String trimmed = name.trim();
+        if (trimmed.contains("/") || trimmed.contains("\\") || trimmed.contains("..")) {
+            throw new ScenarioException(
+                    "captureScreenshot name must be a file name without path separators: '" + name + "'"
+            );
+        }
+        if (trimmed.toLowerCase(Locale.ROOT).endsWith(".png")) {
+            return trimmed;
+        }
+        return trimmed + ".png";
+    }
+
+    boolean tick(Minecraft client, String filename) {
+        Object current = inFlight.get();
+        if (current == null) {
+            inFlight.set(Pending.INSTANCE);
+            try {
+                Screenshot.grab(
+                        client.gameDirectory,
+                        filename,
+                        client.gameRenderer.mainRenderTarget(),
+                        NO_DOWNSCALE,
+                        message -> inFlight.set(interpret(message))
+                );
+            } catch (RuntimeException exception) {
+                inFlight.set(null);
+                throw exception;
+            }
+            return false;
+        }
+        if (current == Pending.INSTANCE) {
+            return false;
+        }
+
+        Completed completed = (Completed) current;
+        inFlight.set(null);
+        logger.info("{}", completed.message());
+        if (completed.failed()) {
+            throw new ScenarioException("captureScreenshot failed: " + completed.message());
+        }
+        if (completed.path() != null) {
+            logger.info("captureScreenshot saved {}", completed.path());
+        }
+        return true;
+    }
+
+    private static Completed interpret(Component message) {
+        String text = message.getString();
+        if (message.getContents() instanceof TranslatableContents contents
+                && "screenshot.failure".equals(contents.getKey())) {
+            Object[] args = contents.getArgs();
+            String detail = args.length > 0 ? String.valueOf(args[0]) : text;
+            return new Completed(true, detail, null);
+        }
+        return new Completed(false, text, savedPath(message));
+    }
+
+    private static String savedPath(Component message) {
+        if (message.getContents() instanceof TranslatableContents contents) {
+            for (Object arg : contents.getArgs()) {
+                if (arg instanceof Component component) {
+                    String path = pathFromClick(component);
+                    if (path != null) {
+                        return path;
+                    }
+                }
+            }
+        }
+        return pathFromClick(message);
+    }
+
+    private static String pathFromClick(Component component) {
+        if (component.getStyle().getClickEvent() instanceof ClickEvent.OpenFile openFile) {
+            return openFile.file().getAbsolutePath();
+        }
+        for (Component sibling : component.getSiblings()) {
+            String path = pathFromClick(sibling);
+            if (path != null) {
+                return path;
+            }
+        }
+        return null;
+    }
+
+    private enum Pending {
+        INSTANCE
+    }
+
+    private record Completed(boolean failed, String message, String path) {
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/VanillaServerProcess.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/VanillaServerProcess.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 
-final class VanillaServerProcess {
+public final class VanillaServerProcess {
     static final int DEFAULT_PORT = 25565;
     static final String DIR_PROPERTY = "dwm.scenario.vanilla-server-dir";
     static final String JAR_PATH_FILE = "server-jar.path";
@@ -40,7 +40,7 @@ final class VanillaServerProcess {
         this.logger = logger;
     }
 
-    static int parsePort(Object value) {
+    public static int parsePort(Object value) {
         if (value == null) {
             return DEFAULT_PORT;
         }
@@ -91,7 +91,7 @@ final class VanillaServerProcess {
         return "eula=true\n";
     }
 
-    boolean tick(int port) {
+    public boolean tick(int port) {
         synchronized (lock) {
             if (completed) {
                 throw new ScenarioException("startVanillaServer can only run once per scenario");

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/VanillaServerProcess.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/VanillaServerProcess.java
@@ -1,0 +1,263 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+
+final class VanillaServerProcess {
+    static final int DEFAULT_PORT = 25565;
+    static final String DIR_PROPERTY = "dwm.scenario.vanilla-server-dir";
+    static final String JAR_PATH_FILE = "server-jar.path";
+
+    private static final int MIN_PORT = 1;
+    private static final int MAX_PORT = 65535;
+    private static final int PROBE_TIMEOUT_MS = 100;
+    private static final int STOP_WAIT_SECONDS = 5;
+    private static final int DESTROY_WAIT_SECONDS = 3;
+    private static final int LOG_TAIL_LINES = 40;
+    private static final String LOOPBACK = "127.0.0.1";
+
+    private final Logger logger;
+    private final Object lock = new Object();
+
+    private Process process;
+    private Path logFile;
+    private Thread shutdownHook;
+    private boolean launched;
+    private boolean completed;
+    private boolean stopped;
+
+    VanillaServerProcess(Logger logger) {
+        this.logger = logger;
+    }
+
+    static int parsePort(Object value) {
+        if (value == null) {
+            return DEFAULT_PORT;
+        }
+        int port;
+        if (value instanceof Integer integer) {
+            port = integer;
+        } else if (value instanceof Long longValue) {
+            if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+                throw invalidPort();
+            }
+            port = longValue.intValue();
+        } else if (value instanceof String string) {
+            if (string.isBlank()) {
+                throw invalidPort();
+            }
+            try {
+                port = Integer.parseInt(string.trim());
+            } catch (NumberFormatException exception) {
+                throw invalidPort();
+            }
+        } else {
+            throw invalidPort();
+        }
+        if (port < MIN_PORT || port > MAX_PORT) {
+            throw invalidPort();
+        }
+        return port;
+    }
+
+    static String serverProperties(int port) {
+        parsePort(port);
+        return """
+                online-mode=false
+                server-ip=%s
+                server-port=%d
+                level-type=minecraft:flat
+                spawn-monsters=false
+                spawn-npcs=false
+                spawn-animals=false
+                difficulty=peaceful
+                enforce-secure-profile=false
+                max-tick-time=-1
+                motd=DWM Scenario Vanilla Server
+                """.formatted(LOOPBACK, port);
+    }
+
+    static String eulaText() {
+        return "eula=true\n";
+    }
+
+    boolean tick(int port) {
+        synchronized (lock) {
+            if (completed) {
+                throw new ScenarioException("startVanillaServer can only run once per scenario");
+            }
+            if (!launched) {
+                start(port);
+                launched = true;
+                return false;
+            }
+            if (process == null || !process.isAlive()) {
+                throw died();
+            }
+            if (isListening(port)) {
+                logger.info("Vanilla server is accepting connections on {}:{}", LOOPBACK, port);
+                completed = true;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    void stop() {
+        synchronized (lock) {
+            if (stopped) {
+                return;
+            }
+            stopped = true;
+            if (process != null && process.isAlive()) {
+                try {
+                    OutputStream stdin = process.getOutputStream();
+                    stdin.write("stop\n".getBytes(StandardCharsets.UTF_8));
+                    stdin.flush();
+                    if (!process.waitFor(STOP_WAIT_SECONDS, TimeUnit.SECONDS) && process.isAlive()) {
+                        process.destroyForcibly();
+                        process.waitFor(DESTROY_WAIT_SECONDS, TimeUnit.SECONDS);
+                    }
+                } catch (InterruptedException exception) {
+                    Thread.currentThread().interrupt();
+                    process.destroyForcibly();
+                } catch (IOException exception) {
+                    process.destroyForcibly();
+                }
+            }
+            if (shutdownHook != null) {
+                try {
+                    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                } catch (IllegalStateException ignored) {
+                    // JVM is already shutting down.
+                }
+                shutdownHook = null;
+            }
+        }
+    }
+
+    private void start(int port) {
+        parsePort(port);
+        Path dir = resolveServerDir();
+        Path jar = resolveServerJar(dir);
+        if (isListening(port)) {
+            throw new ScenarioException("Port " + port + " is already in use");
+        }
+
+        try {
+            Files.createDirectories(dir);
+            Files.writeString(dir.resolve("eula.txt"), eulaText(), StandardCharsets.UTF_8);
+            Files.writeString(dir.resolve("server.properties"), serverProperties(port), StandardCharsets.UTF_8);
+            Path logs = dir.resolve("logs");
+            Files.createDirectories(logs);
+            logFile = logs.resolve("harness.log");
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not prepare the vanilla server directory " + dir, exception);
+        }
+
+        ProcessBuilder builder = new ProcessBuilder(
+                javaExecutable(),
+                "-Xmx1G",
+                "-jar",
+                jar.toAbsolutePath().toString(),
+                "nogui"
+        );
+        builder.directory(dir.toFile());
+        builder.redirectErrorStream(true);
+        builder.redirectOutput(ProcessBuilder.Redirect.appendTo(logFile.toFile()));
+
+        try {
+            process = builder.start();
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not start the vanilla Minecraft server", exception);
+        }
+
+        shutdownHook = new Thread(this::stop, "dwm-vanilla-server-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        logger.info("Started vanilla server pid {} on {}:{} using {}", process.pid(), LOOPBACK, port, jar);
+    }
+
+    private static Path resolveServerDir() {
+        String dir = System.getProperty(DIR_PROPERTY);
+        if (dir == null || dir.isBlank()) {
+            throw new ScenarioException("System property '" + DIR_PROPERTY
+                    + "' is missing. Run prepareScenarioTestRun first.");
+        }
+        return Path.of(dir);
+    }
+
+    private static Path resolveServerJar(Path dir) {
+        Path jarPathFile = dir.resolve(JAR_PATH_FILE);
+        if (!Files.isRegularFile(jarPathFile)) {
+            throw new ScenarioException("Vanilla server jar path file is missing: " + jarPathFile
+                    + ". Run prepareScenarioTestRun first.");
+        }
+        String raw;
+        try {
+            raw = Files.readString(jarPathFile, StandardCharsets.UTF_8).trim();
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not read " + jarPathFile, exception);
+        }
+        if (raw.isEmpty()) {
+            throw new ScenarioException("Vanilla server jar path file is empty: " + jarPathFile
+                    + ". Run prepareScenarioTestRun first.");
+        }
+        Path jar = Path.of(raw);
+        if (!Files.isRegularFile(jar)) {
+            throw new ScenarioException("Vanilla server jar is missing: " + jar
+                    + ". Run prepareScenarioTestRun first.");
+        }
+        return jar;
+    }
+
+    private static boolean isListening(int port) {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(LOOPBACK, port), PROBE_TIMEOUT_MS);
+            return true;
+        } catch (IOException exception) {
+            return false;
+        }
+    }
+
+    private static String javaExecutable() {
+        String home = System.getProperty("java.home");
+        boolean windows = System.getProperty("os.name", "").toLowerCase(Locale.ROOT).startsWith("win");
+        return Path.of(home, "bin", windows ? "java.exe" : "java").toString();
+    }
+
+    private ScenarioException died() {
+        int exit = process == null ? -1 : process.exitValue();
+        return new ScenarioException("Vanilla Minecraft server exited with code " + exit
+                + " before accepting connections. Last log lines:\n" + lastLogLines());
+    }
+
+    private String lastLogLines() {
+        if (logFile == null || !Files.isRegularFile(logFile)) {
+            return "<no harness log>";
+        }
+        try {
+            List<String> lines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+            int from = Math.max(0, lines.size() - LOG_TAIL_LINES);
+            if (from >= lines.size()) {
+                return "<empty harness log>";
+            }
+            return String.join("\n", lines.subList(from, lines.size()));
+        } catch (IOException exception) {
+            return "<could not read harness log: " + exception.getMessage() + ">";
+        }
+    }
+
+    private static ScenarioException invalidPort() {
+        return new ScenarioException("startVanillaServer port must be an integer between 1 and 65535");
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
@@ -1,0 +1,81 @@
+package com.adamkali.dwm.scenariotest;
+
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.components.TabButton;
+import net.minecraft.client.gui.components.events.ContainerEventHandler;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.Screen;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+final class WidgetFinder {
+    Optional<AbstractWidget> find(Screen screen, Map<String, Object> selector) {
+        if (screen == null) {
+            return Optional.empty();
+        }
+        String expectedType = (String) selector.get("type");
+        String expectedName = (String) selector.get("name");
+        return widgets(screen).stream()
+                .filter(widget -> matchesType(widget, expectedType))
+                .filter(widget -> widget.visible)
+                .filter(widget -> expectedName.equals(widget.getMessage().getString()))
+                .findFirst();
+    }
+
+    List<String> visibleWidgets(Screen screen) {
+        if (screen == null) {
+            return List.of();
+        }
+        return widgets(screen).stream()
+                .filter(widget -> widget.visible)
+                .map(widget -> widgetType(widget) + ":" + widget.getMessage().getString())
+                .toList();
+    }
+
+    private static List<AbstractWidget> widgets(ContainerEventHandler root) {
+        List<AbstractWidget> widgets = new ArrayList<>();
+        collectWidgets(root.children(), widgets);
+        return widgets;
+    }
+
+    private static void collectWidgets(
+            List<? extends GuiEventListener> children,
+            List<AbstractWidget> widgets
+    ) {
+        for (GuiEventListener child : children) {
+            if (child instanceof AbstractWidget widget) {
+                widgets.add(widget);
+            }
+            if (child instanceof ContainerEventHandler container) {
+                collectWidgets(container.children(), widgets);
+            }
+        }
+    }
+
+    private static boolean matchesType(AbstractWidget widget, String expectedType) {
+        return switch (expectedType) {
+            case "button" -> widget instanceof Button;
+            case "cycle" -> widget instanceof CycleButton<?>;
+            case "tab" -> widget instanceof TabButton;
+            default -> false;
+        };
+    }
+
+    private static String widgetType(AbstractWidget widget) {
+        if (widget instanceof TabButton) {
+            return "tab";
+        }
+        if (widget instanceof Button) {
+            return "button";
+        }
+        if (widget instanceof CycleButton<?>) {
+            return "cycle";
+        }
+        return widget.getClass().getSimpleName();
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.scenariotest;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.CycleButton;
+import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.components.TabButton;
 import net.minecraft.client.gui.components.events.ContainerEventHandler;
 import net.minecraft.client.gui.components.events.GuiEventListener;
@@ -89,6 +90,7 @@ final class WidgetFinder {
             case "button" -> widget instanceof Button;
             case "cycle" -> widget instanceof CycleButton<?>;
             case "tab" -> widget instanceof TabButton;
+            case "editbox" -> widget instanceof EditBox;
             default -> false;
         };
     }
@@ -102,6 +104,9 @@ final class WidgetFinder {
         }
         if (widget instanceof CycleButton<?>) {
             return "cycle";
+        }
+        if (widget instanceof EditBox) {
+            return "editbox";
         }
         return widget.getClass().getSimpleName();
     }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-final class WidgetFinder {
-    Optional<AbstractWidget> find(Screen screen, Map<String, Object> selector) {
+public final class WidgetFinder {
+    public Optional<AbstractWidget> find(Screen screen, Map<String, Object> selector) {
         if (screen == null) {
             return Optional.empty();
         }
@@ -28,7 +28,7 @@ final class WidgetFinder {
                 .findFirst();
     }
 
-    List<String> visibleWidgets(Screen screen) {
+    public List<String> visibleWidgets(Screen screen) {
         if (screen == null) {
             return List.of();
         }
@@ -38,7 +38,7 @@ final class WidgetFinder {
                 .toList();
     }
 
-    String describeVisibleWidgets(Screen screen) {
+    public String describeVisibleWidgets(Screen screen) {
         StringBuilder dump = new StringBuilder();
         dump.append("debugScreen: ")
                 .append(screen == null ? "<none>" : screen.getClass().getName())

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
@@ -37,6 +37,33 @@ final class WidgetFinder {
                 .toList();
     }
 
+    String describeVisibleWidgets(Screen screen) {
+        StringBuilder dump = new StringBuilder();
+        dump.append("debugScreen: ")
+                .append(screen == null ? "<none>" : screen.getClass().getName())
+                .append('\n');
+        if (screen == null) {
+            return dump.toString();
+        }
+        List<AbstractWidget> visible = widgets(screen).stream()
+                .filter(widget -> widget.visible)
+                .toList();
+        for (int i = 0; i < visible.size(); i++) {
+            AbstractWidget widget = visible.get(i);
+            dump.append("  [").append(i).append("] ")
+                    .append(widgetType(widget))
+                    .append(" name=\"").append(widget.getMessage().getString()).append('"')
+                    .append(" active=").append(widget.active)
+                    .append(" bounds=(")
+                    .append(widget.getX()).append(',')
+                    .append(widget.getY()).append(',')
+                    .append(widget.getWidth()).append(',')
+                    .append(widget.getHeight())
+                    .append(")\n");
+        }
+        return dump.toString();
+    }
+
     private static List<AbstractWidget> widgets(ContainerEventHandler root) {
         List<AbstractWidget> widgets = new ArrayList<>();
         collectWidgets(root.children(), widgets);

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/WidgetFinder.java
@@ -4,10 +4,13 @@ import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.CycleButton;
 import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.StringWidget;
 import net.minecraft.client.gui.components.TabButton;
 import net.minecraft.client.gui.components.events.ContainerEventHandler;
 import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.screens.ConnectScreen;
 import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,14 +31,31 @@ public final class WidgetFinder {
                 .findFirst();
     }
 
+    public boolean matches(Screen screen, Map<String, Object> selector) {
+        if ("screen".equals(selector.get("type"))) {
+            return screen != null && selector.get("name").equals(screen.getClass().getSimpleName());
+        }
+        if (find(screen, selector).isPresent()) {
+            return true;
+        }
+        String expectedName = (String) selector.get("name");
+        return "label".equals(selector.get("type")) && expectedName.equals(connectScreenStatus(screen));
+    }
+
     public List<String> visibleWidgets(Screen screen) {
         if (screen == null) {
             return List.of();
         }
-        return widgets(screen).stream()
+        List<String> visible = new ArrayList<>();
+        String connectStatus = connectScreenStatus(screen);
+        if (connectStatus != null) {
+            visible.add("label:" + connectStatus);
+        }
+        widgets(screen).stream()
                 .filter(widget -> widget.visible)
                 .map(widget -> widgetType(widget) + ":" + widget.getMessage().getString())
-                .toList();
+                .forEach(visible::add);
+        return List.copyOf(visible);
     }
 
     public String describeVisibleWidgets(Screen screen) {
@@ -46,12 +66,17 @@ public final class WidgetFinder {
         if (screen == null) {
             return dump.toString();
         }
+        String connectStatus = connectScreenStatus(screen);
+        int index = 0;
+        if (connectStatus != null) {
+            dump.append("  [").append(index++).append("] ")
+                    .append("label name=\"").append(connectStatus).append("\"\n");
+        }
         List<AbstractWidget> visible = widgets(screen).stream()
                 .filter(widget -> widget.visible)
                 .toList();
-        for (int i = 0; i < visible.size(); i++) {
-            AbstractWidget widget = visible.get(i);
-            dump.append("  [").append(i).append("] ")
+        for (AbstractWidget widget : visible) {
+            dump.append("  [").append(index++).append("] ")
                     .append(widgetType(widget))
                     .append(" name=\"").append(widget.getMessage().getString()).append('"')
                     .append(" active=").append(widget.active)
@@ -63,6 +88,18 @@ public final class WidgetFinder {
                     .append(")\n");
         }
         return dump.toString();
+    }
+
+    private static String connectScreenStatus(Screen screen) {
+        if (!(screen instanceof ConnectScreen connectScreen)) {
+            return null;
+        }
+        Component status = connectScreen.status;
+        if (status == null) {
+            return null;
+        }
+        String text = status.getString();
+        return text.isBlank() ? null : text;
     }
 
     private static List<AbstractWidget> widgets(ContainerEventHandler root) {
@@ -91,6 +128,7 @@ public final class WidgetFinder {
             case "cycle" -> widget instanceof CycleButton<?>;
             case "tab" -> widget instanceof TabButton;
             case "editbox" -> widget instanceof EditBox;
+            case "label" -> widget instanceof StringWidget;
             default -> false;
         };
     }
@@ -107,6 +145,9 @@ public final class WidgetFinder {
         }
         if (widget instanceof EditBox) {
             return "editbox";
+        }
+        if (widget instanceof StringWidget) {
+            return "label";
         }
         return widget.getClass().getSimpleName();
     }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/AssertVisiblePrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/AssertVisiblePrimitive.java
@@ -1,0 +1,20 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import java.util.Map;
+
+public final class AssertVisiblePrimitive extends SelectorPrimitive {
+    @Override
+    public String name() {
+        return "assertVisible";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireSelector(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        return context.widgetFinder().find(context.screen(), context.arguments()).isPresent();
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/AssertVisiblePrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/AssertVisiblePrimitive.java
@@ -15,6 +15,6 @@ public final class AssertVisiblePrimitive extends SelectorPrimitive {
 
     @Override
     public boolean execute(ScenarioPrimitiveContext context) {
-        return context.widgetFinder().find(context.screen(), context.arguments()).isPresent();
+        return context.widgetFinder().matches(context.screen(), context.arguments());
     }
 }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/CaptureScreenshotPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/CaptureScreenshotPrimitive.java
@@ -1,0 +1,40 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import com.adamkali.dwm.scenariotest.ScreenshotCapture;
+
+import java.util.Map;
+
+public final class CaptureScreenshotPrimitive implements ScenarioPrimitive {
+    @Override
+    public String name() {
+        return "captureScreenshot";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        if (arguments.isEmpty()) {
+            return arguments;
+        }
+        for (String key : arguments.keySet()) {
+            if (!"name".equals(key)) {
+                throw new ScenarioException(source + ": captureScreenshot does not accept '" + key + "'");
+            }
+        }
+        Object value = arguments.get("name");
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(source + ": captureScreenshot requires a non-empty string 'name'");
+        }
+        try {
+            arguments.put("name", ScreenshotCapture.normalizeFileName(string));
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+        return arguments;
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        return context.screenshotCapture().tick(context.client(), (String) context.arguments().get("name"));
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ClickPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ClickPrimitive.java
@@ -1,0 +1,41 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.MouseButtonInfo;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class ClickPrimitive extends SelectorPrimitive {
+    @Override
+    public String name() {
+        return "click";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireSelector(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Screen screen = context.screen();
+        Optional<AbstractWidget> widget = context.widgetFinder().find(screen, context.arguments());
+        if (widget.isEmpty() || !widget.get().active) {
+            return false;
+        }
+        AbstractWidget target = widget.get();
+        context.logger().info("Activating {} on {} (visible widgets: {})",
+                target.getClass().getName(),
+                screen == null ? "<none>" : screen.getClass().getName(),
+                context.widgetFinder().visibleWidgets(screen));
+        MouseButtonEvent event = new MouseButtonEvent(
+                target.getX() + target.getWidth() / 2.0,
+                target.getY() + target.getHeight() / 2.0,
+                new MouseButtonInfo(0, 0)
+        );
+        return screen.mouseClicked(event, false);
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ClickPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ClickPrimitive.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.scenariotest.primitive;
 
+import com.adamkali.dwm.scenariotest.ScenarioException;
 import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.MouseButtonEvent;
@@ -16,7 +17,11 @@ public final class ClickPrimitive extends SelectorPrimitive {
 
     @Override
     public Map<String, Object> validate(Map<String, Object> arguments, String source) {
-        return requireSelector(arguments, source);
+        Map<String, Object> selector = requireSelector(arguments, source);
+        if ("screen".equals(selector.get("type"))) {
+            throw new ScenarioException(source + ": step 'click' cannot target type 'screen'");
+        }
+        return selector;
     }
 
     @Override

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/CloseScreenPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/CloseScreenPrimitive.java
@@ -1,0 +1,32 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import net.minecraft.client.Minecraft;
+
+import java.util.Map;
+
+public final class CloseScreenPrimitive extends NoArgPrimitive {
+    @Override
+    public String name() {
+        return "closeScreen";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireNoArguments(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        if (client.player == null) {
+            return false;
+        }
+        if (context.screen() == null) {
+            return true;
+        }
+        context.logger().info("Closing {}", context.screen().getClass().getName());
+        client.player.closeContainer();
+        client.gui.setScreen(null);
+        return context.screen() == null;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/CreateWorldPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/CreateWorldPrimitive.java
@@ -1,0 +1,35 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.CreateWorldProcess;
+import com.adamkali.dwm.scenariotest.ScenarioException;
+
+import java.time.Duration;
+import java.util.Map;
+
+public final class CreateWorldPrimitive implements ScenarioPrimitive {
+    private static final Duration TIMEOUT_FLOOR = Duration.ofSeconds(120);
+
+    @Override
+    public String name() {
+        return "createWorld";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        try {
+            return CreateWorldProcess.normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        return context.createWorld().tick(context.client(), context.arguments());
+    }
+
+    @Override
+    public Duration timeout(Duration stepTimeout) {
+        return stepTimeout.compareTo(TIMEOUT_FLOOR) >= 0 ? stepTimeout : TIMEOUT_FLOOR;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/DebugScreenPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/DebugScreenPrimitive.java
@@ -1,0 +1,21 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import java.util.Map;
+
+public final class DebugScreenPrimitive extends NoArgPrimitive {
+    @Override
+    public String name() {
+        return "debugScreen";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireNoArguments(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        context.logger().info("{}", context.widgetFinder().describeVisibleWidgets(context.screen()));
+        return true;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/KeyboardInputPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/KeyboardInputPrimitive.java
@@ -1,0 +1,51 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.input.CharacterEvent;
+
+import java.util.Map;
+
+public final class KeyboardInputPrimitive implements ScenarioPrimitive {
+    @Override
+    public String name() {
+        return "keyboardInput";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        for (String key : arguments.keySet()) {
+            if (!"text".equals(key)) {
+                throw new ScenarioException(source + ": keyboardInput does not accept '" + key + "'");
+            }
+        }
+        Object value = arguments.get("text");
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(source + ": keyboardInput requires a non-empty string 'text'");
+        }
+        return arguments;
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Screen screen = context.screen();
+        if (screen == null || !(screen.getFocused() instanceof EditBox editBox) || !editBox.canConsumeInput()) {
+            return false;
+        }
+        String text = (String) context.arguments().get("text");
+        context.logger().info("Typing {} characters into {} on {}",
+                text.length(),
+                editBox.getClass().getName(),
+                screen.getClass().getName());
+        for (int index = 0; index < text.length(); ) {
+            int codepoint = text.codePointAt(index);
+            if (!screen.charTyped(new CharacterEvent(codepoint))) {
+                throw new ScenarioException("keyboardInput rejected codepoint at index " + index
+                        + " in \"" + text + "\" from " + context.source());
+            }
+            index += Character.charCount(codepoint);
+        }
+        return true;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/LaunchGamePrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/LaunchGamePrimitive.java
@@ -1,0 +1,22 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import net.minecraft.client.gui.screens.TitleScreen;
+
+import java.util.Map;
+
+public final class LaunchGamePrimitive extends NoArgPrimitive {
+    @Override
+    public String name() {
+        return "launchGame";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireNoArguments(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        return context.screen() instanceof TitleScreen;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/LookAtPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/LookAtPrimitive.java
@@ -1,0 +1,122 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioCoordinates;
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.commands.arguments.EntityAnchorArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class LookAtPrimitive implements ScenarioPrimitive {
+    private static final Set<String> ROTATION_KEYS = Set.of("yaw", "pitch");
+    private static final Set<String> POSITION_KEYS = Set.of("x", "y", "z");
+    private static final Set<String> KEYS = Set.of("yaw", "pitch", "x", "y", "z");
+
+    @Override
+    public String name() {
+        return "lookAt";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        try {
+            return normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        LocalPlayer player = client.player;
+        if (player == null) {
+            return false;
+        }
+        Map<String, Object> arguments = context.arguments();
+        if (arguments.containsKey("yaw")) {
+            float yaw = (Float) arguments.get("yaw");
+            float pitch = (Float) arguments.get("pitch");
+            context.logger().info("Looking yaw {} pitch {}", yaw, pitch);
+            player.setYRot(yaw);
+            player.setXRot(pitch);
+            return true;
+        }
+        BlockPos origin = player.blockPosition();
+        BlockPos target = new BlockPos(
+                ScenarioCoordinates.parse(arguments.get("x"), "lookAt x").resolve(origin.getX()),
+                ScenarioCoordinates.parse(arguments.get("y"), "lookAt y").resolve(origin.getY()),
+                ScenarioCoordinates.parse(arguments.get("z"), "lookAt z").resolve(origin.getZ())
+        );
+        context.logger().info("Looking at {} from {}", target, origin);
+        player.lookAt(EntityAnchorArgument.Anchor.EYES, Vec3.atCenterOf(target));
+        return true;
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw new ScenarioException("lookAt does not accept '" + key + "'");
+            }
+        }
+        boolean hasRotation = arguments.keySet().stream().anyMatch(ROTATION_KEYS::contains);
+        boolean hasPosition = arguments.keySet().stream().anyMatch(POSITION_KEYS::contains);
+        if (hasRotation == hasPosition) {
+            throw new ScenarioException("lookAt requires yaw and pitch, or x, y, and z");
+        }
+        if (hasRotation) {
+            return normalizeRotation(arguments);
+        }
+        return normalizePosition(arguments);
+    }
+
+    private static Map<String, Object> normalizeRotation(Map<String, Object> arguments) {
+        if (!arguments.containsKey("yaw") || !arguments.containsKey("pitch")) {
+            throw new ScenarioException("lookAt requires yaw and pitch, or x, y, and z");
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("yaw", parseDegrees(arguments.get("yaw"), "yaw"));
+        normalized.put("pitch", parsePitch(arguments.get("pitch")));
+        return normalized;
+    }
+
+    private static Map<String, Object> normalizePosition(Map<String, Object> arguments) {
+        if (!arguments.containsKey("x") || !arguments.containsKey("y") || !arguments.containsKey("z")) {
+            throw new ScenarioException("lookAt requires yaw and pitch, or x, y, and z");
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        for (String axis : List.of("x", "y", "z")) {
+            ScenarioCoordinates.Component component = ScenarioCoordinates.parse(arguments.get(axis), "lookAt " + axis);
+            normalized.put(axis, component.authored());
+        }
+        return normalized;
+    }
+
+    static float parseDegrees(Object value, String field) {
+        if (value instanceof Number number) {
+            return number.floatValue();
+        }
+        if (value instanceof String string && !string.isBlank()) {
+            try {
+                return Float.parseFloat(string.trim());
+            } catch (NumberFormatException exception) {
+                throw new ScenarioException("lookAt " + field + " must be a number");
+            }
+        }
+        throw new ScenarioException("lookAt " + field + " must be a number");
+    }
+
+    static float parsePitch(Object value) {
+        float pitch = parseDegrees(value, "pitch");
+        if (pitch < -90.0F || pitch > 90.0F) {
+            throw new ScenarioException("lookAt pitch must be between -90 and 90");
+        }
+        return pitch;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/NoArgPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/NoArgPrimitive.java
@@ -1,0 +1,14 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+
+import java.util.Map;
+
+public abstract class NoArgPrimitive implements ScenarioPrimitive {
+    protected Map<String, Object> requireNoArguments(Map<String, Object> arguments, String source) {
+        if (!arguments.isEmpty()) {
+            throw new ScenarioException(source + ": " + name() + " does not accept arguments");
+        }
+        return arguments;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/OpenInventoryPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/OpenInventoryPrimitive.java
@@ -1,6 +1,8 @@
 package com.adamkali.dwm.scenariotest.primitive;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.inventory.CreativeModeInventoryScreen;
 import net.minecraft.client.gui.screens.inventory.InventoryScreen;
 
 import java.util.Map;
@@ -18,7 +20,7 @@ public final class OpenInventoryPrimitive extends NoArgPrimitive {
 
     @Override
     public boolean execute(ScenarioPrimitiveContext context) {
-        if (context.screen() instanceof InventoryScreen) {
+        if (isInventoryScreen(context.screen())) {
             return true;
         }
         Minecraft client = context.client();
@@ -27,6 +29,10 @@ public final class OpenInventoryPrimitive extends NoArgPrimitive {
         }
         context.logger().info("Opening inventory on {}", client.player.getName().getString());
         client.gui.setScreen(new InventoryScreen(client.player));
-        return context.screen() instanceof InventoryScreen;
+        return isInventoryScreen(context.screen());
+    }
+
+    private static boolean isInventoryScreen(Screen screen) {
+        return screen instanceof InventoryScreen || screen instanceof CreativeModeInventoryScreen;
     }
 }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/OpenInventoryPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/OpenInventoryPrimitive.java
@@ -1,0 +1,32 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.inventory.InventoryScreen;
+
+import java.util.Map;
+
+public final class OpenInventoryPrimitive extends NoArgPrimitive {
+    @Override
+    public String name() {
+        return "openInventory";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireNoArguments(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        if (context.screen() instanceof InventoryScreen) {
+            return true;
+        }
+        Minecraft client = context.client();
+        if (client.player == null) {
+            return false;
+        }
+        context.logger().info("Opening inventory on {}", client.player.getName().getString());
+        client.gui.setScreen(new InventoryScreen(client.player));
+        return context.screen() instanceof InventoryScreen;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/RunCommandPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/RunCommandPrimitive.java
@@ -1,0 +1,76 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class RunCommandPrimitive implements ScenarioPrimitive {
+    public static final int MAX_COMMAND_LENGTH = 256;
+    private static final Set<String> KEYS = Set.of("command", "text");
+
+    @Override
+    public String name() {
+        return "runCommand";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        try {
+            return normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        ClientPacketListener connection = client.getConnection();
+        if (client.player == null || connection == null) {
+            return false;
+        }
+        String authored = (String) context.arguments().get("command");
+        String payload = normalizeCommand(authored);
+        context.logger().info("Running command \"{}\"", authored);
+        connection.sendCommand(payload);
+        return true;
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw new ScenarioException("runCommand does not accept '" + key + "'");
+            }
+        }
+        boolean hasCommand = arguments.containsKey("command");
+        boolean hasText = arguments.containsKey("text");
+        if (hasCommand == hasText) {
+            throw new ScenarioException("runCommand requires a non-empty string 'command'");
+        }
+        Object value = hasCommand ? arguments.get("command") : arguments.get("text");
+        normalizeCommand(value);
+        String authored = ((String) value).trim();
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("command", authored);
+        return normalized;
+    }
+
+    public static String normalizeCommand(Object value) {
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException("runCommand requires a non-empty string 'command'");
+        }
+        String trimmed = string.trim();
+        String stripped = trimmed.startsWith("/") ? trimmed.substring(1).trim() : trimmed;
+        if (stripped.isBlank()) {
+            throw new ScenarioException("runCommand requires a non-empty string 'command'");
+        }
+        if (stripped.length() > MAX_COMMAND_LENGTH) {
+            throw new ScenarioException("runCommand must be at most " + MAX_COMMAND_LENGTH + " characters");
+        }
+        return stripped;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitive.java
@@ -1,0 +1,16 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import java.time.Duration;
+import java.util.Map;
+
+public interface ScenarioPrimitive {
+    String name();
+
+    Map<String, Object> validate(Map<String, Object> arguments, String source);
+
+    boolean execute(ScenarioPrimitiveContext context);
+
+    default Duration timeout(Duration stepTimeout) {
+        return stepTimeout;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitiveContext.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitiveContext.java
@@ -1,0 +1,32 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioPlan;
+import com.adamkali.dwm.scenariotest.ScreenshotCapture;
+import com.adamkali.dwm.scenariotest.VanillaServerProcess;
+import com.adamkali.dwm.scenariotest.WidgetFinder;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.Screen;
+import org.slf4j.Logger;
+
+import java.util.Map;
+
+public record ScenarioPrimitiveContext(
+        Minecraft client,
+        ScenarioPlan.Step step,
+        WidgetFinder widgetFinder,
+        ScreenshotCapture screenshotCapture,
+        VanillaServerProcess vanillaServer,
+        Logger logger
+) {
+    public Screen screen() {
+        return client.gui.screen();
+    }
+
+    public Map<String, Object> arguments() {
+        return step.arguments();
+    }
+
+    public String source() {
+        return step.source();
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitiveContext.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitiveContext.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.scenariotest.primitive;
 
+import com.adamkali.dwm.scenariotest.CreateWorldProcess;
 import com.adamkali.dwm.scenariotest.ScenarioPlan;
 import com.adamkali.dwm.scenariotest.ScreenshotCapture;
 import com.adamkali.dwm.scenariotest.VanillaServerProcess;
@@ -16,6 +17,7 @@ public record ScenarioPrimitiveContext(
         WidgetFinder widgetFinder,
         ScreenshotCapture screenshotCapture,
         VanillaServerProcess vanillaServer,
+        CreateWorldProcess createWorld,
         Logger logger
 ) {
     public Screen screen() {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -17,7 +17,11 @@ public final class ScenarioPrimitives {
             new KeyboardInputPrimitive(),
             new RunCommandPrimitive(),
             new WaitUntilPrimitive(),
-            new OpenInventoryPrimitive()
+            new OpenInventoryPrimitive(),
+            new CloseScreenPrimitive(),
+            new SelectHotbarPrimitive(),
+            new LookAtPrimitive(),
+            new UseItemPrimitive()
     ).stream().collect(Collectors.toUnmodifiableMap(ScenarioPrimitive::name, Function.identity()));
 
     private ScenarioPrimitives() {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -1,0 +1,25 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public final class ScenarioPrimitives {
+    private static final Map<String, ScenarioPrimitive> BY_NAME = List.of(
+            new LaunchGamePrimitive(),
+            new DebugScreenPrimitive(),
+            new AssertVisiblePrimitive(),
+            new ClickPrimitive(),
+            new CaptureScreenshotPrimitive(),
+            new StartVanillaServerPrimitive(),
+            new KeyboardInputPrimitive()
+    ).stream().collect(Collectors.toUnmodifiableMap(ScenarioPrimitive::name, Function.identity()));
+
+    private ScenarioPrimitives() {
+    }
+
+    public static ScenarioPrimitive find(String name) {
+        return BY_NAME.get(name);
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -15,6 +15,7 @@ public final class ScenarioPrimitives {
             new StartVanillaServerPrimitive(),
             new CreateWorldPrimitive(),
             new KeyboardInputPrimitive(),
+            new RunCommandPrimitive(),
             new WaitUntilPrimitive(),
             new OpenInventoryPrimitive()
     ).stream().collect(Collectors.toUnmodifiableMap(ScenarioPrimitive::name, Function.identity()));

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -14,7 +14,8 @@ public final class ScenarioPrimitives {
             new CaptureScreenshotPrimitive(),
             new StartVanillaServerPrimitive(),
             new KeyboardInputPrimitive(),
-            new WaitUntilPrimitive()
+            new WaitUntilPrimitive(),
+            new OpenInventoryPrimitive()
     ).stream().collect(Collectors.toUnmodifiableMap(ScenarioPrimitive::name, Function.identity()));
 
     private ScenarioPrimitives() {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -13,7 +13,8 @@ public final class ScenarioPrimitives {
             new ClickPrimitive(),
             new CaptureScreenshotPrimitive(),
             new StartVanillaServerPrimitive(),
-            new KeyboardInputPrimitive()
+            new KeyboardInputPrimitive(),
+            new WaitUntilPrimitive()
     ).stream().collect(Collectors.toUnmodifiableMap(ScenarioPrimitive::name, Function.identity()));
 
     private ScenarioPrimitives() {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -17,6 +17,7 @@ public final class ScenarioPrimitives {
             new KeyboardInputPrimitive(),
             new RunCommandPrimitive(),
             new WaitUntilPrimitive(),
+            new WaitTicksPrimitive(),
             new OpenInventoryPrimitive(),
             new CloseScreenPrimitive(),
             new SelectHotbarPrimitive(),

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -13,6 +13,7 @@ public final class ScenarioPrimitives {
             new ClickPrimitive(),
             new CaptureScreenshotPrimitive(),
             new StartVanillaServerPrimitive(),
+            new CreateWorldPrimitive(),
             new KeyboardInputPrimitive(),
             new WaitUntilPrimitive(),
             new OpenInventoryPrimitive()

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectHotbarPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectHotbarPrimitive.java
@@ -1,0 +1,92 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.protocol.game.ServerboundSetCarriedItemPacket;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class SelectHotbarPrimitive implements ScenarioPrimitive {
+    public static final int MIN_SLOT = 0;
+    public static final int MAX_SLOT = 8;
+    private static final Set<String> KEYS = Set.of("slot", "text");
+
+    @Override
+    public String name() {
+        return "selectHotbar";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        try {
+            return normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        if (client.player == null || client.player.connection == null) {
+            return false;
+        }
+        int slot = (Integer) context.arguments().get("slot");
+        context.logger().info("Selecting hotbar slot {}", slot);
+        client.player.getInventory().setSelectedSlot(slot);
+        client.player.connection.send(new ServerboundSetCarriedItemPacket(slot));
+        return true;
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw new ScenarioException("selectHotbar does not accept '" + key + "'");
+            }
+        }
+        boolean hasSlot = arguments.containsKey("slot");
+        boolean hasText = arguments.containsKey("text");
+        if (hasSlot == hasText) {
+            throw new ScenarioException("selectHotbar requires an integer 'slot' from "
+                    + MIN_SLOT + " to " + MAX_SLOT);
+        }
+        int slot = parseSlot(hasSlot ? arguments.get("slot") : arguments.get("text"));
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("slot", slot);
+        return normalized;
+    }
+
+    public static int parseSlot(Object value) {
+        int slot;
+        if (value instanceof Integer integer) {
+            slot = integer;
+        } else if (value instanceof Long longValue) {
+            if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+                throw invalidSlot();
+            }
+            slot = longValue.intValue();
+        } else if (value instanceof String string) {
+            if (string.isBlank()) {
+                throw invalidSlot();
+            }
+            try {
+                slot = Integer.parseInt(string.trim());
+            } catch (NumberFormatException exception) {
+                throw invalidSlot();
+            }
+        } else {
+            throw invalidSlot();
+        }
+        if (slot < MIN_SLOT || slot > MAX_SLOT) {
+            throw invalidSlot();
+        }
+        return slot;
+    }
+
+    private static ScenarioException invalidSlot() {
+        return new ScenarioException("selectHotbar requires an integer 'slot' from "
+                + MIN_SLOT + " to " + MAX_SLOT);
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectorPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectorPrimitive.java
@@ -1,0 +1,39 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+
+import java.util.Map;
+import java.util.Set;
+
+public abstract class SelectorPrimitive implements ScenarioPrimitive {
+    private static final Set<String> SELECTOR_TYPES = Set.of("button", "cycle", "tab", "editbox");
+    private static final Set<String> SELECTOR_FIELDS = Set.of("type", "name");
+
+    protected Map<String, Object> requireSelector(Map<String, Object> arguments, String source) {
+        String step = name();
+        for (String key : arguments.keySet()) {
+            if (!SELECTOR_FIELDS.contains(key)) {
+                throw new ScenarioException(source + ": step '" + step + "' has unknown selector field '" + key + "'");
+            }
+        }
+        requireSelectorString(arguments, "type", step, source);
+        requireSelectorString(arguments, "name", step, source);
+        if (!SELECTOR_TYPES.contains(arguments.get("type"))) {
+            throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
+                    + "'; supported types: [button, cycle, tab, editbox]");
+        }
+        return arguments;
+    }
+
+    private static void requireSelectorString(
+            Map<String, Object> arguments,
+            String key,
+            String step,
+            String source
+    ) {
+        Object value = arguments.get(key);
+        if (!(value instanceof String string) || string.isBlank()) {
+            throw new ScenarioException(source + ": step '" + step + "' requires a non-empty string '" + key + "'");
+        }
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectorPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectorPrimitive.java
@@ -19,16 +19,21 @@ public abstract class SelectorPrimitive implements ScenarioPrimitive {
     static Map<String, Object> validateSelector(Map<String, Object> arguments, String source, String step) {
         for (String key : arguments.keySet()) {
             if (!SELECTOR_FIELDS.contains(key)) {
-                throw new ScenarioException(source + ": step '" + step + "' has unknown selector field '" + key + "'");
+                throw new ScenarioException(qualify(source,
+                        "step '" + step + "' has unknown selector field '" + key + "'"));
             }
         }
         requireSelectorString(arguments, "type", step, source);
         requireSelectorString(arguments, "name", step, source);
         if (!SELECTOR_TYPES.contains(arguments.get("type"))) {
-            throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
-                    + "'; supported types: " + SELECTOR_TYPE_LIST);
+            throw new ScenarioException(qualify(source, "unsupported element type '" + arguments.get("type")
+                    + "'; supported types: " + SELECTOR_TYPE_LIST));
         }
         return arguments;
+    }
+
+    private static String qualify(String source, String message) {
+        return source == null || source.isBlank() ? message : source + ": " + message;
     }
 
     private static void requireSelectorString(
@@ -39,7 +44,8 @@ public abstract class SelectorPrimitive implements ScenarioPrimitive {
     ) {
         Object value = arguments.get(key);
         if (!(value instanceof String string) || string.isBlank()) {
-            throw new ScenarioException(source + ": step '" + step + "' requires a non-empty string '" + key + "'");
+            throw new ScenarioException(qualify(source,
+                    "step '" + step + "' requires a non-empty string '" + key + "'"));
         }
     }
 }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectorPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/SelectorPrimitive.java
@@ -2,15 +2,21 @@ package com.adamkali.dwm.scenariotest.primitive;
 
 import com.adamkali.dwm.scenariotest.ScenarioException;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public abstract class SelectorPrimitive implements ScenarioPrimitive {
-    private static final Set<String> SELECTOR_TYPES = Set.of("button", "cycle", "tab", "editbox");
+    private static final List<String> SELECTOR_TYPE_LIST = List.of(
+            "button", "cycle", "tab", "editbox", "label", "screen");
+    private static final Set<String> SELECTOR_TYPES = Set.copyOf(SELECTOR_TYPE_LIST);
     private static final Set<String> SELECTOR_FIELDS = Set.of("type", "name");
 
     protected Map<String, Object> requireSelector(Map<String, Object> arguments, String source) {
-        String step = name();
+        return validateSelector(arguments, source, name());
+    }
+
+    static Map<String, Object> validateSelector(Map<String, Object> arguments, String source, String step) {
         for (String key : arguments.keySet()) {
             if (!SELECTOR_FIELDS.contains(key)) {
                 throw new ScenarioException(source + ": step '" + step + "' has unknown selector field '" + key + "'");
@@ -20,7 +26,7 @@ public abstract class SelectorPrimitive implements ScenarioPrimitive {
         requireSelectorString(arguments, "name", step, source);
         if (!SELECTOR_TYPES.contains(arguments.get("type"))) {
             throw new ScenarioException(source + ": unsupported element type '" + arguments.get("type")
-                    + "'; supported types: [button, cycle, tab, editbox]");
+                    + "'; supported types: " + SELECTOR_TYPE_LIST);
         }
         return arguments;
     }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/StartVanillaServerPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/StartVanillaServerPrimitive.java
@@ -1,0 +1,44 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import com.adamkali.dwm.scenariotest.VanillaServerProcess;
+
+import java.time.Duration;
+import java.util.Map;
+
+public final class StartVanillaServerPrimitive implements ScenarioPrimitive {
+    private static final Duration TIMEOUT_FLOOR = Duration.ofSeconds(120);
+
+    @Override
+    public String name() {
+        return "startVanillaServer";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        if (arguments.isEmpty()) {
+            return arguments;
+        }
+        for (String key : arguments.keySet()) {
+            if (!"port".equals(key)) {
+                throw new ScenarioException(source + ": startVanillaServer does not accept '" + key + "'");
+            }
+        }
+        try {
+            arguments.put("port", VanillaServerProcess.parsePort(arguments.get("port")));
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+        return arguments;
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        return context.vanillaServer().tick(VanillaServerProcess.parsePort(context.arguments().get("port")));
+    }
+
+    @Override
+    public Duration timeout(Duration stepTimeout) {
+        return stepTimeout.compareTo(TIMEOUT_FLOOR) >= 0 ? stepTimeout : TIMEOUT_FLOOR;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/UseItemPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/UseItemPrimitive.java
@@ -1,0 +1,35 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+
+import java.util.Map;
+
+public final class UseItemPrimitive extends NoArgPrimitive {
+    @Override
+    public String name() {
+        return "useItem";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        return requireNoArguments(arguments, source);
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        if (client.player == null || client.gameMode == null || context.screen() != null) {
+            return false;
+        }
+        HitResult hit = client.hitResult;
+        if (!(hit instanceof BlockHitResult blockHit) || blockHit.getType() != HitResult.Type.BLOCK) {
+            return false;
+        }
+        context.logger().info("Using item on {} face {}", blockHit.getBlockPos(), blockHit.getDirection());
+        client.gameMode.useItemOn(client.player, InteractionHand.MAIN_HAND, blockHit);
+        return true;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WaitTicksPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WaitTicksPrimitive.java
@@ -1,0 +1,97 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import net.minecraft.client.Minecraft;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public final class WaitTicksPrimitive implements ScenarioPrimitive {
+    public static final int MIN_TICKS = 1;
+    private static final Set<String> KEYS = Set.of("ticks", "text");
+
+    private Long deadlineGameTime;
+
+    @Override
+    public String name() {
+        return "waitTicks";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        try {
+            return normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        if (client.level == null) {
+            return false;
+        }
+        int ticks = (Integer) context.arguments().get("ticks");
+        long gameTime = client.level.getGameTime();
+        if (deadlineGameTime == null) {
+            deadlineGameTime = gameTime + ticks;
+            context.logger().info("Waiting {} ticks until gameTime {}", ticks, deadlineGameTime);
+            return false;
+        }
+        if (gameTime >= deadlineGameTime) {
+            deadlineGameTime = null;
+            return true;
+        }
+        return false;
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw new ScenarioException("waitTicks does not accept '" + key + "'");
+            }
+        }
+        boolean hasTicks = arguments.containsKey("ticks");
+        boolean hasText = arguments.containsKey("text");
+        if (hasTicks == hasText) {
+            throw new ScenarioException("waitTicks requires a positive integer 'ticks'");
+        }
+        int ticks = parseTicks(hasTicks ? arguments.get("ticks") : arguments.get("text"));
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("ticks", ticks);
+        return normalized;
+    }
+
+    public static int parseTicks(Object value) {
+        int ticks;
+        if (value instanceof Integer integer) {
+            ticks = integer;
+        } else if (value instanceof Long longValue) {
+            if (longValue < Integer.MIN_VALUE || longValue > Integer.MAX_VALUE) {
+                throw invalidTicks();
+            }
+            ticks = longValue.intValue();
+        } else if (value instanceof String string) {
+            if (string.isBlank()) {
+                throw invalidTicks();
+            }
+            try {
+                ticks = Integer.parseInt(string.trim());
+            } catch (NumberFormatException exception) {
+                throw invalidTicks();
+            }
+        } else {
+            throw invalidTicks();
+        }
+        if (ticks < MIN_TICKS) {
+            throw invalidTicks();
+        }
+        return ticks;
+    }
+
+    private static ScenarioException invalidTicks() {
+        return new ScenarioException("waitTicks requires a positive integer 'ticks'");
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WaitUntilPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WaitUntilPrimitive.java
@@ -1,14 +1,30 @@
 package com.adamkali.dwm.scenariotest.primitive;
 
+import com.adamkali.dwm.scenariotest.ScenarioCoordinates;
 import com.adamkali.dwm.scenariotest.ScenarioException;
+import com.adamkali.dwm.scenariotest.ScenarioIds;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.block.state.BlockState;
 
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public final class WaitUntilPrimitive implements ScenarioPrimitive {
-    private static final Set<String> CONDITIONS = Set.of("visible", "notVisible");
+    private static final List<String> CONDITION_LIST = List.of("visible", "notVisible", "holding", "block");
+    private static final Set<String> CONDITIONS = Set.copyOf(CONDITION_LIST);
+    private static final Set<String> BLOCK_KEYS = Set.of("id", "x", "y", "z");
+    private static final Set<String> HOLDING_KEYS = Set.of("id");
+    private static final String ONE_OF = CONDITION_LIST.stream()
+            .map(condition -> "'" + condition + "'")
+            .collect(Collectors.collectingAndThen(Collectors.toList(), WaitUntilPrimitive::joinOneOf));
 
     @Override
     public String name() {
@@ -17,52 +33,147 @@ public final class WaitUntilPrimitive implements ScenarioPrimitive {
 
     @Override
     public Map<String, Object> validate(Map<String, Object> arguments, String source) {
-        for (String key : arguments.keySet()) {
-            if (!CONDITIONS.contains(key)) {
-                throw new ScenarioException(source + ": waitUntil does not accept '" + key + "'");
-            }
+        try {
+            return normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
         }
-        boolean hasVisible = arguments.containsKey("visible");
-        boolean hasNotVisible = arguments.containsKey("notVisible");
-        if (hasVisible == hasNotVisible) {
-            throw new ScenarioException(source + ": waitUntil requires exactly one of 'visible' or 'notVisible'");
-        }
-        String condition = hasVisible ? "visible" : "notVisible";
-        Map<String, Object> selector = nestedSelector(arguments.get(condition), source, condition);
-        Map<String, Object> validated = new LinkedHashMap<>();
-        validated.put(condition, Map.copyOf(SelectorPrimitive.validateSelector(
-                selector, source, name() + " " + condition)));
-        return validated;
     }
 
     @Override
     public boolean execute(ScenarioPrimitiveContext context) {
-        boolean expectVisible = context.arguments().containsKey("visible");
+        Map<String, Object> arguments = context.arguments();
+        if (arguments.containsKey("holding")) {
+            return isHolding(context.client(), (String) arguments.get("holding"));
+        }
+        if (arguments.containsKey("block")) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> block = (Map<String, Object>) arguments.get("block");
+            return isBlock(context.client(), block);
+        }
+        boolean expectVisible = arguments.containsKey("visible");
         @SuppressWarnings("unchecked")
-        Map<String, Object> selector = (Map<String, Object>) context.arguments().get(
+        Map<String, Object> selector = (Map<String, Object>) arguments.get(
                 expectVisible ? "visible" : "notVisible");
         boolean matches = context.widgetFinder().matches(context.screen(), selector);
         return expectVisible == matches;
     }
 
-    private static Map<String, Object> nestedSelector(Object value, String source, String condition) {
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!CONDITIONS.contains(key)) {
+                throw new ScenarioException("waitUntil does not accept '" + key + "'");
+            }
+        }
+        long supplied = CONDITION_LIST.stream().filter(arguments::containsKey).count();
+        if (supplied != 1) {
+            throw new ScenarioException("waitUntil requires exactly one of " + ONE_OF);
+        }
+        Map<String, Object> validated = new LinkedHashMap<>();
+        if (arguments.containsKey("holding")) {
+            validated.put("holding", normalizeHolding(arguments.get("holding")));
+            return validated;
+        }
+        if (arguments.containsKey("block")) {
+            validated.put("block", Map.copyOf(normalizeBlock(arguments.get("block"))));
+            return validated;
+        }
+        String condition = arguments.containsKey("visible") ? "visible" : "notVisible";
+        Map<String, Object> selector = nestedObject(arguments.get(condition), condition);
+        validated.put(condition, Map.copyOf(SelectorPrimitive.validateSelector(
+                selector, null, "waitUntil " + condition)));
+        return validated;
+    }
+
+    private static String normalizeHolding(Object value) {
+        if (value instanceof Map<?, ?>) {
+            Map<String, Object> holding = nestedObject(value, "holding");
+            for (String key : holding.keySet()) {
+                if (!HOLDING_KEYS.contains(key)) {
+                    throw new ScenarioException("waitUntil holding does not accept '" + key + "'");
+                }
+            }
+            return ScenarioIds.normalize(holding.get("id"), "waitUntil holding");
+        }
+        return ScenarioIds.normalize(value, "waitUntil holding");
+    }
+
+    private static Map<String, Object> normalizeBlock(Object value) {
+        Map<String, Object> block = nestedObject(value, "block");
+        for (String key : block.keySet()) {
+            if (!BLOCK_KEYS.contains(key)) {
+                throw new ScenarioException("waitUntil block does not accept '" + key + "'");
+            }
+        }
+        for (String key : BLOCK_KEYS) {
+            if (!block.containsKey(key)) {
+                throw new ScenarioException("waitUntil block requires '" + key + "'");
+            }
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("id", ScenarioIds.normalize(block.get("id"), "waitUntil block id"));
+        for (String axis : List.of("x", "y", "z")) {
+            ScenarioCoordinates.Component component = ScenarioCoordinates.parse(
+                    block.get(axis), "waitUntil block " + axis);
+            normalized.put(axis, component.authored());
+        }
+        return normalized;
+    }
+
+    private static boolean isHolding(Minecraft client, String itemId) {
+        LocalPlayer player = client.player;
+        if (player == null) {
+            return false;
+        }
+        ItemStack stack = player.getMainHandItem();
+        if (stack.isEmpty()) {
+            return "minecraft:air".equals(itemId);
+        }
+        Identifier actual = BuiltInRegistries.ITEM.getKey(stack.getItem());
+        return itemId.equals(actual.toString());
+    }
+
+    private static boolean isBlock(Minecraft client, Map<String, Object> block) {
+        LocalPlayer player = client.player;
+        if (player == null || client.level == null) {
+            return false;
+        }
+        BlockPos origin = player.blockPosition();
+        BlockPos pos = new BlockPos(
+                ScenarioCoordinates.parse(block.get("x"), "waitUntil block x").resolve(origin.getX()),
+                ScenarioCoordinates.parse(block.get("y"), "waitUntil block y").resolve(origin.getY()),
+                ScenarioCoordinates.parse(block.get("z"), "waitUntil block z").resolve(origin.getZ())
+        );
+        BlockState state = client.level.getBlockState(pos);
+        Identifier actual = BuiltInRegistries.BLOCK.getKey(state.getBlock());
+        return ((String) block.get("id")).equals(actual.toString());
+    }
+
+    private static Map<String, Object> nestedObject(Object value, String condition) {
         if (value instanceof List<?> list) {
             if (list.size() != 1) {
-                throw new ScenarioException(source + ": step 'waitUntil' "
-                        + condition + " expects one argument object, but received " + list.size());
+                throw new ScenarioException("waitUntil " + condition
+                        + " expects one argument object, but received " + list.size());
             }
             value = list.getFirst();
         }
         if (!(value instanceof Map<?, ?> raw)) {
-            throw new ScenarioException(source + ": waitUntil '" + condition + "' must be a selector object");
+            throw new ScenarioException("waitUntil '" + condition + "' must be an object");
         }
-        Map<String, Object> selector = new LinkedHashMap<>();
+        Map<String, Object> object = new LinkedHashMap<>();
         raw.forEach((key, entryValue) -> {
             if (!(key instanceof String stringKey)) {
-                throw new ScenarioException(source + ": waitUntil '" + condition + "' object keys must be strings");
+                throw new ScenarioException("waitUntil '" + condition + "' object keys must be strings");
             }
-            selector.put(stringKey, entryValue);
+            object.put(stringKey, entryValue);
         });
-        return selector;
+        return object;
+    }
+
+    private static String joinOneOf(List<String> values) {
+        if (values.size() < 2) {
+            return String.join(", ", values);
+        }
+        return String.join(", ", values.subList(0, values.size() - 1)) + ", or " + values.getLast();
     }
 }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WaitUntilPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WaitUntilPrimitive.java
@@ -1,0 +1,68 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioException;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class WaitUntilPrimitive implements ScenarioPrimitive {
+    private static final Set<String> CONDITIONS = Set.of("visible", "notVisible");
+
+    @Override
+    public String name() {
+        return "waitUntil";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        for (String key : arguments.keySet()) {
+            if (!CONDITIONS.contains(key)) {
+                throw new ScenarioException(source + ": waitUntil does not accept '" + key + "'");
+            }
+        }
+        boolean hasVisible = arguments.containsKey("visible");
+        boolean hasNotVisible = arguments.containsKey("notVisible");
+        if (hasVisible == hasNotVisible) {
+            throw new ScenarioException(source + ": waitUntil requires exactly one of 'visible' or 'notVisible'");
+        }
+        String condition = hasVisible ? "visible" : "notVisible";
+        Map<String, Object> selector = nestedSelector(arguments.get(condition), source, condition);
+        Map<String, Object> validated = new LinkedHashMap<>();
+        validated.put(condition, Map.copyOf(SelectorPrimitive.validateSelector(
+                selector, source, name() + " " + condition)));
+        return validated;
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        boolean expectVisible = context.arguments().containsKey("visible");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> selector = (Map<String, Object>) context.arguments().get(
+                expectVisible ? "visible" : "notVisible");
+        boolean matches = context.widgetFinder().matches(context.screen(), selector);
+        return expectVisible == matches;
+    }
+
+    private static Map<String, Object> nestedSelector(Object value, String source, String condition) {
+        if (value instanceof List<?> list) {
+            if (list.size() != 1) {
+                throw new ScenarioException(source + ": step 'waitUntil' "
+                        + condition + " expects one argument object, but received " + list.size());
+            }
+            value = list.getFirst();
+        }
+        if (!(value instanceof Map<?, ?> raw)) {
+            throw new ScenarioException(source + ": waitUntil '" + condition + "' must be a selector object");
+        }
+        Map<String, Object> selector = new LinkedHashMap<>();
+        raw.forEach((key, entryValue) -> {
+            if (!(key instanceof String stringKey)) {
+                throw new ScenarioException(source + ": waitUntil '" + condition + "' object keys must be strings");
+            }
+            selector.put(stringKey, entryValue);
+        });
+        return selector;
+    }
+}

--- a/src/scenarioTest/resources/fabric.mod.json
+++ b/src/scenarioTest/resources/fabric.mod.json
@@ -1,0 +1,19 @@
+{
+  "schemaVersion": 1,
+  "id": "dwm-scenario-test",
+  "version": "1.0.0",
+  "name": "DWM Scenario Test Harness",
+  "environment": "client",
+  "entrypoints": {
+    "client": [
+      "com.adamkali.dwm.scenariotest.ScenarioTestClient"
+    ]
+  },
+  "depends": {
+    "fabricloader": ">=0.19.3",
+    "minecraft": "~26.2",
+    "java": ">=25",
+    "fabric-api": "*",
+    "dwm": "*"
+  }
+}

--- a/src/scenarioTest/resources/tests/createWorld.yaml
+++ b/src/scenarioTest/resources/tests/createWorld.yaml
@@ -4,18 +4,8 @@ type: test
 ---
 steps:
   - launchGame
-  - assertAndClick:
-    - type: button
-      name: "Singleplayer"
-  - assertAndClick:
-    - type: tab
-      name: "World"
-  - assertAndClick:
-    - type: cycle
-      name: "World Type: Default"
-  - assertVisible:
-    - type: cycle
-      name: "World Type: Superflat"
-  - assertAndClick:
-    - type: button
-      name: "Create New World"
+  - createWorld:
+      worldType: superflat
+      gameMode: creative
+  - openInventory
+  - captureScreenshot

--- a/src/scenarioTest/resources/tests/createWorld.yaml
+++ b/src/scenarioTest/resources/tests/createWorld.yaml
@@ -1,0 +1,21 @@
+---
+name: Create World
+type: test
+---
+steps:
+  - launchGame
+  - assertAndClick:
+    - type: button
+      name: "Singleplayer"
+  - assertAndClick:
+    - type: tab
+      name: "World"
+  - assertAndClick:
+    - type: cycle
+      name: "World Type: Default"
+  - assertVisible:
+    - type: cycle
+      name: "World Type: Superflat"
+  - assertAndClick:
+    - type: button
+      name: "Create New World"

--- a/src/scenarioTest/resources/tests/joinVanillaServer.yaml
+++ b/src/scenarioTest/resources/tests/joinVanillaServer.yaml
@@ -18,3 +18,12 @@ steps:
   - assertAndClick:
     - type: button
       name: "Join Server"
+  - assertVisible:
+    - type: screen
+      name: LevelLoadingScreen
+  - waitUntil:
+      notVisible:
+        type: screen
+        name: LevelLoadingScreen
+  - debugScreen
+  - captureScreenshot

--- a/src/scenarioTest/resources/tests/joinVanillaServer.yaml
+++ b/src/scenarioTest/resources/tests/joinVanillaServer.yaml
@@ -1,0 +1,20 @@
+---
+name: Join Vanilla Server
+type: test
+---
+steps:
+  - launchGame
+  - startVanillaServer
+  - assertAndClick:
+    - type: button
+      name: "Multiplayer"
+  - assertAndClick:
+    - type: button
+      name: "Direct Connection"
+  - assertAndClick:
+    - type: editbox
+      name: "Server Address"
+  - keyboardInput: "localhost:25565"
+  - assertAndClick:
+    - type: button
+      name: "Join Server"

--- a/src/scenarioTest/resources/tests/joinVanillaServer.yaml
+++ b/src/scenarioTest/resources/tests/joinVanillaServer.yaml
@@ -25,5 +25,6 @@ steps:
       notVisible:
         type: screen
         name: LevelLoadingScreen
+  - openInventory
   - debugScreen
   - captureScreenshot

--- a/src/scenarioTest/resources/tests/placeAndOpenTardis.yaml
+++ b/src/scenarioTest/resources/tests/placeAndOpenTardis.yaml
@@ -1,0 +1,40 @@
+---
+name: Place and Open TARDIS
+type: test
+---
+steps:
+  - launchGame
+  - createWorld:
+      worldType: superflat
+      gameMode: creative
+  - closeScreen
+  - runCommand: "/time set day"
+  - runCommand: "/give @s dwm:tardis_block"
+  - waitUntil:
+      holding: dwm:tardis_block
+  - selectHotbar: 0
+  - lookAt:
+      x: "~1"
+      y: "~-1"
+      z: "~"
+  - useItem
+  - waitUntil:
+      block:
+        id: dwm:tardis_block
+        x: "~1"
+        y: "~"
+        z: "~"
+  - selectHotbar: 1
+  - lookAt:
+      x: "~1"
+      y: "~"
+      z: "~"
+  - useItem
+  - waitTicks: 25
+  - runCommand: "/tp @s ~-3 ~1 ~"
+  - lookAt:
+      x: "~3"
+      y: "~"
+      z: "~"
+  - captureScreenshot:
+      name: tardis-door-open

--- a/src/scenarioTest/resources/tests/placeBlock.yaml
+++ b/src/scenarioTest/resources/tests/placeBlock.yaml
@@ -1,0 +1,27 @@
+---
+name: Place Block
+type: test
+---
+steps:
+  - launchGame
+  - createWorld:
+      worldType: superflat
+      gameMode: creative
+  - closeScreen
+  - runCommand: "/give @s minecraft:dirt"
+  - waitUntil:
+      holding: minecraft:dirt
+  - selectHotbar: 0
+  - lookAt:
+      x: "~1"
+      y: "~-1"
+      z: "~"
+  - useItem
+  - waitUntil:
+      block:
+        id: minecraft:dirt
+        x: "~1"
+        y: "~"
+        z: "~"
+  - captureScreenshot:
+      name: placed-dirt

--- a/src/scenarioTest/resources/tests/subflows/assertAndClick.yaml
+++ b/src/scenarioTest/resources/tests/subflows/assertAndClick.yaml
@@ -1,0 +1,19 @@
+---
+name: Assert and Click
+type: command
+---
+parameters:
+  - name: "name"
+    type: string
+    description: "The name of the element to assert and click"
+  - name: "type"
+    type: string
+    description: "The type of the element to assert and click"
+
+steps:
+  - assertVisible:
+    - type: "{{ type }}"
+      name: "{{ name }}"
+  - click:
+    - type: "{{ type }}"
+      name: "{{ name }}"

--- a/src/test/java/com/adamkali/dwm/scenariotest/CreateWorldProcessTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/CreateWorldProcessTest.java
@@ -1,0 +1,106 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CreateWorldProcessTest {
+    @Test
+    void normalizeAppliesTestFriendlyDefaults() {
+        Map<String, Object> normalized = CreateWorldProcess.normalize(Map.of());
+
+        assertEquals("flat", normalized.get("worldType"));
+        assertEquals("creative", normalized.get("gameMode"));
+        assertEquals("peaceful", normalized.get("difficulty"));
+        assertEquals(true, normalized.get("allowCommands"));
+        assertFalse(normalized.containsKey("name"));
+    }
+
+    @Test
+    void parseWorldTypeAcceptsAliasesAndPresetPaths() {
+        assertEquals("flat", CreateWorldProcess.parseWorldType(null));
+        assertEquals("flat", CreateWorldProcess.parseWorldType("superflat"));
+        assertEquals("flat", CreateWorldProcess.parseWorldType("minecraft:flat"));
+        assertEquals("normal", CreateWorldProcess.parseWorldType("default"));
+        assertEquals("large_biomes", CreateWorldProcess.parseWorldType("largeBiomes"));
+        assertEquals("amplified", CreateWorldProcess.parseWorldType("amplified"));
+        assertEquals("single_biome_surface", CreateWorldProcess.parseWorldType("singleBiome"));
+        assertEquals("flat_all_dimensions", CreateWorldProcess.parseWorldType("flat_all_dimensions"));
+        assertEquals("dwm:custom", CreateWorldProcess.parseWorldType("dwm:custom"));
+    }
+
+    @Test
+    void parseWorldTypeRejectsBlank() {
+        ScenarioException blank = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.parseWorldType("  ")
+        );
+        ScenarioException wrongType = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.parseWorldType(1)
+        );
+
+        assertTrue(blank.getMessage().contains("createWorld worldType must be a non-empty string"));
+        assertTrue(wrongType.getMessage().contains("createWorld worldType must be a non-empty string"));
+    }
+
+    @Test
+    void parseGameModeAndDifficultyRejectUnknownValues() {
+        assertEquals("creative", CreateWorldProcess.parseGameMode(null));
+        assertEquals("survival", CreateWorldProcess.parseGameMode("Survival"));
+        assertEquals("peaceful", CreateWorldProcess.parseDifficulty(null));
+        assertEquals("hard", CreateWorldProcess.parseDifficulty("HARD"));
+
+        ScenarioException gameMode = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.parseGameMode("adventure")
+        );
+        ScenarioException difficulty = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.parseDifficulty("peaceful-plus")
+        );
+
+        assertTrue(gameMode.getMessage().contains("createWorld gameMode must be one of"));
+        assertTrue(difficulty.getMessage().contains("createWorld difficulty must be one of"));
+    }
+
+    @Test
+    void parseAllowCommandsRequiresBoolean() {
+        assertTrue(CreateWorldProcess.parseAllowCommands(null));
+        assertFalse(CreateWorldProcess.parseAllowCommands(false));
+
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.parseAllowCommands("true")
+        );
+
+        assertTrue(exception.getMessage().contains("createWorld allowCommands must be a boolean"));
+    }
+
+    @Test
+    void parseNameRequiresNonEmptyString() {
+        assertEquals("Scenario World", CreateWorldProcess.parseName("Scenario World"));
+
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.parseName("  ")
+        );
+
+        assertTrue(exception.getMessage().contains("createWorld name must be a non-empty string"));
+    }
+
+    @Test
+    void normalizeRejectsUnknownKeys() {
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> CreateWorldProcess.normalize(Map.of("seed", "1"))
+        );
+
+        assertTrue(exception.getMessage().contains("createWorld does not accept 'seed'"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/LookAtPrimitiveTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/LookAtPrimitiveTest.java
@@ -1,0 +1,72 @@
+package com.adamkali.dwm.scenariotest;
+
+import com.adamkali.dwm.scenariotest.primitive.LookAtPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class LookAtPrimitiveTest {
+    @Test
+    void normalizeAcceptsYawAndPitch() {
+        Map<String, Object> normalized = LookAtPrimitive.normalize(Map.of(
+                "yaw", 90,
+                "pitch", -45
+        ));
+
+        assertEquals(90.0F, normalized.get("yaw"));
+        assertEquals(-45.0F, normalized.get("pitch"));
+        assertFalse(normalized.containsKey("x"));
+    }
+
+    @Test
+    void normalizeAcceptsRelativeCoordinates() {
+        Map<String, Object> normalized = LookAtPrimitive.normalize(Map.of(
+                "x", "~1",
+                "y", "~-1",
+                "z", "~"
+        ));
+
+        assertEquals("~1", normalized.get("x"));
+        assertEquals("~-1", normalized.get("y"));
+        assertEquals("~", normalized.get("z"));
+    }
+
+    @Test
+    void normalizeRejectsMixedAndIncompleteTargets() {
+        ScenarioException mixed = assertThrows(
+                ScenarioException.class,
+                () -> LookAtPrimitive.normalize(Map.of("yaw", 90, "x", "~1"))
+        );
+        ScenarioException incompleteRotation = assertThrows(
+                ScenarioException.class,
+                () -> LookAtPrimitive.normalize(Map.of("yaw", 90))
+        );
+        ScenarioException incompletePosition = assertThrows(
+                ScenarioException.class,
+                () -> LookAtPrimitive.normalize(Map.of("x", 1, "y", 2))
+        );
+        ScenarioException unknown = assertThrows(
+                ScenarioException.class,
+                () -> LookAtPrimitive.normalize(Map.of(
+                        "x", 1,
+                        "y", 2,
+                        "z", 3,
+                        "anchor", "eyes"))
+        );
+        ScenarioException pitch = assertThrows(
+                ScenarioException.class,
+                () -> LookAtPrimitive.normalize(Map.of("yaw", 0, "pitch", 91))
+        );
+
+        assertTrue(mixed.getMessage().contains("lookAt requires yaw and pitch, or x, y, and z"));
+        assertTrue(incompleteRotation.getMessage().contains("lookAt requires yaw and pitch, or x, y, and z"));
+        assertTrue(incompletePosition.getMessage().contains("lookAt requires yaw and pitch, or x, y, and z"));
+        assertTrue(unknown.getMessage().contains("lookAt does not accept 'anchor'"));
+        assertTrue(pitch.getMessage().contains("lookAt pitch must be between -90 and 90"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/RunCommandPrimitiveTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/RunCommandPrimitiveTest.java
@@ -1,0 +1,79 @@
+package com.adamkali.dwm.scenariotest;
+
+import com.adamkali.dwm.scenariotest.primitive.RunCommandPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RunCommandPrimitiveTest {
+    @Test
+    void normalizeCommandStripsASingleLeadingSlash() {
+        assertEquals("give @s minecraft:diamond 1",
+                RunCommandPrimitive.normalizeCommand("/give @s minecraft:diamond 1"));
+        assertEquals("give @s minecraft:diamond 1",
+                RunCommandPrimitive.normalizeCommand("give @s minecraft:diamond 1"));
+        assertEquals("give @s diamond", RunCommandPrimitive.normalizeCommand("  /give @s diamond  "));
+    }
+
+    @Test
+    void normalizeCommandRejectsBlankAndSlashOnly() {
+        ScenarioException blank = assertThrows(
+                ScenarioException.class,
+                () -> RunCommandPrimitive.normalizeCommand("  ")
+        );
+        ScenarioException slash = assertThrows(
+                ScenarioException.class,
+                () -> RunCommandPrimitive.normalizeCommand("/")
+        );
+        ScenarioException missing = assertThrows(
+                ScenarioException.class,
+                () -> RunCommandPrimitive.normalizeCommand(null)
+        );
+
+        assertTrue(blank.getMessage().contains("runCommand requires a non-empty string 'command'"));
+        assertTrue(slash.getMessage().contains("runCommand requires a non-empty string 'command'"));
+        assertTrue(missing.getMessage().contains("runCommand requires a non-empty string 'command'"));
+    }
+
+    @Test
+    void normalizeCommandRejectsOverlongPayload() {
+        String allowed = "a".repeat(RunCommandPrimitive.MAX_COMMAND_LENGTH);
+        String tooLong = "a".repeat(RunCommandPrimitive.MAX_COMMAND_LENGTH + 1);
+
+        assertEquals(allowed, RunCommandPrimitive.normalizeCommand(allowed));
+        assertEquals(allowed, RunCommandPrimitive.normalizeCommand("/" + allowed));
+
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> RunCommandPrimitive.normalizeCommand(tooLong)
+        );
+
+        assertTrue(exception.getMessage().contains("runCommand must be at most 256 characters"));
+    }
+
+    @Test
+    void normalizeRemapsTextToCommand() {
+        Map<String, Object> normalized = RunCommandPrimitive.normalize(
+                Map.of("text", "/give @s diamond"));
+
+        assertEquals("/give @s diamond", normalized.get("command"));
+        assertFalse(normalized.containsKey("text"));
+    }
+
+    @Test
+    void normalizeRejectsBothCommandAndText() {
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> RunCommandPrimitive.normalize(Map.of(
+                        "command", "/give @s diamond",
+                        "text", "/give @s diamond"))
+        );
+
+        assertTrue(exception.getMessage().contains("runCommand requires a non-empty string 'command'"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -189,6 +189,108 @@ class ScenarioCompilerTest {
     }
 
     @Test
+    void compilesCaptureScreenshotAsANoArgPrimitive(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - captureScreenshot
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("captureScreenshot", plan.steps().get(1).name());
+        assertTrue(plan.steps().get(1).arguments().isEmpty());
+    }
+
+    @Test
+    void compilesCaptureScreenshotWithName(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - captureScreenshot:
+                      name: after-world-tab
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("captureScreenshot", plan.steps().get(0).name());
+        assertEquals("after-world-tab.png", plan.steps().get(0).arguments().get("name"));
+    }
+
+    @Test
+    void rejectsCaptureScreenshotUnknownFields(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - captureScreenshot:
+                      type: button
+                      name: Singleplayer
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("captureScreenshot does not accept 'type'"));
+    }
+
+    @Test
+    void rejectsCaptureScreenshotBlankName(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - captureScreenshot:
+                      name: "  "
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("captureScreenshot requires a non-empty string 'name'"));
+    }
+
+    @Test
+    void rejectsCaptureScreenshotPathName(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - captureScreenshot:
+                      name: ../escape.png
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("without path separators"));
+    }
+
+    @Test
     void rejectsUnsupportedElementTypes(@TempDir Path root) throws Exception {
         write(root.resolve("test.yaml"), """
                 ---

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -1,0 +1,176 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScenarioCompilerTest {
+    @Test
+    void compilesBundledCreateWorldScenario() throws URISyntaxException {
+        Path scenarioRoot = Path.of(getClass().getResource("/tests").toURI());
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("createWorld");
+
+        assertEquals(10, plan.steps().size());
+        assertEquals("tab", plan.steps().get(3).arguments().get("type"));
+        assertEquals("cycle", plan.steps().get(5).arguments().get("type"));
+    }
+
+    @Test
+    void classifiesDocumentsRecursivelyAndExpandsCommandTemplates() throws URISyntaxException {
+        Path fixtureRoot = Path.of(getClass().getResource("/scenario-fixtures/valid").toURI());
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(fixtureRoot);
+        ScenarioPlan plan = new ScenarioCompiler(catalog).compile("createWorld.yaml");
+
+        assertEquals(1, catalog.tests().size());
+        assertEquals(1, catalog.commands().size());
+        assertEquals("assertAndClick", catalog.commands().keySet().iterator().next());
+        assertEquals(3, plan.steps().size());
+        assertEquals("launchGame", plan.steps().get(0).name());
+        assertEquals("assertVisible", plan.steps().get(1).name());
+        assertEquals("button", plan.steps().get(1).arguments().get("type"));
+        assertEquals("Singleplayer", plan.steps().get(1).arguments().get("name"));
+        assertEquals("click", plan.steps().get(2).name());
+    }
+
+    @Test
+    void rejectsUnsupportedFrontmatterType(@TempDir Path root) throws Exception {
+        write(root.resolve("invalid.yaml"), """
+                ---
+                name: Invalid
+                type: suite
+                ---
+                steps:
+                  - launchGame
+                """);
+
+        ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
+
+        assertTrue(exception.getMessage().contains("unsupported frontmatter type 'suite'"));
+    }
+
+    @Test
+    void rejectsDuplicateCommandIdsAcrossDirectories(@TempDir Path root) throws Exception {
+        String command = """
+                ---
+                name: Duplicate
+                type: command
+                ---
+                steps:
+                  - launchGame
+                """;
+        write(root.resolve("first/reused.yaml"), command);
+        write(root.resolve("second/reused.yaml"), command);
+
+        ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
+
+        assertTrue(exception.getMessage().contains("Duplicate command id 'reused'"));
+    }
+
+    @Test
+    void rejectsMissingCommandParameters(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - reusable:
+                      type: button
+                """);
+        write(root.resolve("reusable.yaml"), """
+                ---
+                name: Reusable
+                type: command
+                ---
+                parameters:
+                  - name: type
+                    type: string
+                  - name: name
+                    type: string
+                steps:
+                  - assertVisible:
+                      type: "{{ type }}"
+                      name: "{{ name }}"
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("missing parameter 'name'"));
+    }
+
+    @Test
+    void rejectsRecursiveCommandCycles(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - first
+                """);
+        write(root.resolve("first.yaml"), """
+                ---
+                name: First
+                type: command
+                ---
+                steps:
+                  - second
+                """);
+        write(root.resolve("second.yaml"), """
+                ---
+                name: Second
+                type: command
+                ---
+                steps:
+                  - first
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("first -> second -> first"));
+    }
+
+    @Test
+    void rejectsUnsupportedElementTypes(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - assertVisible:
+                      type: label
+                      name: Heading
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("supported types: [button, cycle, tab]"));
+    }
+
+    private static void write(Path path, String content) throws Exception {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content);
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -309,7 +309,7 @@ class ScenarioCompilerTest {
                 () -> new ScenarioCompiler(catalog).compile("test")
         );
 
-        assertTrue(exception.getMessage().contains("supported types: [button, cycle, tab]"));
+        assertTrue(exception.getMessage().contains("supported types: [button, cycle, tab, editbox]"));
     }
 
     @Test
@@ -430,6 +430,147 @@ class ScenarioCompilerTest {
         );
 
         assertTrue(exception.getMessage().contains("startVanillaServer does not accept 'type'"));
+    }
+
+    @Test
+    void compilesBundledJoinVanillaServerScenario() throws URISyntaxException {
+        Path scenarioRoot = Path.of(getClass().getResource("/tests").toURI());
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("joinVanillaServer");
+
+        assertEquals(11, plan.steps().size());
+        assertEquals("startVanillaServer", plan.steps().get(1).name());
+        assertEquals("editbox", plan.steps().get(6).arguments().get("type"));
+        assertEquals("Server Address", plan.steps().get(6).arguments().get("name"));
+        assertEquals("assertVisible", plan.steps().get(6).name());
+        assertEquals("click", plan.steps().get(7).name());
+        assertEquals("keyboardInput", plan.steps().get(8).name());
+        assertEquals("localhost:25565", plan.steps().get(8).arguments().get("text"));
+        assertEquals("keyboardInput \"localhost:25565\"", plan.steps().get(8).displayName());
+    }
+
+    @Test
+    void compilesKeyboardInputWithTextMap(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - keyboardInput:
+                      text: "hello"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("keyboardInput", plan.steps().get(0).name());
+        assertEquals("hello", plan.steps().get(0).arguments().get("text"));
+    }
+
+    @Test
+    void compilesKeyboardInputScalar(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - keyboardInput: "localhost:25565"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("keyboardInput", plan.steps().get(0).name());
+        assertEquals("localhost:25565", plan.steps().get(0).arguments().get("text"));
+    }
+
+    @Test
+    void compilesEditboxSelector(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - assertVisible:
+                      type: editbox
+                      name: "Server Address"
+                  - click:
+                      type: editbox
+                      name: "Server Address"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("editbox", plan.steps().get(0).arguments().get("type"));
+        assertEquals("Server Address", plan.steps().get(0).arguments().get("name"));
+        assertEquals("editbox", plan.steps().get(1).arguments().get("type"));
+    }
+
+    @Test
+    void rejectsKeyboardInputBlankText(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - keyboardInput:
+                      text: "  "
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("keyboardInput requires a non-empty string 'text'"));
+    }
+
+    @Test
+    void rejectsKeyboardInputUnknownFields(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - keyboardInput:
+                      name: Server Address
+                      text: localhost
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("keyboardInput does not accept 'name'"));
+    }
+
+    @Test
+    void rejectsKeyboardInputWithoutText(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - keyboardInput
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("keyboardInput requires a non-empty string 'text'"));
     }
 
     private static void write(Path path, String content) throws Exception {

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -312,6 +312,126 @@ class ScenarioCompilerTest {
         assertTrue(exception.getMessage().contains("supported types: [button, cycle, tab]"));
     }
 
+    @Test
+    void compilesStartVanillaServerAsANoArgPrimitive(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - startVanillaServer
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("startVanillaServer", plan.steps().get(1).name());
+        assertTrue(plan.steps().get(1).arguments().isEmpty());
+    }
+
+    @Test
+    void compilesStartVanillaServerWithIntegerPort(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - startVanillaServer:
+                      port: 25565
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("startVanillaServer", plan.steps().get(0).name());
+        assertEquals(25565, plan.steps().get(0).arguments().get("port"));
+    }
+
+    @Test
+    void compilesStartVanillaServerWithQuotedPort(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - startVanillaServer:
+                      port: "25566"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals(25566, plan.steps().get(0).arguments().get("port"));
+    }
+
+    @Test
+    void rejectsStartVanillaServerPortZero(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - startVanillaServer:
+                      port: 0
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("startVanillaServer port must be an integer between 1 and 65535"));
+    }
+
+    @Test
+    void rejectsStartVanillaServerPortOutOfRange(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - startVanillaServer:
+                      port: 70000
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("startVanillaServer port must be an integer between 1 and 65535"));
+    }
+
+    @Test
+    void rejectsStartVanillaServerUnknownFields(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - startVanillaServer:
+                      type: button
+                      port: 25565
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("startVanillaServer does not accept 'type'"));
+    }
+
     private static void write(Path path, String content) throws Exception {
         Files.createDirectories(path.getParent());
         Files.writeString(path, content);

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -299,7 +300,7 @@ class ScenarioCompilerTest {
                 ---
                 steps:
                   - assertVisible:
-                      type: label
+                      type: slider
                       name: Heading
                 """);
 
@@ -309,7 +310,78 @@ class ScenarioCompilerTest {
                 () -> new ScenarioCompiler(catalog).compile("test")
         );
 
-        assertTrue(exception.getMessage().contains("supported types: [button, cycle, tab, editbox]"));
+        assertTrue(exception.getMessage().contains("supported types: [button, cycle, tab, editbox, label, screen]"));
+    }
+
+    @Test
+    void compilesLabelSelector(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - assertVisible:
+                      type: label
+                      name: Heading
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("label", plan.steps().get(0).arguments().get("type"));
+        assertEquals("Heading", plan.steps().get(0).arguments().get("name"));
+    }
+
+    @Test
+    void compilesScreenSelector(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - assertVisible:
+                      type: screen
+                      name: LevelLoadingScreen
+                  - waitUntil:
+                      notVisible:
+                        type: screen
+                        name: LevelLoadingScreen
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("screen", plan.steps().get(0).arguments().get("type"));
+        assertEquals("LevelLoadingScreen", plan.steps().get(0).arguments().get("name"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> notVisible = (Map<String, Object>) plan.steps().get(1).arguments().get("notVisible");
+        assertEquals("screen", notVisible.get("type"));
+        assertEquals("LevelLoadingScreen", notVisible.get("name"));
+        assertEquals("waitUntil notVisible \"LevelLoadingScreen\"", plan.steps().get(1).displayName());
+    }
+
+    @Test
+    void rejectsClickOnScreenSelector(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - click:
+                      type: screen
+                      name: TitleScreen
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("step 'click' cannot target type 'screen'"));
     }
 
     @Test
@@ -438,7 +510,7 @@ class ScenarioCompilerTest {
 
         ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("joinVanillaServer");
 
-        assertEquals(11, plan.steps().size());
+        assertEquals(14, plan.steps().size());
         assertEquals("startVanillaServer", plan.steps().get(1).name());
         assertEquals("editbox", plan.steps().get(6).arguments().get("type"));
         assertEquals("Server Address", plan.steps().get(6).arguments().get("name"));
@@ -447,6 +519,14 @@ class ScenarioCompilerTest {
         assertEquals("keyboardInput", plan.steps().get(8).name());
         assertEquals("localhost:25565", plan.steps().get(8).arguments().get("text"));
         assertEquals("keyboardInput \"localhost:25565\"", plan.steps().get(8).displayName());
+        assertEquals("waitUntil", plan.steps().get(11).name());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> notVisible = (Map<String, Object>) plan.steps().get(11).arguments().get("notVisible");
+        assertEquals("screen", notVisible.get("type"));
+        assertEquals("LevelLoadingScreen", notVisible.get("name"));
+        assertEquals("waitUntil notVisible \"LevelLoadingScreen\"", plan.steps().get(11).displayName());
+        assertEquals("debugScreen", plan.steps().get(12).name());
+        assertEquals("captureScreenshot", plan.steps().get(13).name());
     }
 
     @Test
@@ -571,6 +651,147 @@ class ScenarioCompilerTest {
         );
 
         assertTrue(exception.getMessage().contains("keyboardInput requires a non-empty string 'text'"));
+    }
+
+    @Test
+    void compilesWaitUntilVisible(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil:
+                      visible:
+                        type: button
+                        name: Singleplayer
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("waitUntil", plan.steps().get(0).name());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> visible = (Map<String, Object>) plan.steps().get(0).arguments().get("visible");
+        assertEquals("button", visible.get("type"));
+        assertEquals("Singleplayer", visible.get("name"));
+        assertEquals("waitUntil visible \"Singleplayer\"", plan.steps().get(0).displayName());
+    }
+
+    @Test
+    void compilesWaitUntilNotVisibleListSelector(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil:
+                      notVisible:
+                        - type: label
+                          name: "Connecting to the server..."
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> notVisible = (Map<String, Object>) plan.steps().get(0).arguments().get("notVisible");
+        assertEquals("label", notVisible.get("type"));
+        assertEquals("Connecting to the server...", notVisible.get("name"));
+    }
+
+    @Test
+    void rejectsWaitUntilWithoutCondition(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("waitUntil requires exactly one of 'visible' or 'notVisible'"));
+    }
+
+    @Test
+    void rejectsWaitUntilWithBothConditions(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil:
+                      visible:
+                        type: button
+                        name: Singleplayer
+                      notVisible:
+                        type: label
+                        name: Heading
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("waitUntil requires exactly one of 'visible' or 'notVisible'"));
+    }
+
+    @Test
+    void rejectsWaitUntilUnknownFields(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil:
+                      timeout: 30
+                      notVisible:
+                        type: label
+                        name: Heading
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("waitUntil does not accept 'timeout'"));
+    }
+
+    @Test
+    void rejectsWaitUntilInvalidNestedSelector(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil:
+                      notVisible:
+                        type: slider
+                        name: Heading
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("unsupported element type 'slider'"));
     }
 
     private static void write(Path path, String content) throws Exception {

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -190,6 +190,47 @@ class ScenarioCompilerTest {
     }
 
     @Test
+    void compilesOpenInventoryAsANoArgPrimitive(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - openInventory
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("openInventory", plan.steps().get(1).name());
+        assertTrue(plan.steps().get(1).arguments().isEmpty());
+    }
+
+    @Test
+    void rejectsOpenInventoryArguments(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - openInventory:
+                      type: button
+                      name: Singleplayer
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("openInventory does not accept arguments"));
+    }
+
+    @Test
     void compilesCaptureScreenshotAsANoArgPrimitive(@TempDir Path root) throws Exception {
         write(root.resolve("test.yaml"), """
                 ---
@@ -510,7 +551,7 @@ class ScenarioCompilerTest {
 
         ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("joinVanillaServer");
 
-        assertEquals(14, plan.steps().size());
+        assertEquals(16, plan.steps().size());
         assertEquals("startVanillaServer", plan.steps().get(1).name());
         assertEquals("editbox", plan.steps().get(6).arguments().get("type"));
         assertEquals("Server Address", plan.steps().get(6).arguments().get("name"));
@@ -519,14 +560,16 @@ class ScenarioCompilerTest {
         assertEquals("keyboardInput", plan.steps().get(8).name());
         assertEquals("localhost:25565", plan.steps().get(8).arguments().get("text"));
         assertEquals("keyboardInput \"localhost:25565\"", plan.steps().get(8).displayName());
-        assertEquals("waitUntil", plan.steps().get(11).name());
+        assertEquals("waitUntil", plan.steps().get(12).name());
         @SuppressWarnings("unchecked")
-        Map<String, Object> notVisible = (Map<String, Object>) plan.steps().get(11).arguments().get("notVisible");
+        Map<String, Object> notVisible = (Map<String, Object>) plan.steps().get(12).arguments().get("notVisible");
         assertEquals("screen", notVisible.get("type"));
         assertEquals("LevelLoadingScreen", notVisible.get("name"));
-        assertEquals("waitUntil notVisible \"LevelLoadingScreen\"", plan.steps().get(11).displayName());
-        assertEquals("debugScreen", plan.steps().get(12).name());
-        assertEquals("captureScreenshot", plan.steps().get(13).name());
+        assertEquals("waitUntil notVisible \"LevelLoadingScreen\"", plan.steps().get(12).displayName());
+        assertEquals("openInventory", plan.steps().get(13).name());
+        assertTrue(plan.steps().get(13).arguments().isEmpty());
+        assertEquals("debugScreen", plan.steps().get(14).name());
+        assertEquals("captureScreenshot", plan.steps().get(15).name());
     }
 
     @Test

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -1006,7 +1006,7 @@ class ScenarioCompilerTest {
                 () -> new ScenarioCompiler(catalog).compile("test")
         );
 
-        assertTrue(exception.getMessage().contains("waitUntil requires exactly one of 'visible' or 'notVisible'"));
+        assertTrue(exception.getMessage().contains("waitUntil requires exactly one of"));
     }
 
     @Test
@@ -1032,7 +1032,7 @@ class ScenarioCompilerTest {
                 () -> new ScenarioCompiler(catalog).compile("test")
         );
 
-        assertTrue(exception.getMessage().contains("waitUntil requires exactly one of 'visible' or 'notVisible'"));
+        assertTrue(exception.getMessage().contains("waitUntil requires exactly one of"));
     }
 
     @Test
@@ -1080,6 +1080,147 @@ class ScenarioCompilerTest {
         );
 
         assertTrue(exception.getMessage().contains("unsupported element type 'slider'"));
+    }
+
+    @Test
+    void compilesBundledPlaceBlockScenario() throws URISyntaxException {
+        Path scenarioRoot = Path.of(getClass().getResource("/tests").toURI());
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("placeBlock");
+
+        assertEquals(10, plan.steps().size());
+        assertEquals("createWorld", plan.steps().get(1).name());
+        assertEquals("closeScreen", plan.steps().get(2).name());
+        assertEquals("runCommand", plan.steps().get(3).name());
+        assertEquals("waitUntil holding \"minecraft:dirt\"", plan.steps().get(4).displayName());
+        assertEquals(0, plan.steps().get(5).arguments().get("slot"));
+        assertEquals("~1", plan.steps().get(6).arguments().get("x"));
+        assertEquals("useItem", plan.steps().get(7).name());
+        assertEquals("waitUntil block \"minecraft:dirt\"", plan.steps().get(8).displayName());
+        assertEquals("placed-dirt.png", plan.steps().get(9).arguments().get("name"));
+    }
+
+    @Test
+    void compilesCloseScreenAndUseItemAsNoArgPrimitives(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - closeScreen
+                  - useItem
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("closeScreen", plan.steps().get(0).name());
+        assertTrue(plan.steps().get(0).arguments().isEmpty());
+        assertEquals("useItem", plan.steps().get(1).name());
+        assertTrue(plan.steps().get(1).arguments().isEmpty());
+    }
+
+    @Test
+    void rejectsCloseScreenArguments(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - closeScreen:
+                      type: button
+                      name: Singleplayer
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("closeScreen does not accept arguments"));
+    }
+
+    @Test
+    void compilesSelectHotbarFromSlotAndScalar(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - selectHotbar:
+                      slot: 3
+                  - selectHotbar: 0
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals(3, plan.steps().get(0).arguments().get("slot"));
+        assertEquals("selectHotbar \"3\"", plan.steps().get(0).displayName());
+        assertEquals(0, plan.steps().get(1).arguments().get("slot"));
+        assertEquals("selectHotbar \"0\"", plan.steps().get(1).displayName());
+    }
+
+    @Test
+    void compilesLookAtCoordinatesAndRotation(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - lookAt:
+                      x: "~1"
+                      y: "~-1"
+                      z: "~"
+                  - lookAt:
+                      yaw: 90
+                      pitch: 45
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("~1", plan.steps().get(0).arguments().get("x"));
+        assertEquals("~-1", plan.steps().get(0).arguments().get("y"));
+        assertEquals("~", plan.steps().get(0).arguments().get("z"));
+        assertEquals("lookAt \"~1 ~-1 ~\"", plan.steps().get(0).displayName());
+        assertEquals(90.0F, plan.steps().get(1).arguments().get("yaw"));
+        assertEquals(45.0F, plan.steps().get(1).arguments().get("pitch"));
+    }
+
+    @Test
+    void compilesWaitUntilHoldingAndBlock(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - waitUntil:
+                      holding: dirt
+                  - waitUntil:
+                      block:
+                        id: minecraft:dirt
+                        x: "~1"
+                        y: "~"
+                        z: "~"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("minecraft:dirt", plan.steps().get(0).arguments().get("holding"));
+        assertEquals("waitUntil holding \"minecraft:dirt\"", plan.steps().get(0).displayName());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> block = (Map<String, Object>) plan.steps().get(1).arguments().get("block");
+        assertEquals("minecraft:dirt", block.get("id"));
+        assertEquals("~", block.get("y"));
+        assertEquals("waitUntil block \"minecraft:dirt\"", plan.steps().get(1).displayName());
     }
 
     private static void write(Path path, String content) throws Exception {

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -148,6 +148,47 @@ class ScenarioCompilerTest {
     }
 
     @Test
+    void compilesDebugScreenAsANoArgPrimitive(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - debugScreen
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("debugScreen", plan.steps().get(1).name());
+        assertTrue(plan.steps().get(1).arguments().isEmpty());
+    }
+
+    @Test
+    void rejectsDebugScreenArguments(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - debugScreen:
+                      type: button
+                      name: Singleplayer
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("debugScreen does not accept arguments"));
+    }
+
+    @Test
     void rejectsUnsupportedElementTypes(@TempDir Path root) throws Exception {
         write(root.resolve("test.yaml"), """
                 ---

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -9,6 +9,7 @@ import java.nio.file.Path;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -19,9 +20,14 @@ class ScenarioCompilerTest {
 
         ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("createWorld");
 
-        assertEquals(10, plan.steps().size());
-        assertEquals("tab", plan.steps().get(3).arguments().get("type"));
-        assertEquals("cycle", plan.steps().get(5).arguments().get("type"));
+        assertEquals(4, plan.steps().size());
+        assertEquals("createWorld", plan.steps().get(1).name());
+        assertEquals("flat", plan.steps().get(1).arguments().get("worldType"));
+        assertEquals("creative", plan.steps().get(1).arguments().get("gameMode"));
+        assertEquals("peaceful", plan.steps().get(1).arguments().get("difficulty"));
+        assertEquals(true, plan.steps().get(1).arguments().get("allowCommands"));
+        assertEquals("openInventory", plan.steps().get(2).name());
+        assertEquals("captureScreenshot", plan.steps().get(3).name());
     }
 
     @Test
@@ -543,6 +549,121 @@ class ScenarioCompilerTest {
         );
 
         assertTrue(exception.getMessage().contains("startVanillaServer does not accept 'type'"));
+    }
+
+    @Test
+    void compilesCreateWorldAsANoArgPrimitive(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - createWorld
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("createWorld", plan.steps().get(1).name());
+        assertEquals("flat", plan.steps().get(1).arguments().get("worldType"));
+        assertEquals("creative", plan.steps().get(1).arguments().get("gameMode"));
+        assertEquals("peaceful", plan.steps().get(1).arguments().get("difficulty"));
+        assertEquals(true, plan.steps().get(1).arguments().get("allowCommands"));
+        assertFalse(plan.steps().get(1).arguments().containsKey("name"));
+    }
+
+    @Test
+    void compilesCreateWorldWithSettings(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - createWorld:
+                      worldType: superflat
+                      gameMode: creative
+                      difficulty: peaceful
+                      allowCommands: true
+                      name: Scenario World
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("createWorld", plan.steps().get(0).name());
+        assertEquals("flat", plan.steps().get(0).arguments().get("worldType"));
+        assertEquals("creative", plan.steps().get(0).arguments().get("gameMode"));
+        assertEquals("peaceful", plan.steps().get(0).arguments().get("difficulty"));
+        assertEquals(true, plan.steps().get(0).arguments().get("allowCommands"));
+        assertEquals("Scenario World", plan.steps().get(0).arguments().get("name"));
+        assertEquals("createWorld \"Scenario World\"", plan.steps().get(0).displayName());
+    }
+
+    @Test
+    void rejectsCreateWorldUnknownFields(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - createWorld:
+                      type: button
+                      worldType: superflat
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("createWorld does not accept 'type'"));
+    }
+
+    @Test
+    void rejectsCreateWorldInvalidGameMode(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - createWorld:
+                      gameMode: adventure
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("createWorld gameMode must be one of"));
+    }
+
+    @Test
+    void rejectsCreateWorldBlankName(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - createWorld:
+                      name: "  "
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("createWorld name must be a non-empty string"));
     }
 
     @Test

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -818,6 +818,130 @@ class ScenarioCompilerTest {
     }
 
     @Test
+    void compilesRunCommandWithCommandMap(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - runCommand:
+                      command: "/give @s minecraft:diamond 1"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("runCommand", plan.steps().get(0).name());
+        assertEquals("/give @s minecraft:diamond 1", plan.steps().get(0).arguments().get("command"));
+        assertFalse(plan.steps().get(0).arguments().containsKey("text"));
+        assertEquals("runCommand \"/give @s minecraft:diamond 1\"", plan.steps().get(0).displayName());
+    }
+
+    @Test
+    void compilesRunCommandScalar(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - runCommand: "/give @s minecraft:diamond 1"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(1, plan.steps().size());
+        assertEquals("runCommand", plan.steps().get(0).name());
+        assertEquals("/give @s minecraft:diamond 1", plan.steps().get(0).arguments().get("command"));
+        assertFalse(plan.steps().get(0).arguments().containsKey("text"));
+        assertEquals("runCommand \"/give @s minecraft:diamond 1\"", plan.steps().get(0).displayName());
+    }
+
+    @Test
+    void rejectsRunCommandBlankCommand(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - runCommand:
+                      command: "  "
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("runCommand requires a non-empty string 'command'"));
+    }
+
+    @Test
+    void rejectsRunCommandUnknownFields(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - runCommand:
+                      name: Server Address
+                      command: "/give @s diamond"
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("runCommand does not accept 'name'"));
+    }
+
+    @Test
+    void rejectsRunCommandWithoutCommand(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - runCommand
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("runCommand requires a non-empty string 'command'"));
+    }
+
+    @Test
+    void rejectsRunCommandOverlongCommand(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - runCommand: "%s"
+                """.formatted("a".repeat(257)));
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compile("test")
+        );
+
+        assertTrue(exception.getMessage().contains("runCommand must be at most 256 characters"));
+    }
+
+    @Test
     void compilesWaitUntilVisible(@TempDir Path root) throws Exception {
         write(root.resolve("test.yaml"), """
                 ---

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCoordinatesTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCoordinatesTest.java
@@ -1,0 +1,66 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScenarioCoordinatesTest {
+    @Test
+    void parseRelativeOffsets() {
+        ScenarioCoordinates.Component origin = ScenarioCoordinates.parse("~", "x");
+        ScenarioCoordinates.Component plus = ScenarioCoordinates.parse("~1", "x");
+        ScenarioCoordinates.Component minus = ScenarioCoordinates.parse("~-1", "x");
+        ScenarioCoordinates.Component plusSigned = ScenarioCoordinates.parse("~+2", "x");
+
+        assertTrue(origin.relative());
+        assertEquals(0, origin.value());
+        assertEquals("~", origin.authored());
+        assertEquals(10, origin.resolve(10));
+        assertEquals(11, plus.resolve(10));
+        assertEquals(9, minus.resolve(10));
+        assertEquals(12, plusSigned.resolve(10));
+        assertEquals("~1", plus.authored());
+        assertEquals("~-1", minus.authored());
+        assertEquals("~2", plusSigned.authored());
+    }
+
+    @Test
+    void parseAbsoluteIntegersFromNumbersAndStrings() {
+        ScenarioCoordinates.Component fromInt = ScenarioCoordinates.parse(4, "y");
+        ScenarioCoordinates.Component fromString = ScenarioCoordinates.parse(" -8 ", "y");
+
+        assertFalse(fromInt.relative());
+        assertEquals(4, fromInt.value());
+        assertEquals("4", fromInt.authored());
+        assertEquals(4, fromInt.resolve(100));
+        assertEquals(-8, fromString.resolve(0));
+    }
+
+    @Test
+    void parseRejectsBlankNullAndFractionalValues() {
+        ScenarioException missing = assertThrows(
+                ScenarioException.class,
+                () -> ScenarioCoordinates.parse(null, "z")
+        );
+        ScenarioException blank = assertThrows(
+                ScenarioException.class,
+                () -> ScenarioCoordinates.parse("  ", "z")
+        );
+        ScenarioException fraction = assertThrows(
+                ScenarioException.class,
+                () -> ScenarioCoordinates.parse(1.5, "z")
+        );
+        ScenarioException invalid = assertThrows(
+                ScenarioException.class,
+                () -> ScenarioCoordinates.parse("~~", "z")
+        );
+
+        assertTrue(missing.getMessage().contains("quote \"~\" in YAML"));
+        assertTrue(blank.getMessage().contains("must be a relative"));
+        assertTrue(fraction.getMessage().contains("must be a relative"));
+        assertTrue(invalid.getMessage().contains("must be a relative"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScreenshotCaptureTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScreenshotCaptureTest.java
@@ -1,0 +1,44 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScreenshotCaptureTest {
+    @Test
+    void appendsPngWhenMissing() {
+        assertEquals("after-world-tab.png", ScreenshotCapture.normalizeFileName("after-world-tab"));
+    }
+
+    @Test
+    void keepsExistingPngSuffix() {
+        assertEquals("after-world-tab.png", ScreenshotCapture.normalizeFileName("after-world-tab.png"));
+    }
+
+    @Test
+    void rejectsBlankName() {
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> ScreenshotCapture.normalizeFileName("  ")
+        );
+
+        assertTrue(exception.getMessage().contains("non-empty string"));
+    }
+
+    @Test
+    void rejectsPathSeparators() {
+        ScenarioException slash = assertThrows(
+                ScenarioException.class,
+                () -> ScreenshotCapture.normalizeFileName("nested/shot.png")
+        );
+        ScenarioException parent = assertThrows(
+                ScenarioException.class,
+                () -> ScreenshotCapture.normalizeFileName("../escape.png")
+        );
+
+        assertTrue(slash.getMessage().contains("without path separators"));
+        assertTrue(parent.getMessage().contains("without path separators"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/SelectHotbarPrimitiveTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/SelectHotbarPrimitiveTest.java
@@ -1,0 +1,48 @@
+package com.adamkali.dwm.scenariotest;
+
+import com.adamkali.dwm.scenariotest.primitive.SelectHotbarPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SelectHotbarPrimitiveTest {
+    @Test
+    void normalizeAcceptsSlotAndRemapsText() {
+        Map<String, Object> fromSlot = SelectHotbarPrimitive.normalize(Map.of("slot", 3));
+        Map<String, Object> fromText = SelectHotbarPrimitive.normalize(Map.of("text", "8"));
+
+        assertEquals(3, fromSlot.get("slot"));
+        assertEquals(8, fromText.get("slot"));
+        assertFalse(fromText.containsKey("text"));
+    }
+
+    @Test
+    void normalizeRejectsOutOfRangeMissingAndUnknownFields() {
+        ScenarioException missing = assertThrows(
+                ScenarioException.class,
+                () -> SelectHotbarPrimitive.normalize(Map.of())
+        );
+        ScenarioException both = assertThrows(
+                ScenarioException.class,
+                () -> SelectHotbarPrimitive.normalize(Map.of("slot", 0, "text", "0"))
+        );
+        ScenarioException range = assertThrows(
+                ScenarioException.class,
+                () -> SelectHotbarPrimitive.normalize(Map.of("slot", 9))
+        );
+        ScenarioException unknown = assertThrows(
+                ScenarioException.class,
+                () -> SelectHotbarPrimitive.normalize(Map.of("index", 1))
+        );
+
+        assertTrue(missing.getMessage().contains("selectHotbar requires an integer 'slot'"));
+        assertTrue(both.getMessage().contains("selectHotbar requires an integer 'slot'"));
+        assertTrue(range.getMessage().contains("from 0 to 8"));
+        assertTrue(unknown.getMessage().contains("selectHotbar does not accept 'index'"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/VanillaServerProcessTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/VanillaServerProcessTest.java
@@ -1,0 +1,49 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class VanillaServerProcessTest {
+    @Test
+    void parsePortDefaultsWhenMissing() {
+        assertEquals(25565, VanillaServerProcess.parsePort(null));
+    }
+
+    @Test
+    void parsePortAcceptsIntegerAndString() {
+        assertEquals(25565, VanillaServerProcess.parsePort(25565));
+        assertEquals(25566, VanillaServerProcess.parsePort("25566"));
+    }
+
+    @Test
+    void parsePortRejectsOutOfRangeAndBlank() {
+        ScenarioException zero = assertThrows(ScenarioException.class, () -> VanillaServerProcess.parsePort(0));
+        ScenarioException high = assertThrows(ScenarioException.class, () -> VanillaServerProcess.parsePort(70000));
+        ScenarioException blank = assertThrows(ScenarioException.class, () -> VanillaServerProcess.parsePort("  "));
+
+        assertTrue(zero.getMessage().contains("between 1 and 65535"));
+        assertTrue(high.getMessage().contains("between 1 and 65535"));
+        assertTrue(blank.getMessage().contains("between 1 and 65535"));
+    }
+
+    @Test
+    void serverPropertiesUseOfflineLoopbackAndChosenPort() {
+        String properties = VanillaServerProcess.serverProperties(25567);
+
+        assertTrue(properties.contains("online-mode=false"));
+        assertTrue(properties.contains("server-ip=127.0.0.1"));
+        assertTrue(properties.contains("server-port=25567"));
+        assertTrue(properties.contains("level-type=minecraft:flat"));
+        assertTrue(properties.contains("enforce-secure-profile=false"));
+        assertTrue(properties.contains("max-tick-time=-1"));
+        assertTrue(properties.contains("difficulty=peaceful"));
+    }
+
+    @Test
+    void eulaIsAccepted() {
+        assertEquals("eula=true\n", VanillaServerProcess.eulaText());
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/WaitTicksPrimitiveTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/WaitTicksPrimitiveTest.java
@@ -1,0 +1,53 @@
+package com.adamkali.dwm.scenariotest;
+
+import com.adamkali.dwm.scenariotest.primitive.WaitTicksPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WaitTicksPrimitiveTest {
+    @Test
+    void normalizeAcceptsTicksAndRemapsText() {
+        Map<String, Object> fromTicks = WaitTicksPrimitive.normalize(Map.of("ticks", 25));
+        Map<String, Object> fromText = WaitTicksPrimitive.normalize(Map.of("text", "25"));
+
+        assertEquals(25, fromTicks.get("ticks"));
+        assertEquals(25, fromText.get("ticks"));
+        assertFalse(fromText.containsKey("text"));
+    }
+
+    @Test
+    void normalizeRejectsMissingZeroAndUnknownFields() {
+        ScenarioException missing = assertThrows(
+                ScenarioException.class,
+                () -> WaitTicksPrimitive.normalize(Map.of())
+        );
+        ScenarioException both = assertThrows(
+                ScenarioException.class,
+                () -> WaitTicksPrimitive.normalize(Map.of("ticks", 25, "text", "25"))
+        );
+        ScenarioException zero = assertThrows(
+                ScenarioException.class,
+                () -> WaitTicksPrimitive.normalize(Map.of("ticks", 0))
+        );
+        ScenarioException negative = assertThrows(
+                ScenarioException.class,
+                () -> WaitTicksPrimitive.normalize(Map.of("ticks", -1))
+        );
+        ScenarioException unknown = assertThrows(
+                ScenarioException.class,
+                () -> WaitTicksPrimitive.normalize(Map.of("duration", 25))
+        );
+
+        assertTrue(missing.getMessage().contains("waitTicks requires a positive integer 'ticks'"));
+        assertTrue(both.getMessage().contains("waitTicks requires a positive integer 'ticks'"));
+        assertTrue(zero.getMessage().contains("waitTicks requires a positive integer 'ticks'"));
+        assertTrue(negative.getMessage().contains("waitTicks requires a positive integer 'ticks'"));
+        assertTrue(unknown.getMessage().contains("waitTicks does not accept 'duration'"));
+    }
+}

--- a/src/test/java/com/adamkali/dwm/scenariotest/WaitUntilPrimitiveTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/WaitUntilPrimitiveTest.java
@@ -1,0 +1,59 @@
+package com.adamkali.dwm.scenariotest;
+
+import com.adamkali.dwm.scenariotest.primitive.WaitUntilPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WaitUntilPrimitiveTest {
+    @Test
+    void normalizeHoldingAcceptsBareAndNamespacedIds() {
+        Map<String, Object> dirt = WaitUntilPrimitive.normalize(Map.of("holding", "dirt"));
+        Map<String, Object> nested = WaitUntilPrimitive.normalize(Map.of(
+                "holding", Map.of("id", "minecraft:oak_log")));
+
+        assertEquals("minecraft:dirt", dirt.get("holding"));
+        assertEquals("minecraft:oak_log", nested.get("holding"));
+    }
+
+    @Test
+    void normalizeBlockStoresAuthoredCoordinates() {
+        Map<String, Object> normalized = WaitUntilPrimitive.normalize(Map.of(
+                "block", Map.of(
+                        "id", "dirt",
+                        "x", "~1",
+                        "y", "~-1",
+                        "z", "~"
+                )
+        ));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> block = (Map<String, Object>) normalized.get("block");
+        assertEquals("minecraft:dirt", block.get("id"));
+        assertEquals("~1", block.get("x"));
+        assertEquals("~-1", block.get("y"));
+        assertEquals("~", block.get("z"));
+    }
+
+    @Test
+    void normalizeRejectsMissingBlockFieldsAndMixedConditions() {
+        ScenarioException missing = assertThrows(
+                ScenarioException.class,
+                () -> WaitUntilPrimitive.normalize(Map.of(
+                        "block", Map.of("id", "dirt", "x", 1, "y", 2)))
+        );
+        ScenarioException mixed = assertThrows(
+                ScenarioException.class,
+                () -> WaitUntilPrimitive.normalize(Map.of(
+                        "holding", "dirt",
+                        "visible", Map.of("type", "button", "name", "Singleplayer")))
+        );
+
+        assertTrue(missing.getMessage().contains("waitUntil block requires 'z'"));
+        assertTrue(mixed.getMessage().contains("waitUntil requires exactly one of"));
+    }
+}

--- a/src/test/resources/scenario-fixtures/valid/createWorld.yaml
+++ b/src/test/resources/scenario-fixtures/valid/createWorld.yaml
@@ -1,0 +1,9 @@
+---
+name: Fixture Test
+type: test
+---
+steps:
+  - launchGame
+  - assertAndClick:
+    - type: button
+      name: "Singleplayer"

--- a/src/test/resources/scenario-fixtures/valid/nested/assertAndClick.yaml
+++ b/src/test/resources/scenario-fixtures/valid/nested/assertAndClick.yaml
@@ -1,0 +1,16 @@
+---
+name: Assert and Click
+type: command
+---
+parameters:
+  - name: type
+    type: string
+  - name: name
+    type: string
+steps:
+  - assertVisible:
+    - type: "{{ type }}"
+      name: "{{ name }}"
+  - click:
+    - type: "{{ type }}"
+      name: "{{ name }}"

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+## Scope
+This file applies to `tools/` — offline Python scripts for TARDIS travel SFX and related analysis. These are **not** invoked by Gradle or CI.
+
+## Local Context
+Scripts synthesize and validate `.ogg` travel loops from spectral targets. Generated game assets are written into `src/client/resources/assets/dwm/sounds/` (or paths documented in each script). Reference audio for analysis stays local and gitignored.
+
+## Commands
+- Create venv (once): `python3 -m venv tools/.venv && tools/.venv/bin/pip install -r tools/requirements.txt`
+- Fetch local golden reference (analysis only, gitignored): `tools/.venv/bin/python tools/fetch_tardis_ref.py`
+- Generate travel SFX: `tools/.venv/bin/python tools/generate_tardis_travel_sfx.py`
+- Compare against golden: `tools/.venv/bin/python tools/compare_tardis_sfx.py`
+- Flutterwing SFX: `tools/.venv/bin/python tools/generate_flutterwing_sfx.py`
+
+See `tools/fixtures/README.md` for validate/compare report options.
+
+## Conventions
+- Run scripts from the **repo root** unless a script documents otherwise.
+- `tools/fixtures/baked_vworp_targets.npz` is committed (analysis targets); WAV/MP3 goldens under `tools/fixtures/` are **not** committed.
+- After regenerating OGGs, smoke in-game or rely on existing sound-related tests; there is no automated audio gate in `./gradlew build`.
+- Do not redistribute downloaded reference clips — analysis/local dev only.
+
+## Common Pitfalls
+- Do not commit `tools/.venv/` or fetched `tardis_ref.wav`.
+- Matplotlib/compare outputs under `tools/fixtures/compare_out/` are local reports — commit only if intentionally updating checked-in fixtures.
+- Python version may differ from Java 25; the venv is independent of the Gradle toolchain.


### PR DESCRIPTION
## Why this matters

- Main-menu and world-creation flows cannot be covered by GameTests or unit tests; a real-client harness makes those UI paths automated and repeatable for local verification.

## Proposed Implementation

- Add a test-only Loom `scenarioTest` source set and `./gradlew runScenarioTest -Pscenario=<id>` run that loads YAML from `src/scenarioTest/resources/tests/`.
- Classify documents by frontmatter `type` (`test` / `command`), expand composite commands with `{{ param }}` templates, and drive widgets (`button`, `tab`, `cycle`) through in-client screen events.
- Include the `createWorld` superflat scenario, DSL unit tests, JUnit XML/diagnostics under `build/scenario-test/`, and usage docs in `src/scenarioTest/README.md`.

## Problems Encountered / Decisions Made

- Clean scenario run dirs skip the world list and open `CreateWorldScreen` directly after Singleplayer, so the fixture no longer clicks an intermediate Create New World.
- “World” is a tab and “World Type: …” is a cycle button; selectors and the finder were extended accordingly.
- Clicks are dispatched via `Screen.mouseClicked` so nested tab navigation receives events correctly.

Made with [Cursor](https://cursor.com)