### PR TITLE
feat(ci): publish Screenplay to Modrinth

### DIFF
--- a/.github/workflows/create-screenplay-release-tag.yml
+++ b/.github/workflows/create-screenplay-release-tag.yml
@@ -1,0 +1,78 @@
+name: Create Screenplay Release Tag
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Resolve tag from metadata/screenplay/version.json
+        id: resolve
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = json.loads(Path("metadata/screenplay/version.json").read_text(encoding="utf-8"))
+          latest = (root.get("promos") or {}).get("latest")
+          if not latest or not isinstance(latest, str):
+              raise SystemExit(
+                  "metadata/screenplay/version.json promos.latest is missing or not a string"
+              )
+
+          if not re.fullmatch(r"\d+\.\d+\.\d+\+\d+\.\d+(?:\.\d+)?", latest):
+              raise SystemExit(
+                  f"promos.latest {latest!r} does not match "
+                  "screenplay_version (e.g. 1.0.0+26.2)"
+              )
+
+          tag = f"screenplay-v{latest}"
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"latest={latest}\n")
+              out.write(f"tag={tag}\n")
+          print(f"Resolved tag {tag} from promos.latest={latest}")
+          PY
+
+      - name: Create and push tag if missing
+        id: tag
+        env:
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q .; then
+            echo "Tag ${TAG} already exists on origin; nothing to do."
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${TAG}" -m "Release ${TAG}"
+          git push origin "${TAG}"
+          echo "Created and pushed tag ${TAG}."
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      # GITHUB_TOKEN pushes do not trigger other workflows; dispatch Release Screenplay explicitly.
+      - name: Trigger Release Screenplay workflow
+        if: steps.tag.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.resolve.outputs.tag }}
+        run: |
+          gh workflow run release-screenplay.yml --ref "${TAG}"
+          echo "Dispatched Release Screenplay workflow for ${TAG}."

