### PR TITLE
docs(screenplay): GitHub Pages quick start and command API reference

### DIFF
--- a/.github/workflows/docs-screenplay.yml
+++ b/.github/workflows/docs-screenplay.yml
@@ -1,0 +1,55 @@
+name: Screenplay Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "screenplay-docs/**"
+      - ".github/workflows/docs-screenplay.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: screenplay-docs
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs
+        run: pip install -r screenplay-docs/requirements.txt
+
+      - name: Build docs
+        working-directory: screenplay-docs
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: screenplay-docs/site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ build/screenplay/metrics.json
 
 # Loom / local Fabric tooling caches
 .fabric/
+
+# MkDocs local build output
+screenplay-docs/site/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 - `screenplay-common` / `screenplay-fabric`: Screenplay real-client scenario library (Fabric path used by this mod).
 - `screenplay-loaders/`: Included build for `screenplay-forge` and `screenplay-neoforge` (isolated from Loom).
 - `screenplay-gradle-plugin`: Gradle plugin `com.adamkali.screenplay` (`runScreenplay`, `runScreenplayTests`).
+- `screenplay-docs/`: Screenplay GitHub Pages site (MkDocs Material) — published at https://adam-k-ali.github.io/DWM/
 - `metadata/screenplay/`: Screenplay Modrinth listing drafts (`modrinth.json`, `modrinth-body.md`).
 - `.cursor/skills/`: Agent skills for GameTests, asset import, Blockbench models, MCP verify, etc.
 - `version.json`: Release changelog and Modrinth/CurseForge promos — synced via `./gradlew syncVersionJson`.

--- a/metadata/screenplay/modrinth-body.md
+++ b/metadata/screenplay/modrinth-body.md
@@ -2,6 +2,8 @@
 
 Real-client Minecraft tests with CI screenshots — built for humans and agents.
 
