### PR TITLE
feat(scenario): walkUntil primitive and enter TARDIS in placeAndOpenTardis

### DIFF
--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -128,6 +128,12 @@ The MVP primitives are:
   components may be absolute integers or relative (`"~"`, `"~1"`, `"~-1"`).
   Quote `"~"` in YAML; a bare `~` is YAML null. Relative values use the
   player's block position. Pitch must be between `-90` and `90`.
+- `walkUntil` — waits until a local player exists and no GUI is open, then holds
+  forward movement (`keyUp`) until one end condition is met: block coordinates
+  `x`/`y`/`z` (same relative/absolute rules as `lookAt`; re-aims at the target
+  each tick), or `dimension` (a namespaced world id such as `dwm:tardis`).
+  Exactly one mode is required. The forward key is released when the step
+  succeeds.
 - `useItem` — waits until a local player, game mode, no open screen, and a
   block crosshair hit exist, then uses the main-hand item on that block (the
   same path as right-click place/interact). It succeeds as soon as the use is
@@ -171,6 +177,12 @@ The MVP primitives are:
 - lookAt:
     yaw: 90
     pitch: 45
+- walkUntil:
+    x: "~3"
+    y: "~"
+    z: "~"
+- walkUntil:
+    dimension: dwm:tardis
 - useItem
 - waitTicks: 25
 - waitTicks:

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioPlan.java
@@ -30,6 +30,9 @@ public record ScenarioPlan(String id, String name, List<Step> steps) {
             if (arguments.containsKey("holding")) {
                 return name + " holding \"" + arguments.get("holding") + "\"";
             }
+            if (arguments.containsKey("dimension")) {
+                return name + " dimension \"" + arguments.get("dimension") + "\"";
+            }
             if (arguments.get("block") instanceof Map<?, ?> block && block.get("id") != null) {
                 return name + " block \"" + block.get("id") + "\"";
             }

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/ScenarioPrimitives.java
@@ -22,7 +22,8 @@ public final class ScenarioPrimitives {
             new CloseScreenPrimitive(),
             new SelectHotbarPrimitive(),
             new LookAtPrimitive(),
-            new UseItemPrimitive()
+            new UseItemPrimitive(),
+            new WalkUntilPrimitive()
     ).stream().collect(Collectors.toUnmodifiableMap(ScenarioPrimitive::name, Function.identity()));
 
     private ScenarioPrimitives() {

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WalkUntilPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WalkUntilPrimitive.java
@@ -1,0 +1,126 @@
+package com.adamkali.dwm.scenariotest.primitive;
+
+import com.adamkali.dwm.scenariotest.ScenarioCoordinates;
+import com.adamkali.dwm.scenariotest.ScenarioException;
+import com.adamkali.dwm.scenariotest.ScenarioIds;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.commands.arguments.EntityAnchorArgument;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public final class WalkUntilPrimitive implements ScenarioPrimitive {
+    private static final Set<String> POSITION_KEYS = Set.of("x", "y", "z");
+    private static final Set<String> KEYS = Set.of("x", "y", "z", "dimension");
+
+    private boolean holdingForward;
+
+    @Override
+    public String name() {
+        return "walkUntil";
+    }
+
+    @Override
+    public Map<String, Object> validate(Map<String, Object> arguments, String source) {
+        try {
+            return normalize(arguments);
+        } catch (ScenarioException exception) {
+            throw new ScenarioException(source + ": " + exception.getMessage());
+        }
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context) {
+        Minecraft client = context.client();
+        LocalPlayer player = client.player;
+        if (player == null || client.level == null || context.screen() != null) {
+            return false;
+        }
+
+        if (!holdingForward) {
+            client.options.keyUp.setDown(true);
+            holdingForward = true;
+            context.logger().info("Holding forward for walkUntil");
+        }
+
+        Map<String, Object> arguments = context.arguments();
+        boolean done;
+        if (arguments.containsKey("dimension")) {
+            String expected = (String) arguments.get("dimension");
+            String actual = client.level.dimension().identifier().toString();
+            done = expected.equals(actual);
+            if (!done) {
+                context.logger().debug("Waiting for dimension {} (current {})", expected, actual);
+            }
+        } else {
+            BlockPos origin = player.blockPosition();
+            BlockPos target = new BlockPos(
+                    ScenarioCoordinates.parse(arguments.get("x"), "walkUntil x").resolve(origin.getX()),
+                    ScenarioCoordinates.parse(arguments.get("y"), "walkUntil y").resolve(origin.getY()),
+                    ScenarioCoordinates.parse(arguments.get("z"), "walkUntil z").resolve(origin.getZ())
+            );
+            player.lookAt(EntityAnchorArgument.Anchor.EYES, Vec3.atCenterOf(target));
+            done = player.blockPosition().equals(target);
+            if (!done) {
+                context.logger().debug("Walking toward {} from {}", target, player.blockPosition());
+            }
+        }
+
+        if (!done) {
+            return false;
+        }
+
+        releaseForward(client);
+        context.logger().info("walkUntil condition met");
+        return true;
+    }
+
+    private void releaseForward(Minecraft client) {
+        client.options.keyUp.setDown(false);
+        holdingForward = false;
+    }
+
+    public static Map<String, Object> normalize(Map<String, Object> arguments) {
+        for (String key : arguments.keySet()) {
+            if (!KEYS.contains(key)) {
+                throw new ScenarioException("walkUntil does not accept '" + key + "'");
+            }
+        }
+        boolean hasDimension = arguments.containsKey("dimension");
+        boolean hasPosition = arguments.keySet().stream().anyMatch(POSITION_KEYS::contains);
+        if (hasDimension == hasPosition) {
+            throw new ScenarioException("walkUntil requires dimension, or x, y, and z");
+        }
+        if (hasDimension) {
+            return normalizeDimension(arguments);
+        }
+        return normalizePosition(arguments);
+    }
+
+    private static Map<String, Object> normalizeDimension(Map<String, Object> arguments) {
+        if (arguments.size() != 1) {
+            throw new ScenarioException("walkUntil requires dimension, or x, y, and z");
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        normalized.put("dimension", ScenarioIds.normalize(arguments.get("dimension"), "walkUntil dimension"));
+        return normalized;
+    }
+
+    private static Map<String, Object> normalizePosition(Map<String, Object> arguments) {
+        if (!arguments.containsKey("x") || !arguments.containsKey("y") || !arguments.containsKey("z")) {
+            throw new ScenarioException("walkUntil requires dimension, or x, y, and z");
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        for (String axis : List.of("x", "y", "z")) {
+            ScenarioCoordinates.Component component = ScenarioCoordinates.parse(
+                    arguments.get(axis), "walkUntil " + axis);
+            normalized.put(axis, component.authored());
+        }
+        return normalized;
+    }
+}

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WalkUntilPrimitive.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/primitive/WalkUntilPrimitive.java
@@ -19,6 +19,7 @@ public final class WalkUntilPrimitive implements ScenarioPrimitive {
     private static final Set<String> KEYS = Set.of("x", "y", "z", "dimension");
 
     private boolean holdingForward;
+    private BlockPos absoluteTarget;
 
     @Override
     public String name() {
@@ -42,13 +43,22 @@ public final class WalkUntilPrimitive implements ScenarioPrimitive {
             return false;
         }
 
+        Map<String, Object> arguments = context.arguments();
         if (!holdingForward) {
+            if (!arguments.containsKey("dimension")) {
+                BlockPos origin = player.blockPosition();
+                absoluteTarget = new BlockPos(
+                        ScenarioCoordinates.parse(arguments.get("x"), "walkUntil x").resolve(origin.getX()),
+                        ScenarioCoordinates.parse(arguments.get("y"), "walkUntil y").resolve(origin.getY()),
+                        ScenarioCoordinates.parse(arguments.get("z"), "walkUntil z").resolve(origin.getZ())
+                );
+                context.logger().info("Walking toward absolute {}", absoluteTarget);
+            }
             client.options.keyUp.setDown(true);
             holdingForward = true;
             context.logger().info("Holding forward for walkUntil");
         }
 
-        Map<String, Object> arguments = context.arguments();
         boolean done;
         if (arguments.containsKey("dimension")) {
             String expected = (String) arguments.get("dimension");
@@ -58,16 +68,10 @@ public final class WalkUntilPrimitive implements ScenarioPrimitive {
                 context.logger().debug("Waiting for dimension {} (current {})", expected, actual);
             }
         } else {
-            BlockPos origin = player.blockPosition();
-            BlockPos target = new BlockPos(
-                    ScenarioCoordinates.parse(arguments.get("x"), "walkUntil x").resolve(origin.getX()),
-                    ScenarioCoordinates.parse(arguments.get("y"), "walkUntil y").resolve(origin.getY()),
-                    ScenarioCoordinates.parse(arguments.get("z"), "walkUntil z").resolve(origin.getZ())
-            );
-            player.lookAt(EntityAnchorArgument.Anchor.EYES, Vec3.atCenterOf(target));
-            done = player.blockPosition().equals(target);
+            player.lookAt(EntityAnchorArgument.Anchor.EYES, Vec3.atCenterOf(absoluteTarget));
+            done = player.blockPosition().equals(absoluteTarget);
             if (!done) {
-                context.logger().debug("Walking toward {} from {}", target, player.blockPosition());
+                context.logger().debug("Walking toward {} from {}", absoluteTarget, player.blockPosition());
             }
         }
 
@@ -83,6 +87,7 @@ public final class WalkUntilPrimitive implements ScenarioPrimitive {
     private void releaseForward(Minecraft client) {
         client.options.keyUp.setDown(false);
         holdingForward = false;
+        absoluteTarget = null;
     }
 
     public static Map<String, Object> normalize(Map<String, Object> arguments) {

--- a/src/scenarioTest/resources/tests/placeAndOpenTardis.yaml
+++ b/src/scenarioTest/resources/tests/placeAndOpenTardis.yaml
@@ -38,3 +38,8 @@ steps:
       z: "~"
   - captureScreenshot:
       name: tardis-door-open
+  - walkUntil:
+      dimension: dwm:tardis
+  - waitTicks: 40
+  - captureScreenshot:
+      name: tardis-interior

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioCompilerTest.java
@@ -1223,6 +1223,47 @@ class ScenarioCompilerTest {
         assertEquals("waitUntil block \"minecraft:dirt\"", plan.steps().get(1).displayName());
     }
 
+    @Test
+    void compilesWalkUntilDimensionAndCoordinates(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                steps:
+                  - walkUntil:
+                      dimension: dwm:tardis
+                  - walkUntil:
+                      x: "~3"
+                      y: "~"
+                      z: "~"
+                """);
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(root)).compile("test");
+
+        assertEquals(2, plan.steps().size());
+        assertEquals("dwm:tardis", plan.steps().get(0).arguments().get("dimension"));
+        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(0).displayName());
+        assertEquals("~3", plan.steps().get(1).arguments().get("x"));
+        assertEquals("~", plan.steps().get(1).arguments().get("y"));
+        assertEquals("~", plan.steps().get(1).arguments().get("z"));
+        assertEquals("walkUntil \"~3 ~ ~\"", plan.steps().get(1).displayName());
+    }
+
+    @Test
+    void compilesBundledPlaceAndOpenTardisScenario() throws URISyntaxException {
+        Path scenarioRoot = Path.of(getClass().getResource("/tests").toURI());
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compile("placeAndOpenTardis");
+
+        assertEquals(20, plan.steps().size());
+        assertEquals("captureScreenshot", plan.steps().get(16).name());
+        assertEquals("tardis-door-open.png", plan.steps().get(16).arguments().get("name"));
+        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(17).displayName());
+        assertEquals(40, plan.steps().get(18).arguments().get("ticks"));
+        assertEquals("tardis-interior.png", plan.steps().get(19).arguments().get("name"));
+    }
+
     private static void write(Path path, String content) throws Exception {
         Files.createDirectories(path.getParent());
         Files.writeString(path, content);

--- a/src/test/java/com/adamkali/dwm/scenariotest/WalkUntilPrimitiveTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/WalkUntilPrimitiveTest.java
@@ -1,0 +1,73 @@
+package com.adamkali.dwm.scenariotest;
+
+import com.adamkali.dwm.scenariotest.primitive.WalkUntilPrimitive;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WalkUntilPrimitiveTest {
+    @Test
+    void normalizeAcceptsDimensionId() {
+        Map<String, Object> normalized = WalkUntilPrimitive.normalize(Map.of(
+                "dimension", "dwm:tardis"
+        ));
+
+        assertEquals("dwm:tardis", normalized.get("dimension"));
+        assertFalse(normalized.containsKey("x"));
+    }
+
+    @Test
+    void normalizeAcceptsRelativeCoordinates() {
+        Map<String, Object> normalized = WalkUntilPrimitive.normalize(Map.of(
+                "x", "~3",
+                "y", "~",
+                "z", "~-1"
+        ));
+
+        assertEquals("~3", normalized.get("x"));
+        assertEquals("~", normalized.get("y"));
+        assertEquals("~-1", normalized.get("z"));
+        assertFalse(normalized.containsKey("dimension"));
+    }
+
+    @Test
+    void normalizeRejectsMixedIncompleteAndUnknown() {
+        ScenarioException mixed = assertThrows(
+                ScenarioException.class,
+                () -> WalkUntilPrimitive.normalize(Map.of(
+                        "dimension", "dwm:tardis",
+                        "x", "~1"))
+        );
+        ScenarioException incomplete = assertThrows(
+                ScenarioException.class,
+                () -> WalkUntilPrimitive.normalize(Map.of("x", 1, "y", 2))
+        );
+        ScenarioException empty = assertThrows(
+                ScenarioException.class,
+                () -> WalkUntilPrimitive.normalize(Map.of())
+        );
+        ScenarioException unknown = assertThrows(
+                ScenarioException.class,
+                () -> WalkUntilPrimitive.normalize(Map.of(
+                        "x", 1,
+                        "y", 2,
+                        "z", 3,
+                        "sprint", true))
+        );
+        ScenarioException blankDimension = assertThrows(
+                ScenarioException.class,
+                () -> WalkUntilPrimitive.normalize(Map.of("dimension", "  "))
+        );
+
+        assertTrue(mixed.getMessage().contains("walkUntil requires dimension, or x, y, and z"));
+        assertTrue(incomplete.getMessage().contains("walkUntil requires dimension, or x, y, and z"));
+        assertTrue(empty.getMessage().contains("walkUntil requires dimension, or x, y, and z"));
+        assertTrue(unknown.getMessage().contains("walkUntil does not accept 'sprint'"));
+        assertTrue(blankDimension.getMessage().contains("walkUntil dimension"));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Scenario tests could place and open a TARDIS but could not walk the player into the exterior, so interior entry stayed untested on the real client path.

## Proposed Implementation

- Add a `walkUntil` scenario primitive that holds forward (`keyUp`) until either a block cell (`x`/`y`/`z`) or a `dimension` id is reached.
- Position-mode relative coordinates are snapshotted to an absolute cell when forward is first held.
- Register it in `ScenarioPrimitives`, document it in the scenario README, and extend display names for dimension steps.
- Extend `placeAndOpenTardis` to `walkUntil` `dwm:tardis`, wait for settle, and capture `tardis-interior`.
- Add unit/compiler coverage for the new primitive and bundled scenario.

## Problems Encountered / Decisions Made

- Relative `walkUntil` targets must be fixed on the first ready tick; re-resolving `~N` each tick would keep the goal ahead of the player forever.

Validated with `./gradlew test --tests "com.adamkali.dwm.scenariotest.*"` and `./gradlew runScenarioTest -Pscenario=placeAndOpenTardis -PscenarioDisplay=xvfb -PscenarioTimeout=120` (20/20 steps passed, including `walkUntil dimension "dwm:tardis"` in ~1.1s).

![TARDIS door open exterior screenshot](https://cursor.com/artifacts/c/art-4491a57b-ef97-4059-8edb-c560e3e85911)
![TARDIS interior after walk-in screenshot](https://cursor.com/artifacts/c/art-4d6a33a4-6393-4c2c-b694-d99d4db1eac3)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d9a-c75c-76e8-93d4-c2e678516aba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d9a-c75c-76e8-93d4-c2e678516aba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