--- a/.github/workflows/release-screenplay.yml
+++ b/.github/workflows/release-screenplay.yml
@@ -1,0 +1,184 @@
+name: Release Screenplay
+
+on:
+  push:
+    tags:
+      - "screenplay-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Resolve versions
+        id: version
+        run: |
+          SCREENPLAY_VERSION=$(./gradlew properties -q | awk '/^screenplay_version:/ { print $2; exit }')
+          MINECRAFT_VERSION=$(./gradlew properties -q | awk '/^minecraft_version:/ { print $2; exit }')
+          echo "screenplay_version=${SCREENPLAY_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "minecraft_version=${MINECRAFT_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Screenplay loaders
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :screenplay-fabric:build
+          ./gradlew -p screenplay-loaders :forge:build :neoforge:build
+        env:
+          _JAVA_OPTIONS: -Xmx3200m
+          GRADLE_OPTS: -Dorg.gradle.daemon=false
+
+      - name: Generate release notes
+        id: notes
+        env:
+          TAG: ${{ github.ref_name }}
+          SCREENPLAY_VERSION: ${{ steps.version.outputs.screenplay_version }}
+          MINECRAFT_VERSION: ${{ steps.version.outputs.minecraft_version }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          tag = os.environ["TAG"]
+          screenplay_version = os.environ["SCREENPLAY_VERSION"]
+          minecraft_version = os.environ["MINECRAFT_VERSION"]
+
+          prefix = "screenplay-v"
+          if not tag.startswith(prefix):
+              raise SystemExit(
+                  f"Tag {tag!r} does not match screenplay-v{{screenplay_version}} "
+                  f"(e.g. screenplay-v1.0.0+26.2)"
+              )
+          version = tag[len(prefix):]
+          if version != screenplay_version:
+              raise SystemExit(
+                  f"Tag version {version!r} does not match gradle screenplay_version "
+                  f"{screenplay_version!r}"
+              )
+
+          root = json.loads(Path("metadata/screenplay/version.json").read_text(encoding="utf-8"))
+          entry = root.get(version)
+          lines = [f"## {version}", ""]
+          detail_lines = []
+          summary = ""
+
+          if not entry:
+              lines.append("_No changelog entry found in metadata/screenplay/version.json for this release._")
+          else:
+              summary = (entry.get("summary") or "").strip()
+              if not summary:
+                  raise SystemExit(
+                      f"metadata/screenplay/version.json entry for {version} is missing a non-blank summary"
+                  )
+              lines.append(summary)
+              lines.append("")
+              for section, heading in (
+                  ("added", "Added"),
+                  ("changed", "Changed"),
+                  ("removed", "Removed"),
+              ):
+                  items = entry.get(section) or []
+                  if not items:
+                      continue
+                  detail_lines.append(f"### {heading}")
+                  detail_lines.extend(f"- {item}" for item in items)
+                  detail_lines.append("")
+              lines.extend(detail_lines)
+
+          Path("release-notes.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+          print(Path("release-notes.md").read_text(encoding="utf-8"))
+
+          changelog_body = "\n".join([summary, ""] + detail_lines).strip() if entry else ""
+          modrinth_data = {
+              "name": version,
+              "version_number": version,
+              "changelog": changelog_body,
+              "dependencies": [
+                  {"project_id": "P7dR8mSH", "dependency_type": "optional"},
+              ],
+              "game_versions": [minecraft_version],
+              "version_type": "release",
+              "loaders": ["fabric", "forge", "neoforge"],
+              "featured": False,
+              "status": "listed",
+              "project_id": "RdazTKdM",
+              "file_parts": ["fabric", "forge", "neoforge"],
+              "primary_file": "fabric",
+          }
+          Path("modrinth-data.json").write_text(
+              json.dumps(modrinth_data, indent=2) + "\n",
+              encoding="utf-8",
+          )
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+              out.write(f"release_version={version}\n")
+              out.write("summary<<EOF\n")
+              out.write(f"{summary}\n")
+              out.write("EOF\n")
+          PY
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
+          body_path: release-notes.md
+          files: |
+            screenplay-fabric/build/libs/screenplay-fabric-${{ steps.version.outputs.screenplay_version }}.jar
+            screenplay-loaders/forge/build/libs/screenplay-forge-${{ steps.version.outputs.screenplay_version }}.jar
+            screenplay-loaders/neoforge/build/libs/screenplay-neoforge-${{ steps.version.outputs.screenplay_version }}.jar
+          fail_on_unmatched_files: true
+          draft: false
+          prerelease: false
+
+      - name: Publish to Modrinth
+        id: modrinth
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+          SCREENPLAY_VERSION: ${{ steps.version.outputs.screenplay_version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MODRINTH_TOKEN:-}" ]; then
+            echo "MODRINTH_TOKEN secret is not set" >&2
+            exit 1
+          fi
+          FABRIC="screenplay-fabric/build/libs/screenplay-fabric-${SCREENPLAY_VERSION}.jar"
+          FORGE="screenplay-loaders/forge/build/libs/screenplay-forge-${SCREENPLAY_VERSION}.jar"
+          NEOFORGE="screenplay-loaders/neoforge/build/libs/screenplay-neoforge-${SCREENPLAY_VERSION}.jar"
+          for jar in "$FABRIC" "$FORGE" "$NEOFORGE"; do
+            if [ ! -f "$jar" ]; then
+              echo "Missing build artifact: $jar" >&2
+              exit 1
+            fi
+          done
+          RESPONSE=$(curl -fsS -X POST "https://api.modrinth.com/v2/version" \
+            -H "Authorization: ${MODRINTH_TOKEN}" \
+            -H "User-Agent: adam-k-ali/DWM (https://github.com/adam-k-ali/DWM)" \
+            -F "data=@modrinth-data.json;type=application/json" \
+            -F "fabric=@${FABRIC}" \
+            -F "forge=@${FORGE}" \
+            -F "neoforge=@${NEOFORGE}")
+          echo "$RESPONSE" | tee modrinth-response.json
+          VERSION_ID=$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$RESPONSE")
+          VERSION_URL="https://modrinth.com/mod/screenplay/version/${VERSION_ID}"
+          echo "modrinth_version_id=${VERSION_ID}" >> "$GITHUB_OUTPUT"
+          echo "modrinth_version_url=${VERSION_URL}" >> "$GITHUB_OUTPUT"
+          echo "Published Modrinth version: ${VERSION_URL}"

--- a/.github/workflows/sync-modrinth-screenplay.yml
+++ b/.github/workflows/sync-modrinth-screenplay.yml
@@ -1,0 +1,96 @@
+name: Sync Modrinth Screenplay
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Update Modrinth Screenplay project metadata
+        env:
+          MODRINTH_TOKEN: ${{ secrets.MODRINTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MODRINTH_TOKEN:-}" ]; then
+            echo "MODRINTH_TOKEN secret is not set" >&2
+            exit 1
+          fi
+
+          python3 <<'PY'
+          import json
+          import os
+          import sys
+          import urllib.error
+          import urllib.request
+          from pathlib import Path
+
+          token = os.environ["MODRINTH_TOKEN"]
+          meta_path = Path("metadata/screenplay/modrinth.json")
+          body_path = Path("metadata/screenplay/modrinth-body.md")
+
+          if not meta_path.is_file():
+              raise SystemExit(f"Missing {meta_path}")
+          if not body_path.is_file():
+              raise SystemExit(f"Missing {body_path}")
+
+          meta = json.loads(meta_path.read_text(encoding="utf-8"))
+          required = ("description", "categories", "additional_categories")
+          missing = [key for key in required if key not in meta]
+          if missing:
+              raise SystemExit(f"metadata/screenplay/modrinth.json missing keys: {', '.join(missing)}")
+
+          description = meta["description"]
+          categories = meta["categories"]
+          additional_categories = meta["additional_categories"]
+
+          if not isinstance(description, str) or not description.strip():
+              raise SystemExit("description must be a non-blank string")
+          if not isinstance(categories, list) or not all(isinstance(c, str) for c in categories):
+              raise SystemExit("categories must be a list of strings")
+          if not isinstance(additional_categories, list) or not all(
+              isinstance(c, str) for c in additional_categories
+          ):
+              raise SystemExit("additional_categories must be a list of strings")
+
+          body = body_path.read_text(encoding="utf-8").strip()
+          if not body:
+              raise SystemExit("metadata/screenplay/modrinth-body.md must be non-blank")
+
+          payload = {
+              "description": description.strip(),
+              "body": body,
+              "categories": categories,
+              "additional_categories": additional_categories,
+          }
+
+          request = urllib.request.Request(
+              "https://api.modrinth.com/v2/project/RdazTKdM",
+              data=json.dumps(payload).encode("utf-8"),
+              method="PATCH",
+              headers={
+                  "Authorization": token,
+                  "Content-Type": "application/json",
+                  "User-Agent": "adam-k-ali/DWM (https://github.com/adam-k-ali/DWM)",
+              },
+          )
+
+          try:
+              with urllib.request.urlopen(request) as response:
+                  status = response.status
+                  response.read()
+          except urllib.error.HTTPError as exc:
+              detail = exc.read().decode("utf-8", errors="replace")
+              print(detail, file=sys.stderr)
+              raise SystemExit(f"Modrinth PATCH failed with HTTP {exc.code}") from exc
+
+          if status != 204:
+              raise SystemExit(f"Expected HTTP 204 from Modrinth PATCH, got {status}")
+
+          print("Updated Modrinth project listing for RdazTKdM (screenplay)")
+          PY

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -112,3 +112,40 @@ Ship a patch immediately for:
 | [`.github/workflows/sync-modrinth-project.yml`](../.github/workflows/sync-modrinth-project.yml) | `workflow_dispatch` | PATCH Modrinth project listing from [`metadata/`](../metadata/) (Modrinth only; CurseForge listing stays manual) |
 
 CircleCI is retired; do not add draft GitHub releases on every `main` merge.
+
+## Screenplay releases
+
+Screenplay (Modrinth project `RdazTKdM`, slug `screenplay`) is published separately from DWM. Do not use DWM `v*` tags for Screenplay.
+
+Public release id and git tag:
+
+```text
+screenplay-v{screenplay_version}
+```
+
+Example: `screenplay-v1.0.0+26.2` → Gradle `screenplay_version` `1.0.0+26.2` (Minecraft from `minecraft_version` / the `+26.2` suffix).
+
+| Field | Source |
+| --- | --- |
+| `screenplay_version` | [`gradle.properties`](../gradle.properties) |
+| Changelog + promos | [`metadata/screenplay/version.json`](../metadata/screenplay/version.json) |
+| Listing drafts | [`metadata/screenplay/`](../metadata/screenplay/) (`modrinth.json` + `modrinth-body.md`; no `discord_url`) |
+
+### Screenplay distribution checklist
+
+1. On `main`, bump `screenplay_version` in `gradle.properties` (and `screenplay-loaders/gradle.properties` when needed).
+2. Fill `summary` and `added` / `changed` / `removed` for the new version in `metadata/screenplay/version.json`, and set `promos.latest` / `promos.recommended`.
+3. Confirm `./gradlew :screenplay-fabric:build` and `./gradlew -p screenplay-loaders :forge:build :neoforge:build` are green.
+4. Commit, merge to `main`, then create and push tag `screenplay-v{screenplay_version}` (manually, or via **Create Screenplay Release Tag**).
+5. Confirm **Release Screenplay** succeeds:
+   - GitHub Release with Fabric, Forge, and NeoForge jars and notes from `metadata/screenplay/version.json`
+   - Modrinth multi-loader version upload to project `RdazTKdM` (Fabric API optional dependency)
+6. Optionally run **Sync Modrinth Screenplay** to PATCH the listing from `metadata/screenplay/` (Discord stays blank).
+
+Uses the same `MODRINTH_TOKEN` secret as DWM (`VERSION_CREATE` for releases, `PROJECT_WRITE` for listing sync). No CurseForge or Discord announce for Screenplay.
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| [`.github/workflows/create-screenplay-release-tag.yml`](../.github/workflows/create-screenplay-release-tag.yml) | `workflow_dispatch` | Create and push `screenplay-v*` from `metadata/screenplay/version.json` `promos.latest` if missing; then dispatch Release Screenplay |
+| [`.github/workflows/release-screenplay.yml`](../.github/workflows/release-screenplay.yml) | push of tags `screenplay-v*`, or `workflow_dispatch` | Build loader jars; publish GitHub Release and Modrinth version |
+| [`.github/workflows/sync-modrinth-screenplay.yml`](../.github/workflows/sync-modrinth-screenplay.yml) | `workflow_dispatch` | PATCH Modrinth Screenplay listing from [`metadata/screenplay/`](../metadata/screenplay/) |

--- a/metadata/screenplay/modrinth.json
+++ b/metadata/screenplay/modrinth.json
@@ -1,4 +1,5 @@
 {
+  "project_id": "RdazTKdM",
   "description": "Real-client Minecraft scenario tests with CI screenshots for Fabric, Forge, and NeoForge — built for humans and agents.",
   "categories": [
     "library",

--- a/metadata/screenplay/version.json
+++ b/metadata/screenplay/version.json
@@ -1,0 +1,16 @@
+{
+  "promos": {
+    "latest": "1.0.0+26.2",
+    "recommended": "1.0.0+26.2"
+  },
+  "1.0.0+26.2": {
+    "summary": "Initial Screenplay release: real-client YAML scenario harness for Fabric, Forge, and NeoForge.",
+    "added": [
+      "Fabric, Forge, and NeoForge client harness artifacts",
+      "Gradle plugin for runScreenplay / runScreenplayTests with xvfb support",
+      "YAML scenarios, JUnit reports, metrics, and screenshot capture"
+    ],
+    "changed": [],
+    "removed": []
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Screenplay now has a Modrinth project (`RdazTKdM` / `screenplay`) but no CI path to ship Fabric, Forge, and NeoForge jars or sync the listing.
- Separating Screenplay releases from DWM `v*` tags avoids colliding player-mod and library publishing.

## Proposed Implementation

- Add `release-screenplay.yml` on `screenplay-v*` tags: build three loader jars, GitHub Release, Modrinth multi-file upload to `RdazTKdM` (Fabric API optional).
- Add `create-screenplay-release-tag.yml` and `sync-modrinth-screenplay.yml` (listing PATCH without `discord_url`).
- Seed `metadata/screenplay/version.json` and record `project_id` in `metadata/screenplay/modrinth.json`.
- Document the Screenplay release flow in `docs/release-policy.md`.

## Problems Encountered / Decisions Made

- Hardcoded project id `RdazTKdM` (same pattern as DWM’s `CY3ponKT`); no slug lookup.
- Left `discord_url` unset for Screenplay listing sync.
- Confirmed jar paths via local builds: `screenplay-fabric-…jar`, `screenplay-forge-…jar`, `screenplay-neoforge-…jar`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02f96-45ab-767f-931f-5bbe9d990676?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02f96-45ab-767f-931f-5bbe9d990676&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

