### PR TITLE
feat(scenariotest): auto-discover and run all scenario tests

### DIFF
--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -13,14 +13,7 @@ concurrency:
 jobs:
   scenario:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        scenario:
-          - createWorld
-          - placeBlock
-          - joinVanillaServer
+    timeout-minutes: 120
 
     steps:
       - name: Checkout
@@ -50,11 +43,10 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run scenario (${{ matrix.scenario }})
+      - name: Run all scenario tests
         run: |
           chmod +x ./gradlew
-          ./gradlew runScenarioTest \
-            -Pscenario=${{ matrix.scenario }} \
+          ./gradlew runAllScenarioTests \
             -PscenarioDisplay=xvfb \
             -PscenarioTimeout=120
         env:
@@ -65,8 +57,9 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: scenario-${{ matrix.scenario }}
+          name: scenario-tests
           path: |
+            build/scenario-test/results/
             build/scenario-test/report.xml
             build/scenario-test/metrics.json
             build/scenario-test/diagnostics.txt

--- a/build.gradle
+++ b/build.gradle
@@ -198,6 +198,13 @@ def discoverScenarioTestIds = {
     return ids as List
 }
 
+interface ScenarioTestExecOps {
+    @javax.inject.Inject
+    org.gradle.process.ExecOperations getExecOps()
+}
+
+def scenarioTestExecOps = objects.newInstance(ScenarioTestExecOps)
+
 tasks.register("runAllScenarioTests") {
     group = "verification"
     description = "Discover all type:test YAML scenarios and run each via runScenarioTest"
@@ -206,6 +213,7 @@ tasks.register("runAllScenarioTests") {
     def timeoutProperty = providers.gradleProperty("scenarioTimeout")
     def projectDirFile = layout.projectDirectory.asFile
     def resultsRoot = layout.buildDirectory.dir("scenario-test/results")
+    def execOps = scenarioTestExecOps.execOps
 
     doLast {
         def scenarioIds = discoverScenarioTestIds()
@@ -219,7 +227,7 @@ tasks.register("runAllScenarioTests") {
         def gradleCommand = gradleWrapper.exists() ? gradleWrapper.absolutePath : "gradle"
         def failed = []
         def resultsDir = resultsRoot.get().asFile
-        delete(resultsDir)
+        project.delete(resultsDir)
         resultsDir.mkdirs()
 
         scenarioIds.each { String scenarioId ->
@@ -229,7 +237,7 @@ tasks.register("runAllScenarioTests") {
             if (timeoutProperty.isPresent()) {
                 args << "-PscenarioTimeout=${timeoutProperty.get()}"
             }
-            def result = exec {
+            def result = execOps.exec {
                 workingDir projectDirFile
                 commandLine args
                 ignoreExitValue = true
@@ -240,13 +248,17 @@ tasks.register("runAllScenarioTests") {
             ["report.xml", "metrics.json", "diagnostics.txt"].each { String fileName ->
                 def source = new File(projectDirFile, "build/scenario-test/${fileName}")
                 if (source.isFile()) {
-                    ant.copy(file: source, tofile: new File(archiveDir, fileName))
+                    project.copy {
+                        from source
+                        into archiveDir
+                    }
                 }
             }
             def screenshots = new File(projectDirFile, "build/scenario-test/run/screenshots")
             if (screenshots.isDirectory()) {
-                ant.copy(todir: new File(archiveDir, "screenshots")) {
-                    fileset(dir: screenshots)
+                project.copy {
+                    from screenshots
+                    into new File(archiveDir, "screenshots")
                 }
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -163,6 +163,110 @@ tasks.named("runScenarioTest").configure {
     }
 }
 
+def scenarioTestsRoot = file("src/scenarioTest/resources/tests")
+
+def isScenarioTestYaml = { File yamlFile ->
+    def text = yamlFile.getText("UTF-8").replace("\r\n", "\n")
+    if (!text.startsWith("---\n")) {
+        return false
+    }
+    def closing = text.indexOf("\n---\n", 4)
+    if (closing < 0) {
+        return false
+    }
+    return text.substring(4, closing).readLines().any { line ->
+        line.trim() == "type: test"
+    }
+}
+
+def discoverScenarioTestIds = {
+    if (!scenarioTestsRoot.isDirectory()) {
+        throw new GradleException("Scenario tests directory not found: ${scenarioTestsRoot}")
+    }
+    def ids = [] as TreeSet
+    fileTree(dir: scenarioTestsRoot, includes: ["**/*.yaml", "**/*.yml"]).files.each { File yamlFile ->
+        if (!isScenarioTestYaml(yamlFile)) {
+            return
+        }
+        def name = yamlFile.name
+        def extension = name.lastIndexOf('.')
+        def id = extension < 0 ? name : name.substring(0, extension)
+        if (!ids.add(id)) {
+            throw new GradleException("Duplicate scenario test id '${id}' under ${scenarioTestsRoot}")
+        }
+    }
+    return ids as List
+}
+
+tasks.register("runAllScenarioTests") {
+    group = "verification"
+    description = "Discover all type:test YAML scenarios and run each via runScenarioTest"
+
+    def displayMode = scenarioDisplayMode
+    def timeoutProperty = providers.gradleProperty("scenarioTimeout")
+    def projectDirFile = layout.projectDirectory.asFile
+    def resultsRoot = layout.buildDirectory.dir("scenario-test/results")
+
+    doLast {
+        def scenarioIds = discoverScenarioTestIds()
+        if (scenarioIds.isEmpty()) {
+            throw new GradleException("No scenario tests (type: test) found under ${scenarioTestsRoot}")
+        }
+
+        logger.lifecycle("Discovered ${scenarioIds.size()} scenario test(s): ${scenarioIds.join(', ')}")
+
+        def gradleWrapper = new File(projectDirFile, "gradlew")
+        def gradleCommand = gradleWrapper.exists() ? gradleWrapper.absolutePath : "gradle"
+        def failed = []
+        def resultsDir = resultsRoot.get().asFile
+        delete(resultsDir)
+        resultsDir.mkdirs()
+
+        scenarioIds.each { String scenarioId ->
+            logger.lifecycle("Running scenario test '${scenarioId}'")
+            def args = [gradleCommand, "runScenarioTest", "-Pscenario=${scenarioId}"]
+            args << "-PscenarioDisplay=${displayMode.get()}"
+            if (timeoutProperty.isPresent()) {
+                args << "-PscenarioTimeout=${timeoutProperty.get()}"
+            }
+            def result = exec {
+                workingDir projectDirFile
+                commandLine args
+                ignoreExitValue = true
+            }
+
+            def archiveDir = new File(resultsDir, scenarioId)
+            archiveDir.mkdirs()
+            ["report.xml", "metrics.json", "diagnostics.txt"].each { String fileName ->
+                def source = new File(projectDirFile, "build/scenario-test/${fileName}")
+                if (source.isFile()) {
+                    ant.copy(file: source, tofile: new File(archiveDir, fileName))
+                }
+            }
+            def screenshots = new File(projectDirFile, "build/scenario-test/run/screenshots")
+            if (screenshots.isDirectory()) {
+                ant.copy(todir: new File(archiveDir, "screenshots")) {
+                    fileset(dir: screenshots)
+                }
+            }
+
+            if (result.exitValue != 0) {
+                failed << scenarioId
+                logger.error("Scenario test '${scenarioId}' failed (exit ${result.exitValue})")
+            } else {
+                logger.lifecycle("Scenario test '${scenarioId}' passed")
+            }
+        }
+
+        if (!failed.isEmpty()) {
+            throw new GradleException(
+                    "Failed scenario test(s): ${failed.join(', ')} "
+                            + "(${failed.size()} of ${scenarioIds.size()})")
+        }
+        logger.lifecycle("All ${scenarioIds.size()} scenario test(s) passed")
+    }
+}
+
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${project.minecraft_version}"

--- a/src/scenarioTest/AGENTS.md
+++ b/src/scenarioTest/AGENTS.md
@@ -10,8 +10,11 @@ Full step/selector reference: `README.md` in this directory.
 
 ## Commands
 - Run a scenario: `./gradlew runScenarioTest -Pscenario=<yaml-filename-stem>`
+- Run all discovered `type: test` scenarios: `./gradlew runAllScenarioTests`
 - Override step timeout (seconds): `-PscenarioTimeout=60`
+- Display mode: `-PscenarioDisplay=display|xvfb` (default `display`)
 - Reports: `build/scenario-test/report.xml`, `build/scenario-test/metrics.json`, `build/scenario-test/diagnostics.txt`
+- Per-scenario archives from `runAllScenarioTests`: `build/scenario-test/results/<id>/`
 - Screenshots: `build/scenario-test/run/screenshots/`
 - Vanilla server harness dir: `build/scenario-test/vanilla-server/`
 - Perf compare fixtures: `.github/scripts/run_compare_scenario_perf_fixtures.sh`
@@ -25,8 +28,8 @@ Full step/selector reference: `README.md` in this directory.
 - Perf metrics stay under `build/scenario-test/metrics.json` (listed in `.gitignore`; never commit local runs). CI uploads them as artifacts; PRs get an advisory upserted comment vs the latest green `main` Scenario Tests artifacts (20% + 50ms floor; does not fail CI).
 
 ## Common Pitfalls
-- **Display required** — unlike GameTests, this harness boots the client; it will not run headless in Cursor Cloud without `xvfb`.
-- **Scenario execution is a separate workflow** — `./gradlew build` compiles this source set but does not run scenarios; see `.github/workflows/scenario-tests.yml`.
+- **Display required** — unlike GameTests, this harness boots the client; use `-PscenarioDisplay=xvfb` for headless/CI Linux runs.
+- **CI** — `.github/workflows/scenario-tests.yml` runs `./gradlew runAllScenarioTests` with xvfb. `./gradlew build` compiles this source set but does not execute scenarios.
 - Each run deletes saved worlds under `build/scenario-test/run/saves` and clears `build/scenario-test/vanilla-server/world`.
 - `startVanillaServer` and `createWorld` use a 120s timeout floor; `-PscenarioTimeout` only raises it.
 - `runCommand` sends packets immediately — pair with `waitUntil` for inventory/world assertions.

--- a/src/scenarioTest/README.md
+++ b/src/scenarioTest/README.md
@@ -12,6 +12,17 @@ Run a test by its YAML filename without the extension:
 ./gradlew runScenarioTest -Pscenario=createWorld
 ```
 
+Discover every `type: test` YAML under `resources/tests/` and run each one
+(fresh client per scenario):
+
+```bash
+./gradlew runAllScenarioTests
+./gradlew runAllScenarioTests -PscenarioDisplay=xvfb -PscenarioTimeout=120
+```
+
+`runAllScenarioTests` skips `type: command` documents, continues after individual
+failures, and fails the aggregate with the list of failed scenario IDs.
+
 The client uses an isolated directory under `build/scenario-test/run`. Before
 each run, the harness removes its saved worlds, clears
 `build/scenario-test/vanilla-server/world`, and writes deterministic English
@@ -45,6 +56,8 @@ Results are written to:
   (listed in `.gitignore`; CI uploads the file as a workflow artifact)
 - `build/scenario-test/diagnostics.txt` — current screen and visible widgets
 - `build/scenario-test/run/screenshots/` — PNGs from `captureScreenshot`
+- `build/scenario-test/results/<id>/` — per-scenario copies of report, metrics,
+  diagnostics, and screenshots written by `runAllScenarioTests`
 - `build/scenario-test/vanilla-server/` — official dedicated-server run dir from
   `startVanillaServer` (`server-jar.path`, `eula.txt`, `server.properties`,
   `world/`, `logs/harness.log`)
@@ -53,8 +66,9 @@ The Gradle process exits non-zero when loading, validation, or execution fails.
 
 ### Performance vs main (CI)
 
-The [Scenario Tests](../../.github/workflows/scenario-tests.yml) workflow uploads
-`metrics.json` with each matrix artifact. On pull requests, a follow-up job
+The [Scenario Tests](../../.github/workflows/scenario-tests.yml) workflow runs
+`runAllScenarioTests` and uploads `build/scenario-test/results/*/metrics.json`
+(plus the last-run top-level files). On pull requests, a follow-up job
 downloads the latest successful `main` run’s artifacts, compares totals and
 matching step names with
 [`.github/scripts/compare-scenario-perf.py`](../../.github/scripts/compare-scenario-perf.py)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Adding a new YAML scenario currently requires remembering to pass `-Pscenario=<id>` locally and hardcoding it in the CI matrix, so new tests are easy to miss.
- One discovery-driven aggregate task keeps local runs and CI aligned as the suite grows.

## Proposed Implementation

- Add `runAllScenarioTests` in `build.gradle`: discover every `type: test` YAML under `src/scenarioTest/resources/tests/`, log the IDs, and run nested `runScenarioTest` once per ID (fresh client / prepare each time).
- Archive per-scenario `report.xml`, `metrics.json`, diagnostics, and screenshots under `build/scenario-test/results/<id>/` so perf compare still finds metrics via `rglob`.
- Document the task in `src/scenarioTest/README.md` and `AGENTS.md`.
- Switch `.github/workflows/scenario-tests.yml` from a hardcoded matrix to a single `runAllScenarioTests` xvfb job (keeps the advisory perf-compare follow-up).

## Problems Encountered / Decisions Made

- Kept one-scenario-per-client via nested Gradle invocations instead of looping inside the client process, so `prepareScenarioTestRun` still clears state between tests.
- No separate `listScenarioTests` task; discovery lives only inside `runAllScenarioTests`.
- Per-scenario result archives were added so CI metrics compare keeps working after dropping the matrix.
- Gradle 9 removed `Project.exec` from Task `doLast` resolution; the runner uses injected `ExecOperations`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a028b2-d2c2-70c7-9a79-ec172a148747?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a028b2-d2c2-70c7-9a79-ec172a148747&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

