### PR TITLE
Advisory scenario performance compare vs main on PRs

### DIFF
--- a/.github/scripts/compare-scenario-perf.py
+++ b/.github/scripts/compare-scenario-perf.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Compare scenario metrics.json trees against a baseline (advisory; always exits 0)."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+MARKER = "<!-- dwm-scenario-perf -->"
+DEFAULT_TOLERANCE = 0.20
+DEFAULT_FLOOR_MS = 50.0
+
+
+@dataclass(frozen=True)
+class MetricDelta:
+    label: str
+    baseline_ms: float | None
+    current_ms: float | None
+    status: str
+
+    @property
+    def delta_ms(self) -> float | None:
+        if self.baseline_ms is None or self.current_ms is None:
+            return None
+        return self.current_ms - self.baseline_ms
+
+    @property
+    def delta_pct(self) -> float | None:
+        if self.baseline_ms is None or self.current_ms is None:
+            return None
+        if self.baseline_ms == 0:
+            return None if self.current_ms == 0 else float("inf")
+        return (self.current_ms - self.baseline_ms) / self.baseline_ms * 100.0
+
+
+@dataclass(frozen=True)
+class ScenarioComparison:
+    scenario_id: str
+    total: MetricDelta
+    steps: list[MetricDelta]
+
+
+def classify(baseline_ms: float | None, current_ms: float | None, tolerance: float, floor_ms: float) -> str:
+    if baseline_ms is None and current_ms is None:
+        return "NO BASELINE"
+    if baseline_ms is None:
+        return "NO BASELINE"
+    if current_ms is None:
+        return "MISSING"
+    delta = current_ms - baseline_ms
+    threshold = baseline_ms * (1.0 + tolerance)
+    improved_threshold = baseline_ms * (1.0 - tolerance)
+    if current_ms > threshold and delta > floor_ms:
+        return "REGRESSED"
+    if current_ms < improved_threshold and (-delta) > floor_ms:
+        return "IMPROVED"
+    return "OK"
+
+
+def load_metrics_tree(root: Path) -> dict[str, dict[str, Any]]:
+    metrics: dict[str, dict[str, Any]] = {}
+    if not root.exists():
+        return metrics
+    for path in sorted(root.rglob("metrics.json")):
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+        scenario_id = data.get("scenarioId")
+        if not isinstance(scenario_id, str) or not scenario_id:
+            raise ValueError(f"metrics file missing scenarioId: {path}")
+        metrics[scenario_id] = data
+    return metrics
+
+
+def step_map(data: dict[str, Any] | None) -> dict[str, float]:
+    if data is None:
+        return {}
+    steps = data.get("steps") or []
+    out: dict[str, float] = {}
+    for step in steps:
+        name = step.get("name")
+        ms = step.get("ms")
+        if isinstance(name, str) and isinstance(ms, (int, float)):
+            out[name] = float(ms)
+    return out
+
+
+def compare_scenario(
+    scenario_id: str,
+    baseline: dict[str, Any] | None,
+    current: dict[str, Any] | None,
+    tolerance: float,
+    floor_ms: float,
+) -> ScenarioComparison:
+    baseline_total = None if baseline is None else float(baseline.get("totalMs", 0.0))
+    current_total = None if current is None else float(current.get("totalMs", 0.0))
+    total = MetricDelta(
+        label="totalMs",
+        baseline_ms=baseline_total,
+        current_ms=current_total,
+        status=classify(baseline_total, current_total, tolerance, floor_ms),
+    )
+
+    baseline_steps = step_map(baseline)
+    current_steps = step_map(current)
+    step_names = sorted(set(baseline_steps) | set(current_steps))
+    steps: list[MetricDelta] = []
+    for name in step_names:
+        b = baseline_steps.get(name)
+        c = current_steps.get(name)
+        # Only compare steps present in both; unpaired steps are informational NO BASELINE / MISSING
+        if b is None and c is not None:
+            status = "NO BASELINE"
+        elif b is not None and c is None:
+            status = "MISSING"
+        else:
+            status = classify(b, c, tolerance, floor_ms)
+        steps.append(MetricDelta(label=name, baseline_ms=b, current_ms=c, status=status))
+
+    return ScenarioComparison(scenario_id=scenario_id, total=total, steps=steps)
+
+
+def compare_trees(
+    current_dir: Path,
+    baseline_dir: Path,
+    tolerance: float,
+    floor_ms: float,
+) -> list[ScenarioComparison]:
+    current = load_metrics_tree(current_dir)
+    baseline = load_metrics_tree(baseline_dir)
+    scenario_ids = sorted(set(current) | set(baseline))
+    return [
+        compare_scenario(scenario_id, baseline.get(scenario_id), current.get(scenario_id), tolerance, floor_ms)
+        for scenario_id in scenario_ids
+    ]
+
+
+def format_ms(value: float | None) -> str:
+    if value is None:
+        return "—"
+    if abs(value) >= 1000.0:
+        return f"{value / 1000.0:.1f}s"
+    return f"{value:.1f}ms"
+
+
+def format_delta(delta: MetricDelta) -> str:
+    if delta.delta_ms is None:
+        return "—"
+    magnitude = abs(delta.delta_ms)
+    if magnitude >= 1000.0:
+        abs_part = f"{magnitude / 1000.0:.1f}s"
+    else:
+        abs_part = f"{magnitude:.1f}ms"
+    sign = "+" if delta.delta_ms >= 0 else "-"
+    pct = delta.delta_pct
+    if pct is None:
+        pct_part = ""
+    elif pct == float("inf"):
+        pct_part = " (n/a%)"
+    else:
+        pct_sign = "+" if pct >= 0 else ""
+        pct_part = f" ({pct_sign}{pct:.0f}%)"
+    return f"{sign}{abs_part}{pct_part}"
+
+
+def render_markdown(
+    comparisons: list[ScenarioComparison],
+    baseline_label: str,
+    tolerance: float,
+    floor_ms: float,
+) -> str:
+    lines: list[str] = [
+        MARKER,
+        "## Scenario performance vs main",
+        "",
+        f"Baseline: {baseline_label}",
+        "Advisory only — does not fail CI.",
+        "",
+        f"Regression rule: slower by more than {tolerance:.0%} **and** more than {floor_ms:.0f}ms.",
+        "",
+        "| Scenario | Baseline | Current | Delta | Status |",
+        "| --- | ---: | ---: | ---: | --- |",
+    ]
+    for comparison in comparisons:
+        total = comparison.total
+        lines.append(
+            f"| {comparison.scenario_id} | {format_ms(total.baseline_ms)} | "
+            f"{format_ms(total.current_ms)} | {format_delta(total)} | {total.status} |"
+        )
+
+    step_regressions = [
+        (comparison.scenario_id, step)
+        for comparison in comparisons
+        for step in comparison.steps
+        if step.status == "REGRESSED"
+    ]
+    lines.append("")
+    if step_regressions:
+        lines.append("### Step regressions")
+        for scenario_id, step in step_regressions:
+            lines.append(
+                f"- `{scenario_id}` / `{step.label}`: "
+                f"{format_ms(step.baseline_ms)} → {format_ms(step.current_ms)} ({format_delta(step)})"
+            )
+    else:
+        lines.append("### Step regressions")
+        lines.append("_None_")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--current-dir", type=Path, required=True)
+    parser.add_argument("--baseline-dir", type=Path, required=True)
+    parser.add_argument("--tolerance", type=float, default=DEFAULT_TOLERANCE)
+    parser.add_argument("--floor-ms", type=float, default=DEFAULT_FLOOR_MS)
+    parser.add_argument("--markdown-out", type=Path, required=True)
+    parser.add_argument(
+        "--baseline-label",
+        default="_none yet_",
+        help="Human-readable baseline description for the comment header",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    comparisons = compare_trees(args.current_dir, args.baseline_dir, args.tolerance, args.floor_ms)
+    markdown = render_markdown(comparisons, args.baseline_label, args.tolerance, args.floor_ms)
+    args.markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown_out.write_text(markdown, encoding="utf-8")
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with Path(summary_path).open("a", encoding="utf-8") as handle:
+            handle.write(markdown)
+            handle.write("\n")
+    print(markdown)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/run_compare_scenario_perf_fixtures.sh
+++ b/.github/scripts/run_compare_scenario_perf_fixtures.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Fixture checks for compare-scenario-perf.py (advisory; always expects exit 0).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT="$ROOT/compare-scenario-perf.py"
+DATA="$ROOT/testdata/scenario-perf"
+OUT="$(mktemp -d)"
+trap 'rm -rf "$OUT"' EXIT
+
+run_case() {
+  local name="$1"
+  local expect="$2"
+  python3 "$SCRIPT" \
+    --current-dir "$DATA/$name/current" \
+    --baseline-dir "$DATA/$name/baseline" \
+    --markdown-out "$OUT/$name.md" \
+    --baseline-label "fixture:$name" >/dev/null
+  local status
+  status="$(grep -E '^\| placeBlock' "$OUT/$name.md" | awk -F'|' '{gsub(/^ +| +$/,"",$6); print $6}')"
+  if [[ "$status" != "$expect" ]]; then
+    echo "FAIL $name: expected status '$expect', got '$status'" >&2
+    cat "$OUT/$name.md" >&2
+    exit 1
+  fi
+  if ! grep -q '<!-- dwm-scenario-perf -->' "$OUT/$name.md"; then
+    echo "FAIL $name: missing comment marker" >&2
+    exit 1
+  fi
+  echo "OK $name ($expect)"
+}
+
+run_case ok OK
+run_case regressed REGRESSED
+run_case no-baseline "NO BASELINE"
+run_case missing MISSING
+
+# REGRESSED case must still exit 0 (re-run capturing code).
+set +e
+python3 "$SCRIPT" \
+  --current-dir "$DATA/regressed/current" \
+  --baseline-dir "$DATA/regressed/baseline" \
+  --markdown-out "$OUT/regressed-exit.md" >/dev/null
+code=$?
+set -e
+if [[ "$code" -ne 0 ]]; then
+  echo "FAIL regressed exit code: expected 0, got $code" >&2
+  exit 1
+fi
+echo "OK regressed exit code 0"
+
+if ! grep -q 'waitUntil block' "$OUT/regressed.md"; then
+  echo "FAIL regressed: expected step regression details" >&2
+  exit 1
+fi
+echo "OK regressed step details"
+
+echo "All compare-scenario-perf fixtures passed."

--- a/.github/scripts/testdata/scenario-perf/missing/baseline/scenario-placeBlock/metrics.json
+++ b/.github/scripts/testdata/scenario-perf/missing/baseline/scenario-placeBlock/metrics.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "placeBlock",
+  "scenarioName": "Place Block",
+  "passed": true,
+  "totalMs": 10000.0,
+  "steps": [
+    {"name": "useItem", "ms": 10.0, "passed": true}
+  ]
+}