+**Docs:** [https://adam-k-ali.github.io/DWM/](https://adam-k-ali.github.io/DWM/) (quick start + command API reference)
+
 Screenplay boots the **real Minecraft client**, drives deterministic YAML scenarios (UI clicks, world actions, commands), and captures **screenshots and JUnit reports** you can inspect in CI or feed to coding agents.
 
 ## Why not GameTest alone?

--- a/screenplay-docs/docs/extending.md
+++ b/screenplay-docs/docs/extending.md
@@ -1,0 +1,55 @@
+# Extending primitives
+
+Built-in steps live in `screenplay-common`. Mods and libraries can add more
+without forking Screenplay.
+
+## Implement `ScenarioPrimitive`
+
+```java
+package com.example.mymod.screenplay;
+
+import com.adamkali.screenplay.primitive.ScenarioPrimitive;
+import com.adamkali.screenplay.primitive.ScenarioPrimitiveContext;
+
+import java.util.Map;
+
+public final class MyPrimitive implements ScenarioPrimitive {
+    @Override
+    public String name() {
+        return "myStep";
+    }
+
+    @Override
+    public void validate(Map<String, Object> args) {
+        // Reject unknown / missing arguments before the client runs
+    }
+
+    @Override
+    public boolean execute(ScenarioPrimitiveContext context, Map<String, Object> args) {
+        // Return true when the step is complete; false to retry next tick
+        return true;
+    }
+}
+```
+
+## Register via ServiceLoader
+
+Add a provider file on the **client** classpath:
+
+`META-INF/services/com.adamkali.screenplay.primitive.ScenarioPrimitive`
+
+```text
+com.example.mymod.screenplay.MyPrimitive
+```
+
+Screenplay loads built-ins first, then `ServiceLoader` extras. Duplicate names
+from different classes fail at registry load.
+
+## Guidance
+
+- Prefer shared primitives upstream in `screenplay-common` when the step is
+  generally useful.
+- Keep mod-only steps in your mod and register them with ServiceLoader.
+- Validate arguments strictly so malformed YAML fails before the client boots.
+- Steps should be idempotent across ticks: return `false` while waiting, `true`
+  when done, and throw for hard failures.

--- a/screenplay-docs/docs/index.md
+++ b/screenplay-docs/docs/index.md
@@ -1,0 +1,35 @@
+# Screenplay
+
+Real-client Minecraft tests with CI screenshots — built for humans and agents.
+
+Screenplay boots the **real Minecraft client**, drives deterministic YAML scenarios (UI clicks, world actions, commands), and captures **screenshots and JUnit reports** you can inspect in CI or feed to coding agents.
+
+## Why not GameTest alone?
+
+Fabric GameTests (and similar server harnesses) are excellent for headless, server-authoritative logic. They do not exercise the full client: title screens, widgets, create-world flows, or what the player actually sees.
+
+Screenplay fills that gap with a Playwright-style client harness — scriptable, repeatable, and artifact-rich.
+
+## Features
+
+- YAML scenarios and composite commands (`type: test` / `type: command`)
+- Widget and world primitives (click, assertVisible, createWorld, walkUntil, useItem, and more)
+- JUnit XML reports, step timing metrics, diagnostics dumps
+- Screenshot capture for CI and agent review
+- `xvfb` display mode for headless Linux CI
+- Gradle plugin (`com.adamkali.screenplay`) for prepare / run / run-all
+- **Fabric**, **Forge**, and **NeoForge** loader artifacts
+
+## Get started
+
+1. Follow the [Quick start](quickstart.md) to wire the plugin and run your first scenario.
+2. Browse [Commands available](reference/commands.md) for the full API reference.
+3. See [Running tests](running-tests.md) for display modes, timeouts, and CI outputs.
+
+## Loaders
+
+| Loader | Artifact |
+| --- | --- |
+| Fabric | `screenplay-fabric` |
+| Forge | `screenplay-forge` |
+| NeoForge | `screenplay-neoforge` |

--- a/screenplay-docs/docs/quickstart.md
+++ b/screenplay-docs/docs/quickstart.md
@@ -1,0 +1,67 @@
+# Quick start
+
+Add Screenplay to a Fabric (or Forge / NeoForge) Gradle project, write a YAML scenario, and run it.
+
+## 1. Apply the plugin and dependency
+
+```groovy
+plugins {
+    id 'com.adamkali.screenplay' version '<version>'
+}
+
+dependencies {
+    runtimeOnly "com.adamkali.screenplay:screenplay-fabric:<version>"
+}
+
+screenplay {
+    loader = 'fabric'
+    testsDir = file('src/screenplayTests/resources/tests')
+}
+```
+
+Forge and NeoForge use the same plugin with `loader = 'forge'` or `loader = 'neoforge'` and the matching `screenplay-forge` / `screenplay-neoforge` artifact.
+
+See the [Gradle plugin reference](reference/gradle-plugin.md) for all extension fields.
+
+## 2. Add a scenario
+
+Create a file under your tests directory, for example
+`src/screenplayTests/resources/tests/createWorld.yaml`:
+
+```yaml
+---
+name: Create a flat world
+type: test
+---
+steps:
+  - launchGame
+  - createWorld:
+      worldType: flat
+      gameMode: creative
+  - captureScreenshot:
+      name: world-ready.png
+```
+
+The filename stem (`createWorld`) is the scenario ID used on the command line.
+
+## 3. Run it
+
+```bash
+./gradlew runScreenplay -Pscreenplay=createWorld -PscreenplayDisplay=xvfb
+```
+
+On a machine with a real display, omit `-PscreenplayDisplay` or use `display`.
+
+| Property | Purpose |
+| --- | --- |
+| `-Pscreenplay=<id>` | YAML filename stem to run |
+| `-PscreenplayDisplay=display\|xvfb` | Framebuffer strategy (default `display`) |
+| `-PscreenplayTimeout=<seconds>` | Per-step timeout (default 30) |
+
+Results land under `build/screenplay/` (JUnit XML, metrics, diagnostics, screenshots). Details: [Running tests](running-tests.md).
+
+## 4. Next steps
+
+- Learn YAML frontmatter, selectors, and composites in [Writing scenarios](writing-scenarios.md).
+- Look up each step in [Commands available](reference/commands.md).
+- Register custom primitives with [Extending](extending.md).

--- a/screenplay-docs/docs/reference/commands.md
+++ b/screenplay-docs/docs/reference/commands.md
@@ -1,0 +1,25 @@
+# Commands available
+
+Built-in Screenplay steps and the shipped composite command. Each entry links
+to a full reference page with parameters and YAML examples.
+
+- [assertAndClick](commands/assertAndClick.md) — Assert a selector is visible, then click it (composite).
+- [assertVisible](commands/assertVisible.md) — Wait until a matching widget or screen is visible.
+- [captureScreenshot](commands/captureScreenshot.md) — Capture the current framebuffer to a PNG.
+- [click](commands/click.md) — Wait for an active matching widget and left-click its center.
+- [closeScreen](commands/closeScreen.md) — Close the current GUI / container screen.
+- [createWorld](commands/createWorld.md) — Create a local world with the given settings and wait until loaded.
+- [debugScreen](commands/debugScreen.md) — Log the current screen class and every visible widget.
+- [keyboardInput](commands/keyboardInput.md) — Type text into the focused edit box.
+- [launchGame](commands/launchGame.md) — Wait until the title screen is ready.
+- [lookAt](commands/lookAt.md) — Aim the camera by yaw/pitch or at block coordinates.
+- [openInventory](commands/openInventory.md) — Open the player inventory GUI.
+- [runCommand](commands/runCommand.md) — Send an in-game slash command as the local player.
+- [selectHotbar](commands/selectHotbar.md) — Select hotbar slot `0`–`8` and sync to the server.
+- [startVanillaServer](commands/startVanillaServer.md) — Launch Mojang’s dedicated server as a child process.
+- [useItem](commands/useItem.md) — Use the main-hand item on the targeted block.
+- [waitTicks](commands/waitTicks.md) — Wait until the client world advances by N ticks.
+- [waitUntil](commands/waitUntil.md) — Poll until a visibility, holding, or block condition is true.
+- [walkUntil](commands/walkUntil.md) — Hold forward until a block position or dimension is reached.
+
+See also: [Selectors](selectors.md) · [Writing scenarios](../writing-scenarios.md) · [Gradle plugin](gradle-plugin.md)

--- a/screenplay-docs/docs/reference/commands/assertAndClick.md
+++ b/screenplay-docs/docs/reference/commands/assertAndClick.md
@@ -1,0 +1,44 @@
+# assertAndClick
+
+Assert that a [selector](../selectors.md) is visible, then click it. This is a
+shipped **composite** (`type: command`), not a Java primitive — the compiler
+inlines the nested steps.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | yes | Selector type (`button`, `cycle`, `tab`, `editbox`, `label`) |
+| `name` | string | yes | Exact selector name |
+
+Expands to:
+
+1. [`assertVisible`](assertVisible.md) with the same selector
+2. [`click`](click.md) with the same selector
+
+## Usage examples
+
+```yaml
+- assertAndClick:
+  - type: button
+    name: "Singleplayer"
+```
+
+```yaml
+- assertAndClick:
+    type: editbox
+    name: "Server Address"
+```
+
+## Notes
+
+- `type: screen` is invalid for the click half of this composite.
+- Definition: `assertAndClick.yaml` under Screenplay’s library tests resources
+  (filename stem = command ID).
+- Author custom composites as described in [Writing scenarios](../../writing-scenarios.md).
+
+## Related commands
+
+- [assertVisible](assertVisible.md)
+- [click](click.md)
+- [debugScreen](debugScreen.md)

--- a/screenplay-docs/docs/reference/commands/assertVisible.md
+++ b/screenplay-docs/docs/reference/commands/assertVisible.md
@@ -1,0 +1,40 @@
+# assertVisible
+
+Wait until a [selector](../selectors.md) matches a visible widget or the current
+screen. Retries each client tick until success or the step timeout.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | yes | Selector type |
+| `name` | string | yes | Exact match string |
+
+Accepts a direct object or a single-item list.
+
+## Usage examples
+
+```yaml
+- assertVisible:
+    type: button
+    name: "Singleplayer"
+```
+
+```yaml
+- assertVisible:
+  - type: screen
+    name: LevelLoadingScreen
+```
+
+## Notes
+
+- Does not click or change UI state.
+- Equivalent visibility condition: [`waitUntil`](waitUntil.md) with `visible`.
+- Use [`debugScreen`](debugScreen.md) if a selector never matches.
+
+## Related commands
+
+- [click](click.md)
+- [assertAndClick](assertAndClick.md)
+- [waitUntil](waitUntil.md)
+- [debugScreen](debugScreen.md)

--- a/screenplay-docs/docs/reference/commands/captureScreenshot.md
+++ b/screenplay-docs/docs/reference/commands/captureScreenshot.md
@@ -1,0 +1,38 @@
+# captureScreenshot
+
+Capture the current framebuffer (world and GUI) to a PNG under the client run
+screenshots directory (`build/screenplay/run/screenshots/` by default).
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `name` | string | no | PNG stem or filename. `.png` is appended if missing. Must be a simple file name (no `/`, `\`, or `..`). |
+
+With no arguments, Minecraft chooses a vanilla timestamped filename.
+
+## Usage examples
+
+```yaml
+- captureScreenshot
+```
+
+```yaml
+- captureScreenshot:
+    name: world-ready.png
+```
+
+```yaml
+- captureScreenshot:
+    name: after-world-tab
+```
+
+## Notes
+
+- The step waits until the file has been written before succeeding.
+- Failure surfaces as a scenario error if screenshot capture reports failure.
+
+## Related commands
+
+- [debugScreen](debugScreen.md)
+- [launchGame](launchGame.md)

--- a/screenplay-docs/docs/reference/commands/click.md
+++ b/screenplay-docs/docs/reference/commands/click.md
@@ -1,0 +1,39 @@
+# click
+
+Wait for an active matching widget and dispatch a real screen mouse click at its
+center.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `type` | string | yes | Selector type — **not** `screen` |
+| `name` | string | yes | Exact widget name |
+
+## Usage examples
+
+```yaml
+- click:
+    type: button
+    name: "Multiplayer"
+```
+
+```yaml
+- click:
+  - type: tab
+    name: "World"
+```
+
+## Notes
+
+- Retries while the widget is missing or `active == false`.
+- `type: screen` is rejected at validation time.
+- Prefer [`assertAndClick`](assertAndClick.md) when you want an explicit assert
+  before the click.
+
+## Related commands
+
+- [assertVisible](assertVisible.md)
+- [assertAndClick](assertAndClick.md)
+- [keyboardInput](keyboardInput.md)
+- [Selectors](../selectors.md)

--- a/screenplay-docs/docs/reference/commands/closeScreen.md
+++ b/screenplay-docs/docs/reference/commands/closeScreen.md
@@ -1,0 +1,26 @@
+# closeScreen
+
+Close the current GUI (`setScreen(null)` / `closeContainer()`).
+
+## Parameters
+
+None.
+
+## Usage examples
+
+```yaml
+- closeScreen
+```
+
+## Notes
+
+- Waits until a local player exists.
+- If no screen is open, the step succeeds without changing anything.
+- World actions such as [`useItem`](useItem.md) and [`walkUntil`](walkUntil.md)
+  require no open screen.
+
+## Related commands
+
+- [openInventory](openInventory.md)
+- [useItem](useItem.md)
+- [walkUntil](walkUntil.md)

--- a/screenplay-docs/docs/reference/commands/createWorld.md
+++ b/screenplay-docs/docs/reference/commands/createWorld.md
@@ -1,0 +1,45 @@
+# createWorld
+
+Open vanilla Create World, apply the given settings, and wait until the local
+player is in the loaded world.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `worldType` | string | no | `flat` | World preset aliases such as `flat` / `superflat`, `default` / `normal`, `largebiomes`, `amplified`, `singlebiome`, or a full preset id |
+| `gameMode` | string | no | `creative` | `survival`, `hardcore`, or `creative` |
+| `difficulty` | string | no | `peaceful` | `peaceful`, `easy`, `normal`, or `hard` |
+| `allowCommands` | boolean | no | `true` | Whether cheats are enabled |
+| `name` | string | no | vanilla default | Overrides “New World” when set (non-empty) |
+
+## Usage examples
+
+```yaml
+- createWorld
+```
+
+```yaml
+- createWorld:
+    worldType: superflat
+    gameMode: creative
+    difficulty: peaceful
+    allowCommands: true
+    name: Scenario World
+```
+
+## Notes
+
+- Uses a **120 second** timeout floor; `-PscreenplayTimeout` raises it when set
+  higher.
+- Allowed once per scenario.
+- Does **not** click through Create World tabs manually — it drives the process
+  APIs used by the harness.
+- Completes when the player and level are ready and loading GUIs are gone.
+
+## Related commands
+
+- [launchGame](launchGame.md)
+- [openInventory](openInventory.md)
+- [closeScreen](closeScreen.md)
+- [captureScreenshot](captureScreenshot.md)

--- a/screenplay-docs/docs/reference/commands/debugScreen.md
+++ b/screenplay-docs/docs/reference/commands/debugScreen.md
@@ -1,0 +1,26 @@
+# debugScreen
+
+Immediately log the current screen class and every visible widget (type, name,
+active, bounds). Always succeeds on the tick it runs.
+
+## Parameters
+
+None.
+
+## Usage examples
+
+```yaml
+- debugScreen
+```
+
+## Notes
+
+- Side effect only: writes an INFO diagnostics dump (also useful when
+  `diagnostics.txt` is captured after failures).
+- Use while authoring [selectors](../selectors.md).
+
+## Related commands
+
+- [assertVisible](assertVisible.md)
+- [click](click.md)
+- [assertAndClick](assertAndClick.md)

--- a/screenplay-docs/docs/reference/commands/keyboardInput.md
+++ b/screenplay-docs/docs/reference/commands/keyboardInput.md
@@ -1,0 +1,36 @@
+# keyboardInput
+
+Wait until a focused, editable text field can consume input, then type the given
+string once via real `charTyped` events.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `text` | string | yes | Non-empty string to type |
+
+A scalar string shorthand sets `text`.
+
+## Usage examples
+
+```yaml
+- keyboardInput: "localhost:25565"
+```
+
+```yaml
+- keyboardInput:
+    text: "localhost:25565"
+```
+
+## Notes
+
+- Does **not** click or focus the field — click the matching `editbox` first
+  (often via [`assertAndClick`](assertAndClick.md)).
+- Retries while no focused editable `EditBox` is available.
+- Throws if a codepoint is rejected by the field.
+
+## Related commands
+
+- [click](click.md)
+- [assertAndClick](assertAndClick.md)
+- [Selectors](../selectors.md)

--- a/screenplay-docs/docs/reference/commands/launchGame.md
+++ b/screenplay-docs/docs/reference/commands/launchGame.md
@@ -1,0 +1,25 @@
+# launchGame
+
+Wait until the title screen is ready.
+
+## Parameters
+
+None.
+
+## Usage examples
+
+```yaml
+- launchGame
+```
+
+## Notes
+
+- Succeeds when the current screen is `TitleScreen`.
+- Typical first step in every scenario.
+- Uses the default per-step timeout (30s unless overridden).
+
+## Related commands
+
+- [createWorld](createWorld.md)
+- [assertAndClick](assertAndClick.md)
+- [startVanillaServer](startVanillaServer.md)

--- a/screenplay-docs/docs/reference/commands/lookAt.md
+++ b/screenplay-docs/docs/reference/commands/lookAt.md
@@ -1,0 +1,50 @@
+# lookAt
+
+Aim the local player’s camera. Supply either a rotation or block coordinates —
+not both.
+
+## Parameters
+
+### Rotation mode
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `yaw` | number | yes | Yaw degrees |
+| `pitch` | number | yes | Pitch degrees, clamped to **−90…90** |
+
+### Position mode
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `x` | int or relative string | yes | Absolute int or `"~"` / `"~N"` / `"~-N"` |
+| `y` | int or relative string | yes | Same |
+| `z` | int or relative string | yes | Same |
+
+Relative values use the player’s block position. Quote `"~"` in YAML; a bare
+`~` is YAML null.
+
+## Usage examples
+
+```yaml
+- lookAt:
+    yaw: 90
+    pitch: 45
+```
+
+```yaml
+- lookAt:
+    x: "~1"
+    y: "~-1"
+    z: "~"
+```
+
+## Notes
+
+- Waits until a local player exists, then applies the look immediately.
+- Position mode aims at the block center from eye height.
+
+## Related commands
+
+- [useItem](useItem.md)
+- [walkUntil](walkUntil.md)
+- [waitUntil](waitUntil.md)

--- a/screenplay-docs/docs/reference/commands/openInventory.md
+++ b/screenplay-docs/docs/reference/commands/openInventory.md
@@ -1,0 +1,24 @@
+# openInventory
+
+Open the survival or creative inventory GUI.
+
+## Parameters
+
+None.
+
+## Usage examples
+
+```yaml
+- openInventory
+```
+
+## Notes
+
+- Waits until a local player exists.
+- If the inventory is already showing, the step succeeds without reopening it.
+
+## Related commands
+
+- [closeScreen](closeScreen.md)
+- [createWorld](createWorld.md)
+- [selectHotbar](selectHotbar.md)

--- a/screenplay-docs/docs/reference/commands/runCommand.md
+++ b/screenplay-docs/docs/reference/commands/runCommand.md
@@ -1,0 +1,40 @@
+# runCommand
+
+Send an in-game slash command as the local player (same path as typing `/give`
+in chat, without opening the chat GUI).
+
+## Parameters
+
+Provide exactly one of:
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `command` | string | one of | Command text |
+| `text` | string | one of | Alias for `command` (used by scalar shorthand) |
+
+Leading `/` is stripped. Length must be ≤ 256 and non-blank after normalize.
+
+## Usage examples
+
+```yaml
+- runCommand: "/give @s minecraft:diamond 1"
+```
+
+```yaml
+- runCommand:
+    command: "/give @s minecraft:diamond 1"
+```
+
+## Notes
+
+- Succeeds as soon as the command packet is sent — it does **not** wait for
+  success chat or inventory updates. Pair with [`waitUntil`](waitUntil.md).
+- Cheats (singleplayer) or operator (dedicated server) are required for
+  privileged commands. [`startVanillaServer`](startVanillaServer.md) does not
+  OP the player.
+
+## Related commands
+
+- [waitUntil](waitUntil.md)
+- [selectHotbar](selectHotbar.md)
+- [useItem](useItem.md)

--- a/screenplay-docs/docs/reference/commands/selectHotbar.md
+++ b/screenplay-docs/docs/reference/commands/selectHotbar.md
@@ -1,0 +1,32 @@
+# selectHotbar
+
+Select hotbar slot `0`–`8` and sync that slot to the server.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `slot` | int | yes | Hotbar index **0–8** |
+
+A scalar integer shorthand sets `slot`.
+
+## Usage examples
+
+```yaml
+- selectHotbar: 0
+```
+
+```yaml
+- selectHotbar:
+    slot: 3
+```
+
+## Notes
+
+- Waits until a local player and play connection exist.
+
+## Related commands
+
+- [runCommand](runCommand.md)
+- [useItem](useItem.md)
+- [waitUntil](waitUntil.md)

--- a/screenplay-docs/docs/reference/commands/startVanillaServer.md
+++ b/screenplay-docs/docs/reference/commands/startVanillaServer.md
@@ -1,0 +1,41 @@
+# startVanillaServer
+
+Launch Mojang’s official dedicated-server jar as a child process (no Fabric /
+mod loader on the server). Writes offline-mode superflat settings, waits until
+`127.0.0.1` accepts TCP connections, and stops the process when the scenario
+finishes.
+
+## Parameters
+
+| Parameter | Type | Required | Default | Description |
+| --- | --- | --- | --- | --- |
+| `port` | int | no | `25565` | Listen port (`1`–`65535`) |
+
+## Usage examples
+
+```yaml
+- startVanillaServer
+```
+
+```yaml
+- startVanillaServer:
+    port: 25565
+```
+
+## Notes
+
+- This step does **not** connect the client — drive Multiplayer UI separately
+  (for example [`assertAndClick`](assertAndClick.md) +
+  [`keyboardInput`](keyboardInput.md)).
+- Uses a **120 second** timeout floor; `-PscreenplayTimeout` raises it when set
+  higher.
+- Allowed once per scenario.
+- Run directory: `build/screenplay/vanilla-server/` (`server-jar.path`,
+  `eula.txt`, `server.properties`, `world/`, `logs/harness.log`).
+- Fails if the port is in use or the process dies before ready.
+
+## Related commands
+
+- [launchGame](launchGame.md)
+- [keyboardInput](keyboardInput.md)
+- [assertAndClick](assertAndClick.md)

--- a/screenplay-docs/docs/reference/commands/useItem.md
+++ b/screenplay-docs/docs/reference/commands/useItem.md
@@ -1,0 +1,31 @@
+# useItem
+
+Use the main-hand item on the currently targeted block (same path as right-click
+place / interact).
+
+## Parameters
+
+None.
+
+## Usage examples
+
+```yaml
+- useItem
+```
+
+## Notes
+
+- Requires a local player, game mode, **no open screen**, and a block crosshair
+  hit (`hitResult` is a block).
+- Succeeds as soon as the use is sent — it does **not** wait for the world to
+  update. Pair with [`waitUntil`](waitUntil.md) `block`.
+- Aim first with [`lookAt`](lookAt.md); select the item with
+  [`selectHotbar`](selectHotbar.md) / [`runCommand`](runCommand.md).
+
+## Related commands
+
+- [lookAt](lookAt.md)
+- [selectHotbar](selectHotbar.md)
+- [runCommand](runCommand.md)
+- [waitUntil](waitUntil.md)
+- [closeScreen](closeScreen.md)

--- a/screenplay-docs/docs/reference/commands/waitTicks.md
+++ b/screenplay-docs/docs/reference/commands/waitTicks.md
@@ -1,0 +1,34 @@
+# waitTicks
+
+Wait until the client world’s game time has advanced by the given number of
+ticks.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `ticks` | int | yes | Positive integer ≥ 1 |
+
+A scalar positive integer shorthand sets `ticks`.
+
+## Usage examples
+
+```yaml
+- waitTicks: 25
+```
+
+```yaml
+- waitTicks:
+    ticks: 25
+```
+
+## Notes
+
+- Requires `client.level`.
+- Use for short animations that have no [`waitUntil`](waitUntil.md) condition
+  (for example a door swing).
+
+## Related commands
+
+- [waitUntil](waitUntil.md)
+- [useItem](useItem.md)

--- a/screenplay-docs/docs/reference/commands/waitUntil.md
+++ b/screenplay-docs/docs/reference/commands/waitUntil.md
@@ -1,0 +1,57 @@
+# waitUntil
+
+Poll until **exactly one** condition is true.
+
+## Parameters
+
+Provide exactly one of the following keys:
+
+| Key | Value | Description |
+| --- | --- | --- |
+| `visible` | selector object | Matching widget/screen is visible (same as [`assertVisible`](assertVisible.md)) |
+| `notVisible` | selector object | No match on the current tick (including if it has never appeared) |
+| `holding` | item id string or `{id: ...}` | Main hand holds the item (`minecraft:` may be omitted; empty hand is `minecraft:air`) |
+| `block` | `{id, x, y, z}` | Block id at coordinates (relative/absolute rules same as [`lookAt`](lookAt.md)) |
+
+## Usage examples
+
+```yaml
+- waitUntil:
+    visible:
+      type: button
+      name: "Singleplayer"
+```
+
+```yaml
+- waitUntil:
+    notVisible:
+      type: screen
+      name: LevelLoadingScreen
+```
+
+```yaml
+- waitUntil:
+    holding: minecraft:dirt
+```
+
+```yaml
+- waitUntil:
+    block:
+      id: minecraft:dirt
+      x: "~1"
+      y: "~"
+      z: "~"
+```
+
+## Notes
+
+- Retries each tick until the step timeout.
+- Quote relative coords: `"~"` not bare `~`.
+
+## Related commands
+
+- [assertVisible](assertVisible.md)
+- [runCommand](runCommand.md)
+- [useItem](useItem.md)
+- [walkUntil](walkUntil.md)
+- [Selectors](../selectors.md)

--- a/screenplay-docs/docs/reference/commands/walkUntil.md
+++ b/screenplay-docs/docs/reference/commands/walkUntil.md
@@ -1,0 +1,52 @@
+# walkUntil
+
+Hold forward movement (`keyUp`) until one end condition is met. The forward key
+is released when the step succeeds.
+
+## Parameters
+
+Provide exactly one mode:
+
+### Position mode
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `x` | int or relative string | yes | Absolute or `"~"` / `"~N"` |
+| `y` | int or relative string | yes | Same |
+| `z` | int or relative string | yes | Same |
+
+Re-aims at the target each tick. Relative values use the player’s block
+position. Quote `"~"` in YAML.
+
+### Dimension mode
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| `dimension` | string | yes | Namespaced world id (for example `dwm:tardis`) |
+
+## Usage examples
+
+```yaml
+- walkUntil:
+    x: "~3"
+    y: "~"
+    z: "~"
+```
+
+```yaml
+- walkUntil:
+    dimension: dwm:tardis
+```
+
+## Notes
+
+- Requires a local player, level, and **no open screen** — call
+  [`closeScreen`](closeScreen.md) first if needed.
+- Uses the default per-step timeout; a blocked path can time out while still
+  holding forward until failure cleanup.
+
+## Related commands
+
+- [closeScreen](closeScreen.md)
+- [lookAt](lookAt.md)
+- [waitUntil](waitUntil.md)

--- a/screenplay-docs/docs/reference/gradle-plugin.md
+++ b/screenplay-docs/docs/reference/gradle-plugin.md
@@ -1,0 +1,60 @@
+# Gradle plugin
+
+Plugin ID: `com.adamkali.screenplay`
+
+Registered by the `screenplay-gradle-plugin` included build. It wires prepare /
+run tasks for Fabric, Forge, or NeoForge and applies display-mode wrappers.
+
+## Extension (`screenplay { }`)
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `loader` | `String` | auto when unambiguous | `fabric`, `forge`, or `neoforge` |
+| `testsDir` | `File` | `src/screenplayTests/resources/tests` | Primary YAML root |
+| `extraTestsDirs` | `List<File>` | `[]` | Additional roots scanned by `runScreenplayTests` |
+| `runDir` | `String` | `build/screenplay/run` | Client run directory (project-relative) |
+| `outputDir` | `String` | `screenplay` | Build-relative output directory name for reports |
+
+```groovy
+screenplay {
+    loader = 'fabric'
+    testsDir = file('src/screenplayTests/resources/tests')
+    extraTestsDirs = [file('screenplay-common/src/main/resources/tests')]
+    runDir = 'build/screenplay/run'
+    outputDir = 'screenplay'
+}
+```
+
+## Tasks
+
+| Task | Purpose |
+| --- | --- |
+| `runScreenplay` | Run one scenario (`-Pscreenplay=<id>` required) |
+| `runScreenplayTests` | Discover and run every `type: test` YAML |
+
+## Gradle properties
+
+| Property | Description |
+| --- | --- |
+| `-Pscreenplay=<id>` | Scenario filename stem |
+| `-PscreenplayTimeout=<seconds>` | Per-step timeout (default 30) |
+| `-PscreenplayDisplay=display\|xvfb` | Framebuffer strategy (default `display`) |
+
+## Dependencies
+
+```groovy
+dependencies {
+    runtimeOnly "com.adamkali.screenplay:screenplay-fabric:<version>"
+}
+```
+
+| Loader | Artifact |
+| --- | --- |
+| Fabric | `screenplay-fabric` |
+| Forge | `screenplay-forge` |
+| NeoForge | `screenplay-neoforge` |
+
+## Related
+
+- [Quick start](../quickstart.md)
+- [Running tests](../running-tests.md)

--- a/screenplay-docs/docs/reference/selectors.md
+++ b/screenplay-docs/docs/reference/selectors.md
@@ -1,0 +1,55 @@
+# Selectors
+
+Selectors identify UI widgets or the current screen for
+[`assertVisible`](commands/assertVisible.md), [`click`](commands/click.md),
+[`waitUntil`](commands/waitUntil.md) visibility conditions, and composites such
+as [`assertAndClick`](commands/assertAndClick.md).
+
+## Shape
+
+Only two fields are allowed; both are required and non-empty:
+
+| Field | Description |
+| --- | --- |
+| `type` | One of the types below |
+| `name` | Exact match string for that type |
+
+Unknown fields are rejected at compile/validate time.
+
+```yaml
+- assertVisible:
+    type: button
+    name: "Singleplayer"
+```
+
+A single-item list form is equivalent:
+
+```yaml
+- assertVisible:
+  - type: button
+    name: "Singleplayer"
+```
+
+## Types
+
+| `type` | Matches |
+| --- | --- |
+| `button` | Visible `Button` whose message equals `name` |
+| `cycle` | Visible `CycleButton` whose message equals `name` |
+| `tab` | Visible `TabButton` whose message equals `name` |
+| `editbox` | Visible `EditBox` whose accessibility narration label (`getMessage()`) equals `name` — not the current field value |
+| `label` | Visible `StringWidget` message, or painted status text on the vanilla connect screen (for example `"Connecting to the server..."`) |
+| `screen` | Current GUI’s Java **simple class name** equals `name` (for example `LevelLoadingScreen`, not the fully qualified name) |
+
+First match wins among visible widgets.
+
+## Rules of thumb
+
+- Prefer localized UI text as shown in English client options (the harness
+  writes deterministic English options).
+- Direct Connection’s IP field is `"Server Address"`.
+- [`click`](commands/click.md) cannot target `type: screen` (validation error).
+- [`click`](commands/click.md) also cannot activate painted connect-screen
+  status text matched only as a `label`; it only clicks real widgets.
+- Use [`debugScreen`](commands/debugScreen.md) to dump visible widgets while
+  authoring selectors.

--- a/screenplay-docs/docs/running-tests.md
+++ b/screenplay-docs/docs/running-tests.md
@@ -1,0 +1,85 @@
+# Running tests
+
+## Single scenario
+
+Run a test by its YAML filename without the extension:
+
+```bash
+./gradlew runScreenplay -Pscreenplay=createWorld
+```
+
+## All scenarios
+
+Discover every `type: test` YAML under configured tests roots and run each one
+(fresh client per scenario):
+
+```bash
+./gradlew runScreenplayTests
+./gradlew runScreenplayTests -PscreenplayDisplay=xvfb -PscreenplayTimeout=120
+```
+
+`runScreenplayTests` skips `type: command` documents, continues after individual
+failures, and fails the aggregate with the list of failed scenario IDs.
+
+## Isolated run directory
+
+The client uses an isolated directory under `build/screenplay/run`. Before each
+run, the harness removes saved worlds, clears
+`build/screenplay/vanilla-server/world`, and writes deterministic English client
+options.
+
+## Display modes
+
+Select the framebuffer strategy with `-PscreenplayDisplay` (default `display`):
+
+| Value | Behavior |
+| --- | --- |
+| `display` | Real `$DISPLAY` / GLFW window. Fails fast on Linux when `$DISPLAY` is unset. |
+| `xvfb` | Wraps the client with Loom’s `xvfb-run` path (Linux only). Requires `xvfb` (`apt install xvfb`). Sets soft-GL-friendly options and `LIBGL_ALWAYS_SOFTWARE=1`. |
+
+```bash
+./gradlew runScreenplay -Pscreenplay=createWorld -PscreenplayDisplay=display
+./gradlew runScreenplay -Pscreenplay=createWorld -PscreenplayDisplay=xvfb -PscreenplayTimeout=120
+```
+
+## Timeouts
+
+The default per-step timeout is **30 seconds**. Override when debugging or for
+slow soft-GL CI:
+
+```bash
+./gradlew runScreenplay -Pscreenplay=createWorld -PscreenplayTimeout=60
+```
+
+[`createWorld`](reference/commands/createWorld.md) and
+[`startVanillaServer`](reference/commands/startVanillaServer.md) use a **120
+second** timeout floor; `-PscreenplayTimeout` still raises that floor when set
+higher.
+
+## Outputs
+
+| Path | Contents |
+| --- | --- |
+| `build/screenplay/report.xml` | JUnit XML |
+| `build/screenplay/metrics.json` | Wall-clock step timings |
+| `build/screenplay/diagnostics.txt` | Current screen and visible widgets |
+| `build/screenplay/run/screenshots/` | PNGs from `captureScreenshot` |
+| `build/screenplay/results/<id>/` | Per-scenario copies from `runScreenplayTests` |
+| `build/screenplay/vanilla-server/` | Official dedicated-server dir from `startVanillaServer` |
+
+The Gradle process exits non-zero when loading, validation, or execution fails.
+
+## System properties
+
+The plugin sets (among others):
+
+- `screenplay` — scenario ID
+- `screenplay.step-timeout-seconds`
+- `screenplay.report-file`
+- `screenplay.vanilla-server-dir`
+
+## CI tips
+
+- Prefer `-PscreenplayDisplay=xvfb` on headless Linux runners.
+- Upload `report.xml`, `metrics.json`, diagnostics, and screenshots as workflow
+  artifacts for agent and human review.

--- a/screenplay-docs/docs/writing-scenarios.md
+++ b/screenplay-docs/docs/writing-scenarios.md
@@ -1,0 +1,99 @@
+# Writing scenarios
+
+YAML definitions live recursively under your configured tests directory (default
+`src/screenplayTests/resources/tests/`). Directory layout does not determine
+role; the frontmatter `type` does.
+
+## Frontmatter
+
+```yaml
+---
+name: Create World
+type: test
+---
+steps:
+  - launchGame
+```
+
+| `type` | Role |
+| --- | --- |
+| `test` | Executable scenario selected with `-Pscreenplay=<id>` |
+| `command` | Reusable composite command invoked by filename stem |
+
+The **filename stem** is the stable ID. For example,
+`subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test or
+command IDs are rejected even when files live in different directories.
+
+## Steps
+
+Each item under `steps` is either:
+
+- A bare primitive name with no arguments (`launchGame`)
+- A map keyed by primitive or composite ID with arguments
+
+```yaml
+steps:
+  - launchGame
+  - assertVisible:
+      type: button
+      name: "Singleplayer"
+  - click:
+      type: button
+      name: "Singleplayer"
+```
+
+A single-item list form is also accepted for selector-style arguments:
+
+```yaml
+- assertVisible:
+  - type: tab
+    name: "World"
+```
+
+Scalar shorthands map to a `text` field for some commands (for example
+`keyboardInput: "hello"` or `waitTicks: 25`). See each command page for details.
+
+## Selectors
+
+Widget and screen matching uses exact `name` plus one of:
+
+`button`, `cycle`, `tab`, `editbox`, `label`, `screen`
+
+Full rules: [Selectors](reference/selectors.md).
+
+## Composite commands
+
+A `type: command` document declares string parameters and uses them in nested
+steps via `{{ param }}` templates:
+
+```yaml
+---
+name: Assert and Click
+type: command
+---
+parameters:
+  - name: type
+    type: string
+  - name: name
+    type: string
+steps:
+  - assertVisible:
+    - type: "{{ type }}"
+      name: "{{ name }}"
+  - click:
+    - type: "{{ type }}"
+      name: "{{ name }}"
+```
+
+Invoke by filename ID:
+
+```yaml
+- assertAndClick:
+  - type: button
+    name: "Singleplayer"
+```
+
+Screenplay ships [`assertAndClick`](reference/commands/assertAndClick.md) as a
+built-in composite. Unknown steps, missing or extra parameters, unsupported
+types, malformed documents, and recursive command cycles fail **before** the
+client flow begins.

--- a/screenplay-docs/mkdocs.yml
+++ b/screenplay-docs/mkdocs.yml
@@ -1,0 +1,79 @@
+site_name: Screenplay
+site_description: Real-client Minecraft scenario tests with YAML, screenshots, and CI reports
+site_url: https://adam-k-ali.github.io/DWM/
+repo_url: https://github.com/adam-k-ali/DWM
+repo_name: adam-k-ali/DWM
+edit_uri: edit/main/screenplay-docs/docs/
+
+docs_dir: docs
+site_dir: site
+strict: true
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Quick start: quickstart.md
+  - Writing scenarios: writing-scenarios.md
+  - Running tests: running-tests.md
+  - Extending primitives: extending.md
+  - Reference:
+    - Commands available: reference/commands.md
+    - Selectors: reference/selectors.md
+    - Gradle plugin: reference/gradle-plugin.md
+    - Commands:
+      - assertAndClick: reference/commands/assertAndClick.md
+      - assertVisible: reference/commands/assertVisible.md
+      - captureScreenshot: reference/commands/captureScreenshot.md
+      - click: reference/commands/click.md
+      - closeScreen: reference/commands/closeScreen.md
+      - createWorld: reference/commands/createWorld.md
+      - debugScreen: reference/commands/debugScreen.md
+      - keyboardInput: reference/commands/keyboardInput.md
+      - launchGame: reference/commands/launchGame.md
+      - lookAt: reference/commands/lookAt.md
+      - openInventory: reference/commands/openInventory.md
+      - runCommand: reference/commands/runCommand.md
+      - selectHotbar: reference/commands/selectHotbar.md
+      - startVanillaServer: reference/commands/startVanillaServer.md
+      - useItem: reference/commands/useItem.md
+      - waitTicks: reference/commands/waitTicks.md
+      - waitUntil: reference/commands/waitUntil.md
+      - walkUntil: reference/commands/walkUntil.md

--- a/screenplay-docs/requirements.txt
+++ b/screenplay-docs/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.5,<10

--- a/screenplay-fabric/README.md
+++ b/screenplay-fabric/README.md
@@ -2,6 +2,8 @@
 
 **Screenplay** is a multi-loader library for real-client Minecraft scenario tests with CI screenshots.
 
+**Documentation:** [Quick start](https://adam-k-ali.github.io/DWM/quickstart/) · [Commands available](https://adam-k-ali.github.io/DWM/reference/commands/) · [Full docs](https://adam-k-ali.github.io/DWM/)
+
 | Module | Role |
 | --- | --- |
 | `screenplay-common` | Shared YAML compiler, runner, primitives (unit-tested here) |

--- a/src/screenplayTests/AGENTS.md
+++ b/src/screenplayTests/AGENTS.md
@@ -7,8 +7,8 @@ The harness lives in the `screenplay-*` Gradle modules (`screenplay-fabric` on t
 ## Local Context
 YAML scenarios drive the **real Minecraft client** via Screenplay. Primitives and the compiler ship in `screenplay-common`. Mod scenarios stay under `resources/tests/` (e.g. `placeAndOpenTardis.yaml`). Vanilla demos ship inside `screenplay-common` resources.
 
-Full product docs: `screenplay-fabric/README.md` and `metadata/screenplay/modrinth-body.md`.
-Step/selector reference for authors: this directory’s `README.md`.
+Full docs (quick start + API reference): https://adam-k-ali.github.io/DWM/
+Also: `screenplay-fabric/README.md`, `metadata/screenplay/modrinth-body.md`, and this directory’s `README.md`.
 
 ## Commands
 - Run a scenario: `./gradlew runScreenplay -Pscreenplay=<yaml-filename-stem>`

--- a/src/screenplayTests/README.md
+++ b/src/screenplayTests/README.md
@@ -4,6 +4,9 @@ This directory holds mod-owned **Screenplay** YAML scenarios. The harness ships
 as the `screenplay-*` Gradle modules (`screenplay-fabric` on the client run).
 It is not included in the production mod jar.
 
+Full documentation (quick start + command API reference):
+https://adam-k-ali.github.io/DWM/
+
 ## Running a scenario
 
 Run a test by its YAML filename without the extension:
@@ -98,7 +101,7 @@ steps:
 
 Supported frontmatter types are:
 
-- `test` — an executable scenario selected with `-Pscenario`.
+- `test` — an executable scenario selected with `-Pscreenplay`.
 - `command` — a reusable composite command.
 
 The filename stem is the stable ID. For example,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

Screenplay lacked a published docs site. Authors and agents needed a Maestro-style quick start and per-command API reference instead of hunting through scattered READMEs.

## Proposed Implementation

- Added MkDocs Material site under `screenplay-docs/` with home, quick start, writing/running guides, extending primitives, selectors, Gradle plugin reference, and a Commands available index plus one page per built-in command (and `assertAndClick`).
- Added `.github/workflows/docs-screenplay.yml` to build with `mkdocs build --strict` and deploy to GitHub Pages on pushes to `main`.
- Cross-linked the Pages URL from `screenplay-fabric/README.md`, `metadata/screenplay/modrinth-body.md`, root `AGENTS.md`, and `src/screenplayTests/` docs; fixed stale `-Pscenario` wording in the screenplayTests README.

Validated locally with `mkdocs build --strict` (18 command pages + guides). Screenshots of the served site under the `/DWM/` project-pages base path are attached in the agent walkthrough.

**Post-merge:** set the repo Pages source to **GitHub Actions** (Settings → Pages) if not already configured. Site URL: https://adam-k-ali.github.io/DWM/

## Problems Encountered / Decisions Made

- Kept DWM product markdown under `docs/` unpublished separately; this site is Screenplay-only.
- Built-in composite `assertAndClick` is documented alongside Java primitives in the command reference for Maestro-like discoverability.
- `site_url` uses the GitHub project Pages path (`/DWM/`), so local `mkdocs serve` is under `http://127.0.0.1:8000/DWM/`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a02fbb-a577-75e0-b147-1674b098f127?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a02fbb-a577-75e0-b147-1674b098f127&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