--- a/.github/scripts/testdata/scenario-perf/no-baseline/current/scenario-placeBlock/metrics.json
+++ b/.github/scripts/testdata/scenario-perf/no-baseline/current/scenario-placeBlock/metrics.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "placeBlock",
+  "scenarioName": "Place Block",
+  "passed": true,
+  "totalMs": 12000.0,
+  "steps": [
+    {"name": "useItem", "ms": 12.0, "passed": true}
+  ]
+}

--- a/.github/scripts/testdata/scenario-perf/ok/baseline/scenario-placeBlock/metrics.json
+++ b/.github/scripts/testdata/scenario-perf/ok/baseline/scenario-placeBlock/metrics.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "placeBlock",
+  "scenarioName": "Place Block",
+  "passed": true,
+  "totalMs": 10000.0,
+  "steps": [
+    {"name": "useItem", "ms": 10.0, "passed": true},
+    {"name": "waitUntil block \"minecraft:dirt\"", "ms": 40.0, "passed": true}
+  ]
+}

--- a/.github/scripts/testdata/scenario-perf/ok/current/scenario-placeBlock/metrics.json
+++ b/.github/scripts/testdata/scenario-perf/ok/current/scenario-placeBlock/metrics.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "placeBlock",
+  "scenarioName": "Place Block",
+  "passed": true,
+  "totalMs": 10500.0,
+  "steps": [
+    {"name": "useItem", "ms": 11.0, "passed": true},
+    {"name": "waitUntil block \"minecraft:dirt\"", "ms": 42.0, "passed": true}
+  ]
+}

--- a/.github/scripts/testdata/scenario-perf/regressed/baseline/scenario-placeBlock/metrics.json
+++ b/.github/scripts/testdata/scenario-perf/regressed/baseline/scenario-placeBlock/metrics.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "placeBlock",
+  "scenarioName": "Place Block",
+  "passed": true,
+  "totalMs": 10000.0,
+  "steps": [
+    {"name": "useItem", "ms": 10.0, "passed": true},
+    {"name": "waitUntil block \"minecraft:dirt\"", "ms": 40.0, "passed": true}
+  ]
+}

--- a/.github/scripts/testdata/scenario-perf/regressed/current/scenario-placeBlock/metrics.json
+++ b/.github/scripts/testdata/scenario-perf/regressed/current/scenario-placeBlock/metrics.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "scenarioId": "placeBlock",
+  "scenarioName": "Place Block",
+  "passed": true,
+  "totalMs": 15000.0,
+  "steps": [
+    {"name": "useItem", "ms": 10.0, "passed": true},
+    {"name": "waitUntil block \"minecraft:dirt\"", "ms": 200.0, "passed": true}
+  ]
+}

--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -2,9 +2,12 @@ name: Scenario Tests
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
 
 concurrency:
-  group: scenario-tests-${{ github.workflow }}-${{ github.ref }}
+  group: scenario-tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -65,7 +68,98 @@ jobs:
           name: scenario-${{ matrix.scenario }}
           path: |
             build/scenario-test/report.xml
+            build/scenario-test/metrics.json
             build/scenario-test/diagnostics.txt
             build/scenario-test/run/screenshots/
             build/scenario-test/vanilla-server/logs/
           if-no-files-found: ignore
+
+  compare-perf:
+    name: Compare scenario performance
+    needs: scenario
+    if: always() && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download current scenario artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: perf/current
+          pattern: scenario-*
+          merge-multiple: false
+
+      - name: Download latest green main baseline artifacts
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p perf/baseline
+          echo '_none yet_' > perf/baseline-label.txt
+          RUN_JSON="$(gh run list \
+            --workflow=scenario-tests.yml \
+            --branch=main \
+            --status=success \
+            --limit=1 \
+            --json databaseId,url)"
+          RUN_ID="$(echo "$RUN_JSON" | jq -r '.[0].databaseId // empty')"
+          RUN_URL="$(echo "$RUN_JSON" | jq -r '.[0].url // empty')"
+          if [[ -z "$RUN_ID" ]]; then
+            echo "No successful main Scenario Tests run found yet."
+            exit 0
+          fi
+          printf 'run [#%s](%s) on `main`\n' "$RUN_ID" "$RUN_URL" > perf/baseline-label.txt
+          gh run download "$RUN_ID" -D perf/baseline || true
+
+      - name: Compare metrics (advisory)
+        run: |
+          python3 .github/scripts/compare-scenario-perf.py \
+            --current-dir perf/current \
+            --baseline-dir perf/baseline \
+            --markdown-out perf/comment.md \
+            --baseline-label "$(cat perf/baseline-label.txt)"
+
+      - name: Upsert PR performance comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- dwm-scenario-perf -->';
+            const body = fs.readFileSync('perf/comment.md', 'utf8');
+            if (!body.includes(marker)) {
+              throw new Error('compare output missing marker ' + marker);
+            }
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) =>
+              comment.body && comment.body.includes(marker)
+            );
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing scenario perf comment ${existing.id}`);
+            } else {
+              const created = await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+              core.info(`Created scenario perf comment ${created.data.id}`);
+            }

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ tools/fixtures/*.mp3
 tools/fixtures/*.ogg
 tools/fixtures/compare_out/
 
+# scenario harness local perf metrics (CI uploads artifacts; never commit run output)
+build/scenario-test/metrics.json
+
 # accidental dependency jar extracts at repo root
 /LICENSE-fabric-rendering-v1
 /META-INF/

--- a/src/scenarioTest/AGENTS.md
+++ b/src/scenarioTest/AGENTS.md
@@ -11,9 +11,10 @@ Full step/selector reference: `README.md` in this directory.
 ## Commands
 - Run a scenario: `./gradlew runScenarioTest -Pscenario=<yaml-filename-stem>`
 - Override step timeout (seconds): `-PscenarioTimeout=60`
-- Reports: `build/scenario-test/report.xml`, `build/scenario-test/diagnostics.txt`
+- Reports: `build/scenario-test/report.xml`, `build/scenario-test/metrics.json`, `build/scenario-test/diagnostics.txt`
 - Screenshots: `build/scenario-test/run/screenshots/`
 - Vanilla server harness dir: `build/scenario-test/vanilla-server/`
+- Perf compare fixtures: `.github/scripts/run_compare_scenario_perf_fixtures.sh`
 
 ## Conventions
 - YAML files live recursively under `resources/tests/`. Role is set by frontmatter `type`: `test` (runnable) or `command` (composite).
@@ -21,10 +22,11 @@ Full step/selector reference: `README.md` in this directory.
 - Add new behaviour as a `ScenarioPrimitive` in `primitive/`, register it in `ScenarioPrimitives`, and add JUnit coverage in `src/test/java/.../scenariotest/`.
 - Composite commands use `{{ parameter }}` templating; cycles and unknown steps fail at compile time.
 - Selectors match exact widget `name` + `type` (`button`, `cycle`, `tab`, `editbox`, `label`, `screen`).
+- Perf metrics stay under `build/scenario-test/metrics.json` (gitignored). CI uploads them; PRs get an advisory upserted comment vs the latest green `main` Scenario Tests artifacts (20% + 50ms floor; does not fail CI).
 
 ## Common Pitfalls
-- **Display required** — unlike GameTests, this harness boots the client; it will not run headless in Cursor Cloud.
-- **Not in CI** — `./gradlew build` compiles this source set but does not execute scenarios.
+- **Display required** — unlike GameTests, this harness boots the client; it will not run headless in Cursor Cloud without `xvfb`.
+- **Scenario execution is a separate workflow** — `./gradlew build` compiles this source set but does not run scenarios; see `.github/workflows/scenario-tests.yml`.
 - Each run deletes saved worlds under `build/scenario-test/run/saves` and clears `build/scenario-test/vanilla-server/world`.
 - `startVanillaServer` and `createWorld` use a 120s timeout floor; `-PscenarioTimeout` only raises it.
 - `runCommand` sends packets immediately — pair with `waitUntil` for inventory/world assertions.

--- a/src/scenarioTest/AGENTS.md
+++ b/src/scenarioTest/AGENTS.md
@@ -22,7 +22,7 @@ Full step/selector reference: `README.md` in this directory.
 - Add new behaviour as a `ScenarioPrimitive` in `primitive/`, register it in `ScenarioPrimitives`, and add JUnit coverage in `src/test/java/.../scenariotest/`.
 - Composite commands use `{{ parameter }}` templating; cycles and unknown steps fail at compile time.
 - Selectors match exact widget `name` + `type` (`button`, `cycle`, `tab`, `editbox`, `label`, `screen`).
-- Perf metrics stay under `build/scenario-test/metrics.json` (gitignored). CI uploads them; PRs get an advisory upserted comment vs the latest green `main` Scenario Tests artifacts (20% + 50ms floor; does not fail CI).
+- Perf metrics stay under `build/scenario-test/metrics.json` (listed in `.gitignore`; never commit local runs). CI uploads them as artifacts; PRs get an advisory upserted comment vs the latest green `main` Scenario Tests artifacts (20% + 50ms floor; does not fail CI).
 
 ## Common Pitfalls
 - **Display required** — unlike GameTests, this harness boots the client; it will not run headless in Cursor Cloud without `xvfb`.

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -42,7 +42,7 @@ Results are written to:
 
 - `build/scenario-test/report.xml` — JUnit XML
 - `build/scenario-test/metrics.json` — wall-clock step timings for perf compare
-  (under `build/`, so local runs are gitignored)
+  (gitignored; CI uploads the file as a workflow artifact)
 - `build/scenario-test/diagnostics.txt` — current screen and visible widgets
 - `build/scenario-test/run/screenshots/` — PNGs from `captureScreenshot`
 - `build/scenario-test/vanilla-server/` — official dedicated-server run dir from

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -41,6 +41,8 @@ slow soft-GL CI runs):
 Results are written to:
 
 - `build/scenario-test/report.xml` — JUnit XML
+- `build/scenario-test/metrics.json` — wall-clock step timings for perf compare
+  (under `build/`, so local runs are gitignored)
 - `build/scenario-test/diagnostics.txt` — current screen and visible widgets
 - `build/scenario-test/run/screenshots/` — PNGs from `captureScreenshot`
 - `build/scenario-test/vanilla-server/` — official dedicated-server run dir from
@@ -48,6 +50,23 @@ Results are written to:
   `world/`, `logs/harness.log`)
 
 The Gradle process exits non-zero when loading, validation, or execution fails.
+
+### Performance vs main (CI)
+
+The [Scenario Tests](../../.github/workflows/scenario-tests.yml) workflow uploads
+`metrics.json` with each matrix artifact. On pull requests, a follow-up job
+downloads the latest successful `main` run’s artifacts, compares totals and
+matching step names with
+[`.github/scripts/compare-scenario-perf.py`](../../.github/scripts/compare-scenario-perf.py)
+(default: 20% slower **and** more than 50ms), and upserts a single PR comment
+marked `<!-- dwm-scenario-perf -->`. The compare is **advisory** — regressions
+do not fail CI.
+
+Local fixture check for the compare script:
+
+```bash
+.github/scripts/run_compare_scenario_perf_fixtures.sh
+```
 
 ## Files and discovery
 

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -42,7 +42,7 @@ Results are written to:
 
 - `build/scenario-test/report.xml` — JUnit XML
 - `build/scenario-test/metrics.json` — wall-clock step timings for perf compare
-  (gitignored; CI uploads the file as a workflow artifact)
+  (listed in `.gitignore`; CI uploads the file as a workflow artifact)
 - `build/scenario-test/diagnostics.txt` — current screen and visible widgets
 - `build/scenario-test/run/screenshots/` — PNGs from `captureScreenshot`
 - `build/scenario-test/vanilla-server/` — official dedicated-server run dir from

--- a/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioReportWriter.java
+++ b/src/scenarioTest/java/com/adamkali/dwm/scenariotest/ScenarioReportWriter.java
@@ -5,12 +5,19 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
 
 final class ScenarioReportWriter {
+    static final int METRICS_SCHEMA_VERSION = 1;
+
     private final Path reportFile;
 
     ScenarioReportWriter(Path reportFile) {
         this.reportFile = reportFile;
+    }
+
+    Path metricsFile() {
+        return reportFile.resolveSibling("metrics.json");
     }
 
     void write(ScenarioPlan plan, List<StepResult> results, String failure, String diagnostics) {
@@ -22,6 +29,7 @@ final class ScenarioReportWriter {
                     diagnostics == null || diagnostics.isBlank() ? "No diagnostics.\n" : diagnostics,
                     StandardCharsets.UTF_8
             );
+            Files.writeString(metricsFile(), metricsJson(plan, results, failure), StandardCharsets.UTF_8);
         } catch (IOException exception) {
             throw new ScenarioException("Could not write scenario report to " + reportFile, exception);
         }
@@ -32,16 +40,71 @@ final class ScenarioReportWriter {
         write(plan, List.of(), message(failure), message(failure) + "\n");
     }
 
+    static String metricsJson(ScenarioPlan plan, List<StepResult> results, String failure) {
+        long totalNanos = results.stream().mapToLong(StepResult::durationNanos).sum();
+        StringBuilder json = new StringBuilder();
+        json.append("{\n")
+                .append("  \"schemaVersion\": ").append(METRICS_SCHEMA_VERSION).append(",\n")
+                .append("  \"scenarioId\": ").append(jsonString(plan.id())).append(",\n")
+                .append("  \"scenarioName\": ").append(jsonString(plan.name())).append(",\n")
+                .append("  \"passed\": ").append(failure == null).append(",\n")
+                .append("  \"totalMs\": ").append(formatMs(totalNanos)).append(",\n")
+                .append("  \"steps\": [");
+        for (int i = 0; i < results.size(); i++) {
+            StepResult result = results.get(i);
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("\n    {")
+                    .append("\"name\": ").append(jsonString(result.name())).append(", ")
+                    .append("\"ms\": ").append(formatMs(result.durationNanos())).append(", ")
+                    .append("\"passed\": ").append(result.passed())
+                    .append('}');
+        }
+        if (!results.isEmpty()) {
+            json.append('\n').append("  ");
+        }
+        json.append("]\n}\n");
+        return json.toString();
+    }
+
+    private static String formatMs(long durationNanos) {
+        return String.format(Locale.ROOT, "%.1f", durationNanos / 1_000_000.0);
+    }
+
+    private static String jsonString(String value) {
+        StringBuilder escaped = new StringBuilder("\"");
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\' -> escaped.append("\\\\");
+                case '"' -> escaped.append("\\\"");
+                case '\n' -> escaped.append("\\n");
+                case '\r' -> escaped.append("\\r");
+                case '\t' -> escaped.append("\\t");
+                default -> {
+                    if (c < 0x20) {
+                        escaped.append(String.format(Locale.ROOT, "\\u%04x", (int) c));
+                    } else {
+                        escaped.append(c);
+                    }
+                }
+            }
+        }
+        escaped.append('"');
+        return escaped.toString();
+    }
+
     private static String xml(ScenarioPlan plan, List<StepResult> results, String failure) {
         int failureCount = failure == null ? 0 : 1;
         double duration = results.stream().mapToLong(StepResult::durationNanos).sum() / 1_000_000_000.0;
         StringBuilder xml = new StringBuilder();
         xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
                 .append("<testsuite name=\"").append(escape(plan.name())).append("\" tests=\"1\" failures=\"")
-                .append(failureCount).append("\" time=\"").append(String.format(java.util.Locale.ROOT, "%.3f", duration))
+                .append(failureCount).append("\" time=\"").append(String.format(Locale.ROOT, "%.3f", duration))
                 .append("\">\n")
                 .append("  <testcase classname=\"dwm.scenario\" name=\"").append(escape(plan.id()))
-                .append("\" time=\"").append(String.format(java.util.Locale.ROOT, "%.3f", duration)).append("\">");
+                .append("\" time=\"").append(String.format(Locale.ROOT, "%.3f", duration)).append("\">");
         if (failure != null) {
             xml.append("\n    <failure message=\"").append(escape(failure)).append("\">")
                     .append(escape(failure)).append("</failure>\n  ");
@@ -58,7 +121,7 @@ final class ScenarioReportWriter {
             summary.append(result.passed() ? "PASS " : "FAIL ")
                     .append(result.name())
                     .append(" (")
-                    .append(String.format(java.util.Locale.ROOT, "%.3fs", result.durationNanos() / 1_000_000_000.0))
+                    .append(String.format(Locale.ROOT, "%.3fs", result.durationNanos() / 1_000_000_000.0))
                     .append(")\n");
         }
         return summary.toString();

--- a/src/test/java/com/adamkali/dwm/scenariotest/ScenarioReportWriterTest.java
+++ b/src/test/java/com/adamkali/dwm/scenariotest/ScenarioReportWriterTest.java
@@ -1,0 +1,88 @@
+package com.adamkali.dwm.scenariotest;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScenarioReportWriterTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void metricsJson_includesSchemaScenarioTotalsAndSteps() {
+        ScenarioPlan plan = new ScenarioPlan("placeBlock", "Place Block", List.of());
+        List<ScenarioReportWriter.StepResult> results = List.of(
+                new ScenarioReportWriter.StepResult("useItem", 12_300_000L, true),
+                new ScenarioReportWriter.StepResult("waitUntil block \"minecraft:dirt\"", 48_000_000L, true)
+        );
+
+        JSONObject json = new JSONObject(ScenarioReportWriter.metricsJson(plan, results, null));
+
+        assertEquals(ScenarioReportWriter.METRICS_SCHEMA_VERSION, json.getInt("schemaVersion"));
+        assertEquals("placeBlock", json.getString("scenarioId"));
+        assertEquals("Place Block", json.getString("scenarioName"));
+        assertTrue(json.getBoolean("passed"));
+        assertEquals(60.3, json.getDouble("totalMs"), 0.001);
+        JSONArray steps = json.getJSONArray("steps");
+        assertEquals(2, steps.length());
+        assertEquals("useItem", steps.getJSONObject(0).getString("name"));
+        assertEquals(12.3, steps.getJSONObject(0).getDouble("ms"), 0.001);
+        assertTrue(steps.getJSONObject(0).getBoolean("passed"));
+        assertEquals("waitUntil block \"minecraft:dirt\"", steps.getJSONObject(1).getString("name"));
+        assertEquals(48.0, steps.getJSONObject(1).getDouble("ms"), 0.001);
+    }
+
+    @Test
+    void metricsJson_marksFailedWhenFailurePresent() {
+        ScenarioPlan plan = new ScenarioPlan("createWorld", "Create World", List.of());
+        String json = ScenarioReportWriter.metricsJson(
+                plan,
+                List.of(new ScenarioReportWriter.StepResult("launchGame", 1_000_000L, false)),
+                "Timed out"
+        );
+
+        JSONObject parsed = new JSONObject(json);
+        assertFalse(parsed.getBoolean("passed"));
+        assertFalse(parsed.getJSONArray("steps").getJSONObject(0).getBoolean("passed"));
+        assertEquals(1.0, parsed.getDouble("totalMs"), 0.001);
+    }
+
+    @Test
+    void metricsJson_bootstrapFailureHasEmptySteps() {
+        ScenarioPlan plan = new ScenarioPlan("broken", "broken", List.of());
+        JSONObject json = new JSONObject(ScenarioReportWriter.metricsJson(plan, List.of(), "boom"));
+
+        assertFalse(json.getBoolean("passed"));
+        assertEquals(0.0, json.getDouble("totalMs"), 0.001);
+        assertEquals(0, json.getJSONArray("steps").length());
+    }
+
+    @Test
+    void write_emitsMetricsBesideReport() throws Exception {
+        Path reportFile = tempDir.resolve("report.xml");
+        ScenarioReportWriter writer = new ScenarioReportWriter(reportFile);
+        ScenarioPlan plan = new ScenarioPlan("placeBlock", "Place Block", List.of());
+        List<ScenarioReportWriter.StepResult> results = List.of(
+                new ScenarioReportWriter.StepResult("useItem", 5_000_000L, true)
+        );
+
+        writer.write(plan, results, null, "ok\n");
+
+        Path metricsFile = writer.metricsFile();
+        assertTrue(Files.isRegularFile(metricsFile));
+        JSONObject json = new JSONObject(Files.readString(metricsFile));
+        assertEquals("placeBlock", json.getString("scenarioId"));
+        assertEquals(5.0, json.getDouble("totalMs"), 0.001);
+        assertTrue(Files.isRegularFile(reportFile));
+        assertTrue(Files.isRegularFile(tempDir.resolve("diagnostics.txt")));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Scenario runs already timed each step, but there was no way to see whether a PR made place/interact (or other scenarios) slower than `main`.
- An advisory, upserted PR comment gives reviewers a clear before/after without failing CI on noisy xvfb timings.

## Proposed Implementation

- Emit `build/scenario-test/metrics.json` (schema v1: scenario id, totalMs, per-step ms) beside the existing report from `ScenarioReportWriter`.
- Explicitly list `build/scenario-test/metrics.json` in `.gitignore` so local run output is never committed; CI still uploads it as a workflow artifact.
- Upload `metrics.json` from Scenario Tests CI; run the workflow on `pull_request` as well as `main` pushes.
- On PRs, download the latest green `main` Scenario Tests artifacts, run `.github/scripts/compare-scenario-perf.py` (20% + 50ms floor), and upsert a single PR comment marked `<!-- dwm-scenario-perf -->`.
- Regressions are labeled in the comment only; the compare job does not fail CI for perf outcomes.
- Documented in `src/scenarioTest/README.md` and `AGENTS.md`; fixture runner at `.github/scripts/run_compare_scenario_perf_fixtures.sh`.

## Problems Encountered / Decisions Made

- Kept baselines out of git: local metrics are gitignored; only CI artifacts carry timings for compare.
- Chose advisory-only gating so soft-GL xvfb variance does not block merges.
- Compared wall-clock totals and matching step display names only (no frame hitch sampling in this pass).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02d9b-47a2-7367-8f91-36f5f5cd65ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02d9b-47a2-7367-8f91-36f5f5cd65ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

