### PR TITLE
refactor(platform): introduce DwmPlatform SPI for Fabric

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - `tools/`: Offline Python scripts (TARDIS SFX generation/analysis); not part of Gradle build.
 - `metadata/`: Modrinth listing (`modrinth.json`, `modrinth-body.md`).
 - `screenplay-common` / `screenplay-fabric`: Screenplay real-client scenario library (Fabric path used by this mod).
-- `screenplay-loaders/`: Included build for `screenplay-forge` and `screenplay-neoforge` (isolated from Loom).
+- `screenplay-loaders/`: Separate Gradle build for `screenplay-forge` and `screenplay-neoforge` (not wired into the Fabric root; use `./gradlew -p screenplay-loaders`).
 - `screenplay-gradle-plugin`: Gradle plugin `com.adamkali.screenplay` (`runScreenplay`, `runScreenplayTests`).
 - `screenplay-docs/`: Screenplay GitHub Pages site (MkDocs Material) — published at https://adam-k-ali.github.io/DWM/
 - `metadata/screenplay/`: Screenplay Modrinth listing drafts (`modrinth.json`, `modrinth-body.md`).

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,8 +22,11 @@ plugins {
 }
 
 includeBuild('screenplay-gradle-plugin')
-// Isolate Forge/NeoGradle from Fabric Loom runs (NeoGradle treats custom Loom run names as run types).
-includeBuild('screenplay-loaders')
+// Forge/NeoForge stay in screenplay-loaders as a separate Gradle invocation
+// (`./gradlew -p screenplay-loaders …`). Do not includeBuild them here: ForgeGradle's
+// mavenizer fails under the Java language server Tooling API, which leaves the root
+// project without a Java nature and breaks Cursor/VS Code run configs
+// (`ConfigError: The project 'dwm' is not a valid java project`).
 
 include 'screenplay-common'
 include 'screenplay-fabric'

--- a/src/client/java/com/adamkali/dwm/ClientAnalyticsManager.java
+++ b/src/client/java/com/adamkali/dwm/ClientAnalyticsManager.java
@@ -1,7 +1,7 @@
 package com.adamkali.dwm;
 
 import com.adamkali.dwm.analytics.AnalyticsManager;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import com.adamkali.dwm.platform.DwmClientServices;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -31,7 +31,7 @@ public class ClientAnalyticsManager {
                 DELIVERY_INTERVAL_MS,
                 TimeUnit.MILLISECONDS);
 
-        ClientLifecycleEvents.CLIENT_STOPPING.register(client -> shutdown());
+        DwmClientServices.get().registerClientStopping(client -> shutdown());
     }
 
     private static void shutdown() {

--- a/src/client/java/com/adamkali/dwm/ClientTardis.java
+++ b/src/client/java/com/adamkali/dwm/ClientTardis.java
@@ -6,8 +6,8 @@ import com.adamkali.dwm.network.SaveWaypointC2SPayload;
 import com.adamkali.dwm.network.SelectPlayerC2SPayload;
 import com.adamkali.dwm.network.SelectWaypointC2SPayload;
 import com.adamkali.dwm.network.UpdateTardisChameleonC2SPayload;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,26 +25,26 @@ public class ClientTardis {
     }
 
     public void updateChameleonVariant(@NotNull TardisChameleonVariant variant) {
-        ClientPlayNetworking.send(new UpdateTardisChameleonC2SPayload(variant.getId(), this.tardisId));
+        DwmClientServices.get().sendToServer(new UpdateTardisChameleonC2SPayload(variant.getId(), this.tardisId));
     }
 
     public void saveWaypoint(@Nullable String name) {
-        ClientPlayNetworking.send(new SaveWaypointC2SPayload(this.tardisId, name == null ? "" : name));
+        DwmClientServices.get().sendToServer(new SaveWaypointC2SPayload(this.tardisId, name == null ? "" : name));
     }
 
     public void deleteWaypoint(@NotNull UUID waypointId) {
-        ClientPlayNetworking.send(new DeleteWaypointC2SPayload(this.tardisId, waypointId));
+        DwmClientServices.get().sendToServer(new DeleteWaypointC2SPayload(this.tardisId, waypointId));
     }
 
     public void renameWaypoint(@NotNull UUID waypointId, @NotNull String name) {
-        ClientPlayNetworking.send(new RenameWaypointC2SPayload(this.tardisId, waypointId, name));
+        DwmClientServices.get().sendToServer(new RenameWaypointC2SPayload(this.tardisId, waypointId, name));
     }
 
     public void selectWaypoint(@Nullable UUID waypointId) {
-        ClientPlayNetworking.send(new SelectWaypointC2SPayload(this.tardisId, waypointId));
+        DwmClientServices.get().sendToServer(new SelectWaypointC2SPayload(this.tardisId, waypointId));
     }
 
     public void selectPlayer(@Nullable UUID playerUuid) {
-        ClientPlayNetworking.send(new SelectPlayerC2SPayload(this.tardisId, playerUuid));
+        DwmClientServices.get().sendToServer(new SelectPlayerC2SPayload(this.tardisId, playerUuid));
     }
 }

--- a/src/client/java/com/adamkali/dwm/DWMBlockEntityRendererFactories.java
+++ b/src/client/java/com/adamkali/dwm/DWMBlockEntityRendererFactories.java
@@ -1,22 +1,24 @@
 package com.adamkali.dwm;
 
 import com.adamkali.dwm.block.entities.DWMBlockEntities;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.render.FirstDoctorConsoleBlockEntityRenderer;
 import com.adamkali.dwm.render.TardisBlockEntityRenderer;
 import com.adamkali.dwm.render.TardisDecorBlockEntityRenderer;
 import com.adamkali.dwm.render.TardisInteriorDoorBlockEntityRenderer;
-import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;
 
 public class DWMBlockEntityRendererFactories {
     public static void initialize() {
-        BlockEntityRendererRegistry.register(DWMBlockEntities.TARDIS_BLOCK_ENTITY, TardisBlockEntityRenderer::new);
-        BlockEntityRendererRegistry.register(
+        DwmClientPlatform platform = DwmClientServices.get();
+        platform.registerBlockEntityRenderer(DWMBlockEntities.TARDIS_BLOCK_ENTITY, TardisBlockEntityRenderer::new);
+        platform.registerBlockEntityRenderer(
                 DWMBlockEntities.TARDIS_INTERIOR_DOOR_BLOCK_ENTITY,
                 TardisInteriorDoorBlockEntityRenderer::new);
-        BlockEntityRendererRegistry.register(
+        platform.registerBlockEntityRenderer(
                 DWMBlockEntities.FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY,
                 FirstDoctorConsoleBlockEntityRenderer::new);
-        BlockEntityRendererRegistry.register(
+        platform.registerBlockEntityRenderer(
                 DWMBlockEntities.TARDIS_DECOR_BLOCK_ENTITY,
                 TardisDecorBlockEntityRenderer::new);
     }

--- a/src/client/java/com/adamkali/dwm/DWMClient.java
+++ b/src/client/java/com/adamkali/dwm/DWMClient.java
@@ -2,6 +2,8 @@ package com.adamkali.dwm;
 
 import com.adamkali.dwm.network.ClientPayloadTypeRegistry;
 import com.adamkali.dwm.client.DWMEntityRenderers;
+import com.adamkali.dwm.platform.DwmClientServices;
+import com.adamkali.dwm.platform.fabric.FabricDwmClientPlatform;
 import com.adamkali.dwm.render.ConsoleControlHud;
 import com.adamkali.dwm.render.ConsoleHitboxDebugRenderer;
 import com.adamkali.dwm.render.TardisCompactScannerSpecialRenderer;
@@ -14,13 +16,13 @@ import com.adamkali.dwm.render.portal.PortalSupport;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.sound.TardisHumController;
 import net.fabricmc.api.ClientModInitializer;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.renderer.special.SpecialModelRenderers;
 import net.minecraft.resources.Identifier;
 
 public class DWMClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
+        DwmClientServices.set(new FabricDwmClientPlatform());
         SpecialModelRenderers.ID_MAPPER.put(
                 Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "tardis_full_scanner"),
                 TardisFullScannerSpecialRenderer.Unbaked.MAP_CODEC);
@@ -44,6 +46,6 @@ public class DWMClient implements ClientModInitializer {
         // resource reload, which is after client init. Register before that snapshot.
         PortalDoorRenderer.ensurePipelineRegistered();
         PortalSupport.initialize();
-        ClientTickEvents.END_CLIENT_TICK.register(client -> PortalSceneStore.clientTick());
+        DwmClientServices.get().registerEndClientTick(client -> PortalSceneStore.clientTick());
     }
 }

--- a/src/client/java/com/adamkali/dwm/DWMRenderLayerManager.java
+++ b/src/client/java/com/adamkali/dwm/DWMRenderLayerManager.java
@@ -1,7 +1,8 @@
 package com.adamkali.dwm;
 
 import com.adamkali.dwm.model.tileentity.*;
-import net.fabricmc.fabric.api.client.rendering.v1.ModelLayerRegistry;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 
 /**
  * Registers entity/block-entity model layers. Terrain cutout/translucent layers are
@@ -9,69 +10,70 @@ import net.fabricmc.fabric.api.client.rendering.v1.ModelLayerRegistry;
  */
 public class DWMRenderLayerManager {
     private static void registerEntityRenderLayers() {
-        ModelLayerRegistry.registerModelLayer(TTCapsuleModel.LAYER_LOCATION, TTCapsuleModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(FirstDoctorTardisModel.LAYER_LOCATION, FirstDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(SecondDoctorTardisModel.LAYER_LOCATION, SecondDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(ThirdDoctorTardisModel.LAYER_LOCATION, ThirdDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(FourthDoctorTardisModel.LAYER_LOCATION, FourthDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(FifthDoctorTardisModel.LAYER_LOCATION, FifthDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(SixthDoctorTardisModel.LAYER_LOCATION, SixthDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(SeventhDoctorTardisModel.LAYER_LOCATION, SeventhDoctorTardisModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        DwmClientPlatform platform = DwmClientServices.get();
+        platform.registerModelLayer(TTCapsuleModel.LAYER_LOCATION, TTCapsuleModel::getTexturedModelData);
+        platform.registerModelLayer(FirstDoctorTardisModel.LAYER_LOCATION, FirstDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(SecondDoctorTardisModel.LAYER_LOCATION, SecondDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(ThirdDoctorTardisModel.LAYER_LOCATION, ThirdDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(FourthDoctorTardisModel.LAYER_LOCATION, FourthDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(FifthDoctorTardisModel.LAYER_LOCATION, FifthDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(SixthDoctorTardisModel.LAYER_LOCATION, SixthDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(SeventhDoctorTardisModel.LAYER_LOCATION, SeventhDoctorTardisModel::getTexturedModelData);
+        platform.registerModelLayer(
                 TardisClassicInteriorDoorModel.LAYER_LOCATION,
                 TardisClassicInteriorDoorModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 FirstDoctorConsoleModel.LAYER_LOCATION,
                 FirstDoctorConsoleModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 BiomeSelectorModel.LAYER_LOCATION,
                 BiomeSelectorModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 PlanetLocatorModel.LAYER_LOCATION,
                 PlanetLocatorModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 WaypointSelectorModel.LAYER_LOCATION,
                 WaypointSelectorModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 PlayerLocatorModel.LAYER_LOCATION,
                 PlayerLocatorModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 ChameleonCircuitModel.LAYER_LOCATION,
                 ChameleonCircuitModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 MaterialisationLeverModel.LAYER_LOCATION,
                 MaterialisationLeverModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 FastReturnModel.LAYER_LOCATION,
                 FastReturnModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 StabilisersModel.LAYER_LOCATION,
                 StabilisersModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 ReaderModel.LAYER_LOCATION,
                 ReaderModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 RadiationReaderModel.LAYER_LOCATION,
                 RadiationReaderModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 CloakLeverModel.LAYER_LOCATION,
                 CloakLeverModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 DoorLockModel.LAYER_LOCATION,
                 DoorLockModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 TelepathicCircuitModel.LAYER_LOCATION,
                 TelepathicCircuitModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 CoordinateLockModel.LAYER_LOCATION,
                 CoordinateLockModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 TardisGlobeModel.LAYER_LOCATION,
                 TardisGlobeModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 TardisCompactScannerModel.LAYER_LOCATION,
                 TardisCompactScannerModel::getTexturedModelData);
-        ModelLayerRegistry.registerModelLayer(
+        platform.registerModelLayer(
                 TardisFullScannerModel.LAYER_LOCATION,
                 TardisFullScannerModel::getTexturedModelData);
     }

--- a/src/client/java/com/adamkali/dwm/client/DWMEntityRenderers.java
+++ b/src/client/java/com/adamkali/dwm/client/DWMEntityRenderers.java
@@ -6,10 +6,10 @@ import com.adamkali.dwm.block.wood.RegisteredWoodFamily;
 import com.adamkali.dwm.entity.DWMEntityTypes;
 import com.adamkali.dwm.model.entity.BroakirModel;
 import com.adamkali.dwm.model.entity.FlutterwingModel;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.render.BroakirRenderer;
 import com.adamkali.dwm.render.FlutterwingRenderer;
-import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.ModelLayerRegistry;
 import net.minecraft.client.model.geom.ModelLayerLocation;
 import net.minecraft.client.model.object.boat.BoatModel;
 import net.minecraft.client.renderer.entity.BoatRenderer;
@@ -21,22 +21,23 @@ public final class DWMEntityRenderers {
     }
 
     public static void initialize() {
+        DwmClientPlatform platform = DwmClientServices.get();
         for (RegisteredWoodFamily family : DWMBlocks.WOOD_FAMILIES) {
             ModelLayerLocation layer = new ModelLayerLocation(
                     Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "boat/" + family.definition().id()),
                     "main"
             );
-            ModelLayerRegistry.registerModelLayer(layer, BoatModel::createBoatModel);
-            EntityRendererRegistry.register(
+            platform.registerModelLayer(layer, BoatModel::createBoatModel);
+            platform.registerEntityRenderer(
                     family.boatEntity(),
                     context -> new BoatRenderer(context, layer)
             );
         }
-        EntityRendererRegistry.register(DWMEntityTypes.TARDIS_SEAT, NoopRenderer::new);
-        EntityRendererRegistry.register(DWMEntityTypes.CONSOLE_CONTROL, NoopRenderer::new);
-        ModelLayerRegistry.registerModelLayer(BroakirModel.LAYER_LOCATION, BroakirModel::createBodyLayer);
-        EntityRendererRegistry.register(DWMEntityTypes.BROAKIR, BroakirRenderer::new);
-        ModelLayerRegistry.registerModelLayer(FlutterwingModel.LAYER_LOCATION, FlutterwingModel::createBodyLayer);
-        EntityRendererRegistry.register(DWMEntityTypes.FLUTTERWING, FlutterwingRenderer::new);
+        platform.registerEntityRenderer(DWMEntityTypes.TARDIS_SEAT, NoopRenderer::new);
+        platform.registerEntityRenderer(DWMEntityTypes.CONSOLE_CONTROL, NoopRenderer::new);
+        platform.registerModelLayer(BroakirModel.LAYER_LOCATION, BroakirModel::createBodyLayer);
+        platform.registerEntityRenderer(DWMEntityTypes.BROAKIR, BroakirRenderer::new);
+        platform.registerModelLayer(FlutterwingModel.LAYER_LOCATION, FlutterwingModel::createBodyLayer);
+        platform.registerEntityRenderer(DWMEntityTypes.FLUTTERWING, FlutterwingRenderer::new);
     }
 }

--- a/src/client/java/com/adamkali/dwm/gui/PlayerLocatorScreen.java
+++ b/src/client/java/com/adamkali/dwm/gui/PlayerLocatorScreen.java
@@ -4,8 +4,6 @@ import com.adamkali.dwm.ClientTardis;
 import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.network.OpenPlayerLocatorScreen;
 import com.adamkali.dwm.text.DimensionNames;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
@@ -27,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-@Environment(EnvType.CLIENT)
 public class PlayerLocatorScreen extends Screen {
     private static final Identifier BACKGROUND = Identifier.withDefaultNamespace("popup/background");
     private static final Identifier ICON_SELECTED =

--- a/src/client/java/com/adamkali/dwm/gui/TardisChameleonGui.java
+++ b/src/client/java/com/adamkali/dwm/gui/TardisChameleonGui.java
@@ -4,8 +4,6 @@ import com.adamkali.dwm.ClientTardis;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
@@ -16,7 +14,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.Identifier;
 
-@Environment(EnvType.CLIENT)
 public class TardisChameleonGui extends Screen {
     private static final Identifier BACKGROUND = Identifier.withDefaultNamespace("popup/background");
     private static final TardisChameleonVariant[] variants = TardisChameleonVariant.values();

--- a/src/client/java/com/adamkali/dwm/gui/WaypointScreen.java
+++ b/src/client/java/com/adamkali/dwm/gui/WaypointScreen.java
@@ -4,8 +4,6 @@ import com.adamkali.dwm.ClientTardis;
 import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.network.OpenWaypointScreen;
 import com.adamkali.dwm.text.DimensionNames;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
@@ -29,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-@Environment(EnvType.CLIENT)
 public class WaypointScreen extends Screen {
     private static final Identifier BACKGROUND = Identifier.withDefaultNamespace("popup/background");
     private static final Identifier ICON_SELECTED =

--- a/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
+++ b/src/client/java/com/adamkali/dwm/network/ClientPayloadTypeRegistry.java
@@ -4,32 +4,33 @@ import com.adamkali.dwm.ClientTardis;
 import com.adamkali.dwm.gui.PlayerLocatorScreen;
 import com.adamkali.dwm.gui.TardisChameleonGui;
 import com.adamkali.dwm.gui.WaypointScreen;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalRenderTarget;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.sound.TardisTravelSoundController;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.mojang.logging.LogUtils;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import org.slf4j.Logger;
 
 public class ClientPayloadTypeRegistry {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     public static void initialize() {
-        ClientPlayNetworking.registerGlobalReceiver(OpenTardisChameleonScreen.ID, ClientPayloadTypeRegistry::openTardisChameleonScreen);
-        ClientPlayNetworking.registerGlobalReceiver(OpenWaypointScreen.ID, ClientPayloadTypeRegistry::openWaypointScreen);
-        ClientPlayNetworking.registerGlobalReceiver(OpenPlayerLocatorScreen.ID, ClientPayloadTypeRegistry::openPlayerLocatorScreen);
-        ClientPlayNetworking.registerGlobalReceiver(SyncPortalMetaS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalMeta);
-        ClientPlayNetworking.registerGlobalReceiver(SyncPortalChunkS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalChunk);
-        ClientPlayNetworking.registerGlobalReceiver(UnloadPortalChunkS2CPayload.ID, ClientPayloadTypeRegistry::unloadPortalChunk);
-        ClientPlayNetworking.registerGlobalReceiver(SyncPortalEntitySpawnS2CPayload.ID, ClientPayloadTypeRegistry::spawnPortalEntity);
-        ClientPlayNetworking.registerGlobalReceiver(SyncPortalEntityUpdateS2CPayload.ID, ClientPayloadTypeRegistry::updatePortalEntity);
-        ClientPlayNetworking.registerGlobalReceiver(SyncPortalEntityRemoveS2CPayload.ID, ClientPayloadTypeRegistry::removePortalEntity);
-        ClientPlayNetworking.registerGlobalReceiver(SyncPortalPerfS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalPerf);
-        ClientPlayNetworking.registerGlobalReceiver(TravelAudioS2CPayload.ID, ClientPayloadTypeRegistry::travelAudio);
-        ClientPlayConnectionEvents.DISCONNECT.register((handler, client) -> {
+        DwmClientPlatform platform = DwmClientServices.get();
+        platform.registerClientboundHandler(OpenTardisChameleonScreen.ID, ClientPayloadTypeRegistry::openTardisChameleonScreen);
+        platform.registerClientboundHandler(OpenWaypointScreen.ID, ClientPayloadTypeRegistry::openWaypointScreen);
+        platform.registerClientboundHandler(OpenPlayerLocatorScreen.ID, ClientPayloadTypeRegistry::openPlayerLocatorScreen);
+        platform.registerClientboundHandler(SyncPortalMetaS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalMeta);
+        platform.registerClientboundHandler(SyncPortalChunkS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalChunk);
+        platform.registerClientboundHandler(UnloadPortalChunkS2CPayload.ID, ClientPayloadTypeRegistry::unloadPortalChunk);
+        platform.registerClientboundHandler(SyncPortalEntitySpawnS2CPayload.ID, ClientPayloadTypeRegistry::spawnPortalEntity);
+        platform.registerClientboundHandler(SyncPortalEntityUpdateS2CPayload.ID, ClientPayloadTypeRegistry::updatePortalEntity);
+        platform.registerClientboundHandler(SyncPortalEntityRemoveS2CPayload.ID, ClientPayloadTypeRegistry::removePortalEntity);
+        platform.registerClientboundHandler(SyncPortalPerfS2CPayload.ID, ClientPayloadTypeRegistry::syncPortalPerf);
+        platform.registerClientboundHandler(TravelAudioS2CPayload.ID, ClientPayloadTypeRegistry::travelAudio);
+        platform.registerClientDisconnect((handler, client) -> {
             PortalSceneStore.invalidateAll();
             PortalRenderTarget.closeGlobal();
             TardisTravelSoundController.stopAll();
@@ -37,7 +38,7 @@ public class ClientPayloadTypeRegistry {
         });
     }
 
-    private static void openTardisChameleonScreen(OpenTardisChameleonScreen payload, ClientPlayNetworking.Context context) {
+    private static void openTardisChameleonScreen(OpenTardisChameleonScreen payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> {
             if (context.client().level == null) {
                 LOGGER.warn("Received OpenTardisChameleonScreen payload but client or world is null");
@@ -48,7 +49,7 @@ public class ClientPayloadTypeRegistry {
         });
     }
 
-    private static void openWaypointScreen(OpenWaypointScreen payload, ClientPlayNetworking.Context context) {
+    private static void openWaypointScreen(OpenWaypointScreen payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> {
             if (context.client().level == null) {
                 LOGGER.warn("Received OpenWaypointScreen payload but client or world is null");
@@ -66,7 +67,7 @@ public class ClientPayloadTypeRegistry {
         });
     }
 
-    private static void openPlayerLocatorScreen(OpenPlayerLocatorScreen payload, ClientPlayNetworking.Context context) {
+    private static void openPlayerLocatorScreen(OpenPlayerLocatorScreen payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> {
             if (context.client().level == null) {
                 LOGGER.warn("Received OpenPlayerLocatorScreen payload but client or world is null");
@@ -81,7 +82,7 @@ public class ClientPayloadTypeRegistry {
         });
     }
 
-    private static void syncPortalMeta(SyncPortalMetaS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void syncPortalMeta(SyncPortalMetaS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> {
             PortalSceneStore.applyMeta(payload);
             // Remote clients have no save directory; seed the shared cache so exterior
@@ -95,31 +96,31 @@ public class ClientPayloadTypeRegistry {
         });
     }
 
-    private static void syncPortalChunk(SyncPortalChunkS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void syncPortalChunk(SyncPortalChunkS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> PortalSceneStore.applyChunk(payload));
     }
 
-    private static void unloadPortalChunk(UnloadPortalChunkS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void unloadPortalChunk(UnloadPortalChunkS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> PortalSceneStore.unloadChunk(payload));
     }
 
-    private static void spawnPortalEntity(SyncPortalEntitySpawnS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void spawnPortalEntity(SyncPortalEntitySpawnS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> PortalSceneStore.applyEntitySpawn(payload));
     }
 
-    private static void updatePortalEntity(SyncPortalEntityUpdateS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void updatePortalEntity(SyncPortalEntityUpdateS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> PortalSceneStore.applyEntityUpdate(payload));
     }
 
-    private static void removePortalEntity(SyncPortalEntityRemoveS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void removePortalEntity(SyncPortalEntityRemoveS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> PortalSceneStore.removeEntity(payload));
     }
 
-    private static void syncPortalPerf(SyncPortalPerfS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void syncPortalPerf(SyncPortalPerfS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         context.client().execute(() -> PortalPerfStats.applyServerDiag(payload));
     }
 
-    private static void travelAudio(TravelAudioS2CPayload payload, ClientPlayNetworking.Context context) {
+    private static void travelAudio(TravelAudioS2CPayload payload, DwmClientPlatform.ClientPlayContext context) {
         TardisTravelSoundController.handle(payload);
     }
 }

--- a/src/client/java/com/adamkali/dwm/platform/DwmClientPlatform.java
+++ b/src/client/java/com/adamkali/dwm/platform/DwmClientPlatform.java
@@ -1,0 +1,82 @@
+package com.adamkali.dwm.platform;
+
+import net.minecraft.client.DeltaTracker;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.model.geom.builders.LayerDefinition;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.LevelRenderer;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Client-only loader SPI. Installed by the client entrypoint after {@link DwmPlatform}.
+ */
+public interface DwmClientPlatform {
+
+    void registerEndClientTick(Consumer<Minecraft> handler);
+
+    void registerClientStopping(Consumer<Minecraft> handler);
+
+    void registerClientDisconnect(BiConsumer<ClientPacketListener, Minecraft> handler);
+
+    <T extends CustomPacketPayload> void registerClientboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ClientPlayContext> handler
+    );
+
+    void sendToServer(CustomPacketPayload payload);
+
+    void registerModelLayer(ModelLayerLocation location, LayerDefinitionProvider definition);
+
+    <T extends Entity> void registerEntityRenderer(
+            EntityType<? extends T> type,
+            EntityRendererProvider<T> factory
+    );
+
+    <E extends BlockEntity, S extends BlockEntityRenderState> void registerBlockEntityRenderer(
+            BlockEntityType<? extends E> type,
+            BlockEntityRendererProvider<? super E, ? super S> factory
+    );
+
+    Identifier hudAnchorCrosshair();
+
+    Identifier hudAnchorMiscOverlays();
+
+    void attachHudAfter(Identifier afterVanillaElement, Identifier elementId, HudExtractor extractor);
+
+    void registerLevelRenderStartMain(Consumer<LevelRenderCtx> handler);
+
+    void registerLevelRenderEndMain(Consumer<LevelRenderCtx> handler);
+
+    void registerLevelRenderBeforeGizmos(Consumer<LevelRenderCtx> handler);
+
+    interface ClientPlayContext {
+        Minecraft client();
+    }
+
+    @FunctionalInterface
+    interface LayerDefinitionProvider {
+        LayerDefinition createLayerDefinition();
+    }
+
+    @FunctionalInterface
+    interface HudExtractor {
+        void extract(GuiGraphicsExtractor graphics, DeltaTracker deltaTracker);
+    }
+
+    interface LevelRenderCtx {
+        LevelRenderer levelRenderer();
+    }
+}

--- a/src/client/java/com/adamkali/dwm/platform/DwmClientServices.java
+++ b/src/client/java/com/adamkali/dwm/platform/DwmClientServices.java
@@ -1,0 +1,26 @@
+package com.adamkali.dwm.platform;
+
+/**
+ * Holds the loader-installed {@link DwmClientPlatform}. Client entrypoints must call
+ * {@link #set(DwmClientPlatform)} before any client common initialization.
+ */
+public final class DwmClientServices {
+    private static DwmClientPlatform platform;
+
+    private DwmClientServices() {
+    }
+
+    public static void set(DwmClientPlatform instance) {
+        if (instance == null) {
+            throw new IllegalArgumentException("DwmClientPlatform must not be null");
+        }
+        platform = instance;
+    }
+
+    public static DwmClientPlatform get() {
+        if (platform == null) {
+            throw new IllegalStateException("DwmClientPlatform has not been installed by the client entrypoint");
+        }
+        return platform;
+    }
+}

--- a/src/client/java/com/adamkali/dwm/platform/fabric/FabricDwmClientPlatform.java
+++ b/src/client/java/com/adamkali/dwm/platform/fabric/FabricDwmClientPlatform.java
@@ -1,0 +1,113 @@
+package com.adamkali.dwm.platform.fabric;
+
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayConnectionEvents;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.EntityRendererRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.ModelLayerRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
+import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Fabric client implementation of {@link DwmClientPlatform}.
+ */
+public final class FabricDwmClientPlatform implements DwmClientPlatform {
+    @Override
+    public void registerEndClientTick(Consumer<Minecraft> handler) {
+        ClientTickEvents.END_CLIENT_TICK.register(handler::accept);
+    }
+
+    @Override
+    public void registerClientStopping(Consumer<Minecraft> handler) {
+        ClientLifecycleEvents.CLIENT_STOPPING.register(handler::accept);
+    }
+
+    @Override
+    public void registerClientDisconnect(BiConsumer<ClientPacketListener, Minecraft> handler) {
+        ClientPlayConnectionEvents.DISCONNECT.register(handler::accept);
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerClientboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ClientPlayContext> handler
+    ) {
+        ClientPlayNetworking.registerGlobalReceiver(type, (payload, context) ->
+                handler.accept(payload, context::client));
+    }
+
+    @Override
+    public void sendToServer(CustomPacketPayload payload) {
+        ClientPlayNetworking.send(payload);
+    }
+
+    @Override
+    public void registerModelLayer(ModelLayerLocation location, LayerDefinitionProvider definition) {
+        ModelLayerRegistry.registerModelLayer(location, definition::createLayerDefinition);
+    }
+
+    @Override
+    public <T extends Entity> void registerEntityRenderer(
+            EntityType<? extends T> type,
+            EntityRendererProvider<T> factory
+    ) {
+        EntityRendererRegistry.register(type, factory);
+    }
+
+    @Override
+    public <E extends BlockEntity, S extends BlockEntityRenderState> void registerBlockEntityRenderer(
+            BlockEntityType<? extends E> type,
+            BlockEntityRendererProvider<? super E, ? super S> factory
+    ) {
+        BlockEntityRendererRegistry.register(type, factory);
+    }
+
+    @Override
+    public Identifier hudAnchorCrosshair() {
+        return VanillaHudElements.CROSSHAIR;
+    }
+
+    @Override
+    public Identifier hudAnchorMiscOverlays() {
+        return VanillaHudElements.MISC_OVERLAYS;
+    }
+
+    @Override
+    public void attachHudAfter(Identifier afterVanillaElement, Identifier elementId, HudExtractor extractor) {
+        HudElementRegistry.attachElementAfter(afterVanillaElement, elementId, extractor::extract);
+    }
+
+    @Override
+    public void registerLevelRenderStartMain(Consumer<LevelRenderCtx> handler) {
+        LevelRenderEvents.START_MAIN.register(context -> handler.accept(context::levelRenderer));
+    }
+
+    @Override
+    public void registerLevelRenderEndMain(Consumer<LevelRenderCtx> handler) {
+        LevelRenderEvents.END_MAIN.register(context -> handler.accept(context::levelRenderer));
+    }
+
+    @Override
+    public void registerLevelRenderBeforeGizmos(Consumer<LevelRenderCtx> handler) {
+        LevelRenderEvents.BEFORE_GIZMOS.register(context -> handler.accept(context::levelRenderer));
+    }
+}

--- a/src/client/java/com/adamkali/dwm/render/ConsoleControlHud.java
+++ b/src/client/java/com/adamkali/dwm/render/ConsoleControlHud.java
@@ -4,10 +4,10 @@ import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.tardis.logic.ConsoleDisplayState;
 import com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -31,7 +31,8 @@ public final class ConsoleControlHud {
     }
 
     public static void initialize() {
-        HudElementRegistry.attachElementAfter(VanillaHudElements.CROSSHAIR, ELEMENT_ID, ConsoleControlHud::extract);
+        DwmClientPlatform platform = DwmClientServices.get();
+        platform.attachHudAfter(platform.hudAnchorCrosshair(), ELEMENT_ID, ConsoleControlHud::extract);
     }
 
     private static void extract(GuiGraphicsExtractor graphics, DeltaTracker tickCounter) {

--- a/src/client/java/com/adamkali/dwm/render/ConsoleHitboxDebugRenderer.java
+++ b/src/client/java/com/adamkali/dwm/render/ConsoleHitboxDebugRenderer.java
@@ -4,8 +4,8 @@ import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls;
 import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
-import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderContext;
-import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.components.debug.DebugScreenEntries;
 import net.minecraft.core.BlockPos;
@@ -47,10 +47,10 @@ public final class ConsoleHitboxDebugRenderer {
     }
 
     public static void initialize() {
-        LevelRenderEvents.BEFORE_GIZMOS.register(ConsoleHitboxDebugRenderer::beforeGizmos);
+        DwmClientServices.get().registerLevelRenderBeforeGizmos(ConsoleHitboxDebugRenderer::beforeGizmos);
     }
 
-    private static void beforeGizmos(LevelRenderContext context) {
+    private static void beforeGizmos(DwmClientPlatform.LevelRenderCtx context) {
         Minecraft client = Minecraft.getInstance();
         Level world = client.level;
         if (world == null || client.player == null) {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugHud.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalPerfDebugHud.java
@@ -2,8 +2,8 @@ package com.adamkali.dwm.render.portal;
 
 import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.config.DWMConfig;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
-import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import net.minecraft.client.DeltaTracker;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
@@ -50,7 +50,8 @@ public final class PortalPerfDebugHud {
 
     public static void initialize() {
         // No DEBUG element in Fabric 1.21+ VanillaHudElements; MISC_OVERLAYS is the early HUD slot.
-        HudElementRegistry.attachElementAfter(VanillaHudElements.MISC_OVERLAYS, ELEMENT_ID, PortalPerfDebugHud::extract);
+        DwmClientPlatform platform = DwmClientServices.get();
+        platform.attachHudAfter(platform.hudAnchorMiscOverlays(), ELEMENT_ID, PortalPerfDebugHud::extract);
     }
 
     private static void extract(GuiGraphicsExtractor graphics, DeltaTracker tickCounter) {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
@@ -9,10 +9,10 @@ import com.adamkali.dwm.network.SyncPortalMetaS2CPayload;
 import com.adamkali.dwm.network.UnloadPortalChunkS2CPayload;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostExterior;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostMeshCache;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
 import com.adamkali.dwm.tardis.portal.PortalShellState;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.minecraft.client.Minecraft;
 
 import java.util.Map;
@@ -136,7 +136,7 @@ public final class PortalSceneStore {
             return;
         }
         LAST_REQUEST_MS.put(key, now);
-        ClientPlayNetworking.send(new RequestPortalStreamC2SPayload(kind, tardisId));
+        DwmClientServices.get().sendToServer(new RequestPortalStreamC2SPayload(kind, tardisId));
     }
 
     public static void invalidate(PortalStreamKind kind, UUID tardisId) {

--- a/src/client/java/com/adamkali/dwm/render/portal/PortalSupport.java
+++ b/src/client/java/com/adamkali/dwm/render/portal/PortalSupport.java
@@ -1,8 +1,8 @@
 package com.adamkali.dwm.render.portal;
 
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.mojang.logging.LogUtils;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientLifecycleEvents;
-import net.fabricmc.fabric.api.client.rendering.v1.level.LevelRenderEvents;
 import net.minecraft.client.GraphicsPreset;
 import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
@@ -26,10 +26,11 @@ public final class PortalSupport {
             return;
         }
         initialized = true;
-        LevelRenderEvents.START_MAIN.register(context -> PortalRenderTarget.beginClientFrame());
+        DwmClientPlatform platform = DwmClientServices.get();
+        platform.registerLevelRenderStartMain(context -> PortalRenderTarget.beginClientFrame());
         // Portal FBO clear/mesh draws must not run mid-BER (blacks out world/items on 26.2).
-        LevelRenderEvents.END_MAIN.register(context -> PortalScheduler.flushEndMain());
-        ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
+        platform.registerLevelRenderEndMain(context -> PortalScheduler.flushEndMain());
+        platform.registerClientStopping(client -> {
             PortalRenderTarget.closeGlobal();
             PortalFeatureFlush.closeGlobal();
         });

--- a/src/client/java/com/adamkali/dwm/sound/TardisHumController.java
+++ b/src/client/java/com/adamkali/dwm/sound/TardisHumController.java
@@ -1,7 +1,7 @@
 package com.adamkali.dwm.sound;
 
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
-import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.player.LocalPlayer;
 
@@ -15,7 +15,7 @@ public final class TardisHumController {
     }
 
     public static void initialize() {
-        ClientTickEvents.END_CLIENT_TICK.register(TardisHumController::onEndTick);
+        DwmClientServices.get().registerEndClientTick(TardisHumController::onEndTick);
     }
 
     private static void onEndTick(Minecraft client) {

--- a/src/main/java/com/adamkali/dwm/DWMMain.java
+++ b/src/main/java/com/adamkali/dwm/DWMMain.java
@@ -10,13 +10,14 @@ import com.adamkali.dwm.entity.DWMEntityTypes;
 import com.adamkali.dwm.item.DWMDataComponents;
 import com.adamkali.dwm.item.DWMItems;
 import com.adamkali.dwm.network.ServerPayloadTypeRegistry;
+import com.adamkali.dwm.platform.DwmServices;
+import com.adamkali.dwm.platform.fabric.FabricDwmPlatform;
 import com.adamkali.dwm.sound.DWMSounds;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.logic.TardisTravelService;
 import com.adamkali.dwm.tardis.portal.PortalStreamSyncService;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.world.level.storage.LevelResource;
 import org.slf4j.Logger;
 
@@ -25,6 +26,7 @@ public class DWMMain implements ModInitializer {
 
     @Override
     public void onInitialize() {
+        DwmServices.set(new FabricDwmPlatform());
         LOGGER.info("Initializing Doctor Who Mod");
         DWMConfig.init();
         DWMStatistics.initialize();
@@ -39,10 +41,10 @@ public class DWMMain implements ModInitializer {
         PortalStreamSyncService.initialize();
         TardisTravelService.initialize();
         TardisCommands.initialize();
-        ServerLifecycleEvents.SERVER_STARTED.register(server -> {
+        DwmServices.get().registerServerStarted(server -> {
             TardisDataLoader.tardisSaveDirectory = server.getWorldPath(LevelResource.ROOT).resolve("tardis_data");
         });
-        ServerLifecycleEvents.AFTER_SAVE.register((server, flush, force) -> {
+        DwmServices.get().registerAfterSave((server, flush, force) -> {
             TardisDataLoader.save();
         });
 

--- a/src/main/java/com/adamkali/dwm/block/DWMBlocks.java
+++ b/src/main/java/com/adamkali/dwm/block/DWMBlocks.java
@@ -8,10 +8,7 @@ import com.adamkali.dwm.block.wood.WoodFamilyDefinition;
 import com.adamkali.dwm.block.wood.WoodFamilyFeature;
 import com.adamkali.dwm.block.wood.WoodFamilyRegistrar;
 import com.adamkali.dwm.item.DWMItemTags;
-import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
-import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
-import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
-import net.fabricmc.fabric.api.registry.CompostableRegistry;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -526,14 +523,15 @@ public class DWMBlocks {
     public static void initialize() {
         DWMWoodTypes.initialize();
 
-        CompostableRegistry.INSTANCE.add(FLOWER_OF_REMEMBRANCE.asItem(), 0.65F);
-        CompostableRegistry.INSTANCE.add(MOONLIGHT_BLOOM.asItem(), 0.65F);
-        CompostableRegistry.INSTANCE.add(SACCHARINE_CANE.asItem(), 0.50F);
+        var platform = DwmServices.get();
+        platform.registerCompostable(FLOWER_OF_REMEMBRANCE.asItem(), 0.65F);
+        platform.registerCompostable(MOONLIGHT_BLOOM.asItem(), 0.65F);
+        platform.registerCompostable(SACCHARINE_CANE.asItem(), 0.50F);
 
-        PlayerBlockBreakEvents.BEFORE.register((world, player, pos, state, blockEntity) ->
+        platform.registerBeforeBlockBreak((world, player, pos, state, blockEntity) ->
                 !FirstDoctorConsoleBlock.isPlayerBreakDenied(state));
 
-        AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+        platform.registerAttackBlock((player, world, hand, pos, direction) -> {
             if (FirstDoctorConsoleBlock.isPlayerBreakDenied(world.getBlockState(pos))) {
                 return InteractionResult.FAIL;
             }
@@ -544,7 +542,7 @@ public class DWMBlocks {
             WoodFamilyRegistrar.wireRuntime(family);
         }
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.BUILDING_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.BUILDING_BLOCKS, content -> {
             content.accept(BLACK_ROUNDEL_A);
             content.accept(BLUE_ROUNDEL_A);
             content.accept(BROWN_ROUNDEL_A);
@@ -682,7 +680,7 @@ public class DWMBlocks {
             }
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.NATURAL_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.NATURAL_BLOCKS, content -> {
             content.accept(GALLIFREY_GRASS_BLOCK);
             content.accept(GALLIFREY_DIRT);
             content.accept(GALLIFREY_COARSE_DIRT);
@@ -705,7 +703,7 @@ public class DWMBlocks {
             }
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.REDSTONE_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.REDSTONE_BLOCKS, content -> {
             content.accept(TARDIS_DOOR_BUTTON);
             for (RegisteredWoodFamily family : WOOD_FAMILIES) {
                 content.accept(family.blocks().button());
@@ -719,7 +717,7 @@ public class DWMBlocks {
             }
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.FUNCTIONAL_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.FUNCTIONAL_BLOCKS, content -> {
             content.accept(FIRST_DOCTOR_CONSOLE);
         });
     }

--- a/src/main/java/com/adamkali/dwm/block/DWMWoodTypes.java
+++ b/src/main/java/com/adamkali/dwm/block/DWMWoodTypes.java
@@ -1,38 +1,46 @@
 package com.adamkali.dwm.block;
 
 import com.adamkali.dwm.DWMReference;
-import net.fabricmc.fabric.api.object.builder.v1.block.type.BlockSetTypeBuilder;
-import net.fabricmc.fabric.api.object.builder.v1.block.type.WoodTypeBuilder;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.resources.Identifier;
 import net.minecraft.world.level.block.state.properties.BlockSetType;
 import net.minecraft.world.level.block.state.properties.WoodType;
 
 /**
- * Custom wood / block-set types via Fabric builders (no mod access widener).
+ * Custom wood / block-set types via {@link DwmServices}.
  * Must be registered early so client sign atlases see them when
  * {@code TexturedRenderLayers} initializes.
+ *
+ * <p>Fields are assigned in {@link #initialize()} — call that after
+ * {@link DwmServices#set} and before any code that loads {@link DWMBlocks}
+ * (whose static wood-family fields read these types).
  */
 public final class DWMWoodTypes {
-    public static final BlockSetType ASH_SET = new BlockSetTypeBuilder()
-            .register(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "ash"));
-    public static final WoodType ASH = new WoodTypeBuilder()
-            .register(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "ash"), ASH_SET);
+    public static BlockSetType ASH_SET;
+    public static WoodType ASH;
 
-    public static final BlockSetType DARK_ASH_SET = new BlockSetTypeBuilder()
-            .register(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "dark_ash"));
-    public static final WoodType DARK_ASH = new WoodTypeBuilder()
-            .register(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "dark_ash"), DARK_ASH_SET);
+    public static BlockSetType DARK_ASH_SET;
+    public static WoodType DARK_ASH;
 
-    public static final BlockSetType CARDINAL_SET = new BlockSetTypeBuilder()
-            .register(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "cardinal"));
-    public static final WoodType CARDINAL = new WoodTypeBuilder()
-            .register(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "cardinal"), CARDINAL_SET);
+    public static BlockSetType CARDINAL_SET;
+    public static WoodType CARDINAL;
 
     private DWMWoodTypes() {
     }
 
-    /** Forces class initialization / registration. */
+    /** Registers wood / block-set types. Idempotent; safe to call more than once. */
     public static void initialize() {
-        // no-op — static fields register on class load
+        if (ASH_SET != null) {
+            return;
+        }
+        var platform = DwmServices.get();
+        ASH_SET = platform.registerBlockSetType(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "ash"));
+        ASH = platform.registerWoodType(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "ash"), ASH_SET);
+
+        DARK_ASH_SET = platform.registerBlockSetType(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "dark_ash"));
+        DARK_ASH = platform.registerWoodType(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "dark_ash"), DARK_ASH_SET);
+
+        CARDINAL_SET = platform.registerBlockSetType(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "cardinal"));
+        CARDINAL = platform.registerWoodType(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "cardinal"), CARDINAL_SET);
     }
 }

--- a/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
@@ -20,9 +20,9 @@ import com.adamkali.dwm.tardis.logic.StabiliserLogic;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.adamkali.dwm.tardis.logic.TardisTravelService;
 import com.adamkali.dwm.tardis.logic.TelepathicCircuitLogic;
+import com.adamkali.dwm.platform.DwmServices;
 import com.adamkali.dwm.text.DimensionNames;
 import com.mojang.serialization.MapCodec;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
@@ -337,7 +337,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
             return InteractionResult.CONSUME;
         }
         TardisDataModel model = TardisDataLoader.get(tardisId);
-        ServerPlayNetworking.send(player, OpenWaypointScreen.of(tardisId, model));
+        DwmServices.get().sendToPlayer(player, OpenWaypointScreen.of(tardisId, model));
         playClick(world, pos);
         return InteractionResult.SUCCESS;
     }
@@ -357,7 +357,7 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
                 PlayerLocatorLogic.listOnlineExcluding(serverWorld.getServer(), player.getUUID());
         TardisDataModel model = TardisDataLoader.get(tardisId);
         UUID selectedPlayerUuid = model == null ? null : model.selectedPlayerUuid;
-        ServerPlayNetworking.send(player, OpenPlayerLocatorScreen.of(tardisId, players, selectedPlayerUuid));
+        DwmServices.get().sendToPlayer(player, OpenPlayerLocatorScreen.of(tardisId, players, selectedPlayerUuid));
         playClick(world, pos);
         return InteractionResult.SUCCESS;
     }

--- a/src/main/java/com/adamkali/dwm/block/TardisBlock.java
+++ b/src/main/java/com/adamkali/dwm/block/TardisBlock.java
@@ -4,11 +4,11 @@ import com.adamkali.dwm.block.entities.DWMBlockEntities;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.network.OpenTardisChameleonScreen;
+import com.adamkali.dwm.platform.DwmServices;
 import com.adamkali.dwm.tardis.interior.TardisEntryGate;
 import com.adamkali.dwm.tardis.interior.TardisInteriorService;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.mojang.serialization.MapCodec;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -97,7 +97,7 @@ public class TardisBlock extends BaseEntityBlock {
                 }
             }
         } else if (!world.isClientSide() && DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)) {
-            ServerPlayNetworking.send((ServerPlayer) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
+            DwmServices.get().sendToPlayer((ServerPlayer) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
         }
 
         return InteractionResult.SUCCESS;

--- a/src/main/java/com/adamkali/dwm/block/entities/DWMBlockEntities.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/DWMBlockEntities.java
@@ -2,7 +2,8 @@ package com.adamkali.dwm.block.entities;
 
 import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.block.DWMBlocks;
-import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import com.adamkali.dwm.platform.DwmPlatform;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.Identifier;
@@ -10,32 +11,43 @@ import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
+/**
+ * Block entity types. Fields are assigned in {@link #initialize()} after
+ * {@link DwmServices#set} so registration can use the platform SPI.
+ */
 public class DWMBlockEntities {
-    public static final BlockEntityType<TardisBlockEntity> TARDIS_BLOCK_ENTITY =
-            register("tardis", TardisBlockEntity::new, DWMBlocks.TARDIS_BLOCK);
-
-    public static final BlockEntityType<TardisInteriorDoorBlockEntity> TARDIS_INTERIOR_DOOR_BLOCK_ENTITY =
-            register("tardis_interior_door", TardisInteriorDoorBlockEntity::new, DWMBlocks.TARDIS_INTERIOR_DOOR);
-
-    public static final BlockEntityType<FirstDoctorConsoleBlockEntity> FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY =
-            register("first_doctor_console", FirstDoctorConsoleBlockEntity::new, DWMBlocks.FIRST_DOCTOR_CONSOLE);
-
-    public static final BlockEntityType<TardisDecorBlockEntity> TARDIS_DECOR_BLOCK_ENTITY = register(
-            "tardis_decor",
-            TardisDecorBlockEntity::new,
-            DWMBlocks.TARDIS_GLOBE,
-            DWMBlocks.TARDIS_COMPACT_SCANNER,
-            DWMBlocks.TARDIS_FULL_SCANNER);
+    public static BlockEntityType<TardisBlockEntity> TARDIS_BLOCK_ENTITY;
+    public static BlockEntityType<TardisInteriorDoorBlockEntity> TARDIS_INTERIOR_DOOR_BLOCK_ENTITY;
+    public static BlockEntityType<FirstDoctorConsoleBlockEntity> FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY;
+    public static BlockEntityType<TardisDecorBlockEntity> TARDIS_DECOR_BLOCK_ENTITY;
 
     public static void initialize() {
+        if (TARDIS_BLOCK_ENTITY != null) {
+            return;
+        }
+        TARDIS_BLOCK_ENTITY = register("tardis", TardisBlockEntity::new, DWMBlocks.TARDIS_BLOCK);
+        TARDIS_INTERIOR_DOOR_BLOCK_ENTITY = register(
+                "tardis_interior_door", TardisInteriorDoorBlockEntity::new, DWMBlocks.TARDIS_INTERIOR_DOOR);
+        FIRST_DOCTOR_CONSOLE_BLOCK_ENTITY = register(
+                "first_doctor_console", FirstDoctorConsoleBlockEntity::new, DWMBlocks.FIRST_DOCTOR_CONSOLE);
+        TARDIS_DECOR_BLOCK_ENTITY = register(
+                "tardis_decor",
+                TardisDecorBlockEntity::new,
+                DWMBlocks.TARDIS_GLOBE,
+                DWMBlocks.TARDIS_COMPACT_SCANNER,
+                DWMBlocks.TARDIS_FULL_SCANNER);
     }
 
     private static <T extends BlockEntity> BlockEntityType<T> register(
             String name,
-            FabricBlockEntityTypeBuilder.Factory<? extends T> entityFactory,
+            DwmPlatform.BlockEntityFactory<T> entityFactory,
             Block... blocks
     ) {
         Identifier id = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, name);
-        return Registry.register(BuiltInRegistries.BLOCK_ENTITY_TYPE, id, FabricBlockEntityTypeBuilder.<T>create(entityFactory, blocks).build());
+        return Registry.register(
+                BuiltInRegistries.BLOCK_ENTITY_TYPE,
+                id,
+                DwmServices.get().buildBlockEntityType(entityFactory, blocks)
+        );
     }
 }

--- a/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
+++ b/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Objects;
 import java.util.UUID;
-import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.UUIDUtil;
@@ -74,7 +74,7 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
                 }
                 // Cheap enqueue when players track the shell — deferred place avoids MSPT hitch.
                 if (DWMConfig.getBoolean(DWMConfig.ENABLE_DOOR_PORTALS)
-                        && !PlayerLookup.tracking(serverLevel, pos).isEmpty()) {
+                        && DwmServices.get().hasTrackingPlayers(serverLevel, pos)) {
                     TardisInteriorPreloadService.requestPreload(serverLevel, this);
                 }
             }

--- a/src/main/java/com/adamkali/dwm/block/wood/WoodFamilyRegistrar.java
+++ b/src/main/java/com/adamkali/dwm/block/wood/WoodFamilyRegistrar.java
@@ -5,11 +5,8 @@ import com.adamkali.dwm.item.DWMCreativeTabs;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.entity.DWMEntityTypes;
 import com.adamkali.dwm.item.DWMItems;
-import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
-import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
-import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.vehicle.boat.Boat;
 import net.minecraft.world.item.BoatItem;
 import net.minecraft.world.item.HangingSignItem;
@@ -196,26 +193,26 @@ public final class WoodFamilyRegistrar {
 
     public static void wireRuntime(RegisteredWoodFamily family) {
         WoodFamilyBlocks blocks = family.blocks();
+        var platform = DwmServices.get();
 
-        StrippableBlockRegistry.register(blocks.log(), blocks.strippedLog());
-        StrippableBlockRegistry.register(blocks.wood(), blocks.strippedWood());
+        platform.registerStrippable(blocks.log(), blocks.strippedLog());
+        platform.registerStrippable(blocks.wood(), blocks.strippedWood());
 
-        FlammableBlockRegistry flammable = FlammableBlockRegistry.getDefaultInstance();
-        flammable.add(blocks.planks(), 5, 20);
-        flammable.add(blocks.slab(), 5, 20);
-        flammable.add(blocks.fenceGate(), 5, 20);
-        flammable.add(blocks.fence(), 5, 20);
-        flammable.add(blocks.stairs(), 5, 20);
-        flammable.add(blocks.log(), 5, 5);
-        flammable.add(blocks.strippedLog(), 5, 5);
-        flammable.add(blocks.wood(), 5, 5);
-        flammable.add(blocks.strippedWood(), 5, 5);
-        flammable.add(blocks.leaves(), 30, 60);
+        platform.registerFlammable(blocks.planks(), 5, 20);
+        platform.registerFlammable(blocks.slab(), 5, 20);
+        platform.registerFlammable(blocks.fenceGate(), 5, 20);
+        platform.registerFlammable(blocks.fence(), 5, 20);
+        platform.registerFlammable(blocks.stairs(), 5, 20);
+        platform.registerFlammable(blocks.log(), 5, 5);
+        platform.registerFlammable(blocks.strippedLog(), 5, 5);
+        platform.registerFlammable(blocks.wood(), 5, 5);
+        platform.registerFlammable(blocks.strippedWood(), 5, 5);
+        platform.registerFlammable(blocks.leaves(), 30, 60);
         if (blocks.door() != null) {
-            flammable.add(blocks.door(), 5, 20);
+            platform.registerFlammable(blocks.door(), 5, 20);
         }
         if (blocks.trapdoor() != null) {
-            flammable.add(blocks.trapdoor(), 5, 20);
+            platform.registerFlammable(blocks.trapdoor(), 5, 20);
         }
 
         BlockEntityTypes.SIGN.addValidBlock(blocks.sign());
@@ -226,17 +223,18 @@ public final class WoodFamilyRegistrar {
 
     public static void addCreativeTabs(RegisteredWoodFamily family) {
         WoodFamilyBlocks blocks = family.blocks();
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.BUILDING_BLOCKS).register(content -> {
+        var platform = DwmServices.get();
+        platform.modifyCreativeTab(DWMCreativeTabs.BUILDING_BLOCKS, content -> {
             for (Block block : family.buildingBlocks()) {
                 content.accept(block);
             }
         });
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.NATURAL_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.NATURAL_BLOCKS, content -> {
             content.accept(blocks.log());
             content.accept(blocks.leaves());
             content.accept(blocks.sapling());
         });
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.REDSTONE_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.REDSTONE_BLOCKS, content -> {
             content.accept(blocks.button());
             content.accept(blocks.pressurePlate());
             if (blocks.trapdoor() != null) {
@@ -246,8 +244,8 @@ public final class WoodFamilyRegistrar {
                 content.accept(blocks.door());
             }
         });
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.TOOLS_AND_UTILITIES).register(content -> content.accept(family.boatItem()));
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.FUNCTIONAL_BLOCKS).register(content -> {
+        platform.modifyCreativeTab(DWMCreativeTabs.TOOLS_AND_UTILITIES, content -> content.accept(family.boatItem()));
+        platform.modifyCreativeTab(DWMCreativeTabs.FUNCTIONAL_BLOCKS, content -> {
             content.accept(family.signItem());
             content.accept(family.hangingSignItem());
         });

--- a/src/main/java/com/adamkali/dwm/command/TardisCommands.java
+++ b/src/main/java/com/adamkali/dwm/command/TardisCommands.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.command;
 
+import com.adamkali.dwm.platform.DwmServices;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
@@ -11,7 +12,6 @@ import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import java.util.Optional;
 import java.util.UUID;
-import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.commands.arguments.UuidArgument;
@@ -28,7 +28,7 @@ public final class TardisCommands {
     }
 
     public static void initialize() {
-        CommandRegistrationCallback.EVENT.register((dispatcher, buildContext, selection) -> register(dispatcher));
+        DwmServices.get().registerCommands((dispatcher, buildContext, selection) -> register(dispatcher));
     }
 
     static void register(CommandDispatcher<CommandSourceStack> dispatcher) {

--- a/src/main/java/com/adamkali/dwm/entity/DWMEntityTypes.java
+++ b/src/main/java/com/adamkali/dwm/entity/DWMEntityTypes.java
@@ -4,7 +4,7 @@ import com.adamkali.dwm.DWMReference;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.wood.RegisteredWoodFamily;
 import com.adamkali.dwm.block.wood.WoodFamilyRegistrar;
-import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityType;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -81,51 +81,49 @@ public final class DWMEntityTypes {
     private static EntityType<BroakirEntity> registerBroakir() {
         Identifier id = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "broakir");
         ResourceKey<EntityType<?>> key = ResourceKey.create(Registries.ENTITY_TYPE, id);
-        return Registry.register(
+        EntityType<BroakirEntity> type = Registry.register(
                 BuiltInRegistries.ENTITY_TYPE,
                 key,
-                FabricEntityType.Builder.createMob(
-                                BroakirEntity::new,
-                                MobCategory.CREATURE,
-                                mob -> mob
-                                        .spawnPlacement(
-                                                SpawnPlacementTypes.ON_GROUND,
-                                                Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
-                                                (type, level, reason, pos, random) ->
-                                                        Animal.checkAnimalSpawnRules(type, level, reason, pos, random)
-                                        )
-                                        .defaultAttributes(BroakirEntity::createAttributes)
-                        )
+                EntityType.Builder.of(BroakirEntity::new, MobCategory.CREATURE)
                         .sized(1.4F, 2.3F)
                         .eyeHeight(2.0F)
                         .clientTrackingRange(10)
                         .build(key)
         );
+        var platform = DwmServices.get();
+        platform.registerSpawnPlacement(
+                type,
+                SpawnPlacementTypes.ON_GROUND,
+                Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+                (entityType, level, reason, pos, random) ->
+                        Animal.checkAnimalSpawnRules(entityType, level, reason, pos, random)
+        );
+        platform.registerDefaultAttributes(type, BroakirEntity::createAttributes);
+        return type;
     }
 
     private static EntityType<FlutterwingEntity> registerFlutterwing() {
         Identifier id = Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "flutterwing");
         ResourceKey<EntityType<?>> key = ResourceKey.create(Registries.ENTITY_TYPE, id);
-        return Registry.register(
+        EntityType<FlutterwingEntity> type = Registry.register(
                 BuiltInRegistries.ENTITY_TYPE,
                 key,
-                FabricEntityType.Builder.createMob(
-                                FlutterwingEntity::new,
-                                MobCategory.CREATURE,
-                                mob -> mob
-                                        .spawnPlacement(
-                                                SpawnPlacementTypes.ON_GROUND,
-                                                Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
-                                                (type, level, reason, pos, random) ->
-                                                        Animal.checkAnimalSpawnRules(type, level, reason, pos, random)
-                                        )
-                                        .defaultAttributes(FlutterwingEntity::createAttributes)
-                        )
+                EntityType.Builder.of(FlutterwingEntity::new, MobCategory.CREATURE)
                         .sized(0.9F * FlutterwingEntity.SCALE, 1.5F * FlutterwingEntity.SCALE)
                         .eyeHeight(1.2F * FlutterwingEntity.SCALE)
                         .clientTrackingRange(10)
                         .build(key)
         );
+        var platform = DwmServices.get();
+        platform.registerSpawnPlacement(
+                type,
+                SpawnPlacementTypes.ON_GROUND,
+                Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
+                (entityType, level, reason, pos, random) ->
+                        Animal.checkAnimalSpawnRules(entityType, level, reason, pos, random)
+        );
+        platform.registerDefaultAttributes(type, FlutterwingEntity::createAttributes);
+        return type;
     }
 
     public static EntityType<Boat> registerBoat(String path, java.util.function.Supplier<net.minecraft.world.item.Item> boatItem) {

--- a/src/main/java/com/adamkali/dwm/item/DWMItems.java
+++ b/src/main/java/com/adamkali/dwm/item/DWMItems.java
@@ -6,7 +6,7 @@ import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.block.wood.RegisteredWoodFamily;
 import com.adamkali.dwm.block.wood.WoodFamilyRegistrar;
 import com.adamkali.dwm.entity.DWMEntityTypes;
-import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.core.registries.Registries;
@@ -129,11 +129,11 @@ public class DWMItems {
                 "flutterwing_spawn_egg"
         );
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.INGREDIENTS).register(content -> {
+        DwmServices.get().modifyCreativeTab(DWMCreativeTabs.INGREDIENTS, content -> {
             content.accept(AZBANTIUM);
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.TOOLS_AND_UTILITIES).register(content -> {
+        DwmServices.get().modifyCreativeTab(DWMCreativeTabs.TOOLS_AND_UTILITIES, content -> {
             content.accept(SONIC_SECOND_DOCTOR);
             content.accept(SONIC_THIRD_DOCTOR);
             content.accept(SONIC_FOURTH_DOCTOR);
@@ -149,7 +149,7 @@ public class DWMItems {
             }
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.COMBAT).register(content -> {
+        DwmServices.get().modifyCreativeTab(DWMCreativeTabs.COMBAT, content -> {
             content.accept(AZBANTIUM_SWORD);
             content.accept(AZBANTIUM_HELMET);
             content.accept(AZBANTIUM_CHESTPLATE);
@@ -157,14 +157,14 @@ public class DWMItems {
             content.accept(AZBANTIUM_BOOTS);
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.FUNCTIONAL_BLOCKS).register(content -> {
+        DwmServices.get().modifyCreativeTab(DWMCreativeTabs.FUNCTIONAL_BLOCKS, content -> {
             for (RegisteredWoodFamily family : DWMBlocks.WOOD_FAMILIES) {
                 content.accept(family.signItem());
                 content.accept(family.hangingSignItem());
             }
         });
 
-        CreativeModeTabEvents.modifyOutputEvent(DWMCreativeTabs.SPAWN_EGGS).register(content -> {
+        DwmServices.get().modifyCreativeTab(DWMCreativeTabs.SPAWN_EGGS, content -> {
             content.accept(BROAKIR_SPAWN_EGG);
             content.accept(FLUTTERWING_SPAWN_EGG);
         });

--- a/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
+++ b/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.network;
 
+import com.adamkali.dwm.platform.DwmServices;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
@@ -12,8 +13,6 @@ import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.adamkali.dwm.tardis.portal.PortalStreamSyncService;
 import com.adamkali.dwm.tardis.soto.SotoExteriorIndex;
 import com.mojang.logging.LogUtils;
-import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import org.slf4j.Logger;
@@ -25,48 +24,50 @@ public class ServerPayloadTypeRegistry {
     private static final Logger LOGGER = LogUtils.getLogger();
 
     public static void initialize() {
-        PayloadTypeRegistry.clientboundPlay().register(OpenTardisChameleonScreen.ID, OpenTardisChameleonScreen.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(OpenWaypointScreen.ID, OpenWaypointScreen.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(OpenPlayerLocatorScreen.ID, OpenPlayerLocatorScreen.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(SyncPortalMetaS2CPayload.ID, SyncPortalMetaS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(SyncPortalChunkS2CPayload.ID, SyncPortalChunkS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(UnloadPortalChunkS2CPayload.ID, UnloadPortalChunkS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(SyncPortalEntitySpawnS2CPayload.ID, SyncPortalEntitySpawnS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(SyncPortalEntityUpdateS2CPayload.ID, SyncPortalEntityUpdateS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(SyncPortalEntityRemoveS2CPayload.ID, SyncPortalEntityRemoveS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(SyncPortalPerfS2CPayload.ID, SyncPortalPerfS2CPayload.CODEC);
-        PayloadTypeRegistry.clientboundPlay().register(TravelAudioS2CPayload.ID, TravelAudioS2CPayload.CODEC);
+        var platform = DwmServices.get();
 
-        PayloadTypeRegistry.serverboundPlay().register(UpdateTardisChameleonC2SPayload.ID, UpdateTardisChameleonC2SPayload.CODEC);
-        PayloadTypeRegistry.serverboundPlay().register(SaveWaypointC2SPayload.ID, SaveWaypointC2SPayload.CODEC);
-        PayloadTypeRegistry.serverboundPlay().register(DeleteWaypointC2SPayload.ID, DeleteWaypointC2SPayload.CODEC);
-        PayloadTypeRegistry.serverboundPlay().register(RenameWaypointC2SPayload.ID, RenameWaypointC2SPayload.CODEC);
-        PayloadTypeRegistry.serverboundPlay().register(SelectWaypointC2SPayload.ID, SelectWaypointC2SPayload.CODEC);
-        PayloadTypeRegistry.serverboundPlay().register(SelectPlayerC2SPayload.ID, SelectPlayerC2SPayload.CODEC);
-        PayloadTypeRegistry.serverboundPlay().register(RequestPortalStreamC2SPayload.ID, RequestPortalStreamC2SPayload.CODEC);
+        platform.registerClientboundPayload(OpenTardisChameleonScreen.ID, OpenTardisChameleonScreen.CODEC);
+        platform.registerClientboundPayload(OpenWaypointScreen.ID, OpenWaypointScreen.CODEC);
+        platform.registerClientboundPayload(OpenPlayerLocatorScreen.ID, OpenPlayerLocatorScreen.CODEC);
+        platform.registerClientboundPayload(SyncPortalMetaS2CPayload.ID, SyncPortalMetaS2CPayload.CODEC);
+        platform.registerClientboundPayload(SyncPortalChunkS2CPayload.ID, SyncPortalChunkS2CPayload.CODEC);
+        platform.registerClientboundPayload(UnloadPortalChunkS2CPayload.ID, UnloadPortalChunkS2CPayload.CODEC);
+        platform.registerClientboundPayload(SyncPortalEntitySpawnS2CPayload.ID, SyncPortalEntitySpawnS2CPayload.CODEC);
+        platform.registerClientboundPayload(SyncPortalEntityUpdateS2CPayload.ID, SyncPortalEntityUpdateS2CPayload.CODEC);
+        platform.registerClientboundPayload(SyncPortalEntityRemoveS2CPayload.ID, SyncPortalEntityRemoveS2CPayload.CODEC);
+        platform.registerClientboundPayload(SyncPortalPerfS2CPayload.ID, SyncPortalPerfS2CPayload.CODEC);
+        platform.registerClientboundPayload(TravelAudioS2CPayload.ID, TravelAudioS2CPayload.CODEC);
 
-        ServerPlayNetworking.registerGlobalReceiver(UpdateTardisChameleonC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundPayload(UpdateTardisChameleonC2SPayload.ID, UpdateTardisChameleonC2SPayload.CODEC);
+        platform.registerServerboundPayload(SaveWaypointC2SPayload.ID, SaveWaypointC2SPayload.CODEC);
+        platform.registerServerboundPayload(DeleteWaypointC2SPayload.ID, DeleteWaypointC2SPayload.CODEC);
+        platform.registerServerboundPayload(RenameWaypointC2SPayload.ID, RenameWaypointC2SPayload.CODEC);
+        platform.registerServerboundPayload(SelectWaypointC2SPayload.ID, SelectWaypointC2SPayload.CODEC);
+        platform.registerServerboundPayload(SelectPlayerC2SPayload.ID, SelectPlayerC2SPayload.CODEC);
+        platform.registerServerboundPayload(RequestPortalStreamC2SPayload.ID, RequestPortalStreamC2SPayload.CODEC);
+
+        platform.registerServerboundHandler(UpdateTardisChameleonC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandleChameleonUpdate(
                     payload,
                     context.player().getName().getString()
             ));
         });
-        ServerPlayNetworking.registerGlobalReceiver(SaveWaypointC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundHandler(SaveWaypointC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandleSaveWaypoint(payload, context.player()));
         });
-        ServerPlayNetworking.registerGlobalReceiver(DeleteWaypointC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundHandler(DeleteWaypointC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandleDeleteWaypoint(payload, context.player()));
         });
-        ServerPlayNetworking.registerGlobalReceiver(RenameWaypointC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundHandler(RenameWaypointC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandleRenameWaypoint(payload, context.player()));
         });
-        ServerPlayNetworking.registerGlobalReceiver(SelectWaypointC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundHandler(SelectWaypointC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandleSelectWaypoint(payload, context.player()));
         });
-        ServerPlayNetworking.registerGlobalReceiver(SelectPlayerC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundHandler(SelectPlayerC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandleSelectPlayer(payload, context.player()));
         });
-        ServerPlayNetworking.registerGlobalReceiver(RequestPortalStreamC2SPayload.ID, (payload, context) -> {
+        platform.registerServerboundHandler(RequestPortalStreamC2SPayload.ID, (payload, context) -> {
             context.server().execute(() -> safelyHandlePortalStreamRequest(payload, context.player()));
         });
     }
@@ -98,13 +99,13 @@ public class ServerPayloadTypeRegistry {
             player.sendOverlayMessage(Component.translatable("dwm.console.waypoint_save_failed"));
             // Refresh so the client leaves create mode even on failure.
             if (model != null) {
-                ServerPlayNetworking.send(player, OpenWaypointScreen.of(payload.tardisId(), model));
+                DwmServices.get().sendToPlayer(player, OpenWaypointScreen.of(payload.tardisId(), model));
             }
             return false;
         }
         player.sendOverlayMessage(Component.translatable("dwm.console.waypoint_saved", saved.get().name));
         if (model != null) {
-            ServerPlayNetworking.send(player, OpenWaypointScreen.of(payload.tardisId(), model));
+            DwmServices.get().sendToPlayer(player, OpenWaypointScreen.of(payload.tardisId(), model));
         }
         return true;
     }

--- a/src/main/java/com/adamkali/dwm/platform/DwmPlatform.java
+++ b/src/main/java/com/adamkali/dwm/platform/DwmPlatform.java
@@ -1,0 +1,206 @@
+package com.adamkali.dwm.platform;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandBuildContext;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.SpawnPlacementType;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemLike;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.state.properties.WoodType;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.Vec3;
+import net.minecraft.util.RandomSource;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Common/server loader SPI. Client-only hooks live on {@link DwmClientPlatform}.
+ */
+public interface DwmPlatform {
+
+    void registerServerStarted(Consumer<MinecraftServer> handler);
+
+    void registerAfterSave(AfterSaveHandler handler);
+
+    void registerServerStopped(Consumer<MinecraftServer> handler);
+
+    void registerEndServerTick(Consumer<MinecraftServer> handler);
+
+    void registerCommands(CommandRegistrationHandler handler);
+
+    <T extends CustomPacketPayload> void registerClientboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    );
+
+    <T extends CustomPacketPayload> void registerServerboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    );
+
+    <T extends CustomPacketPayload> void registerServerboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ServerPlayContext> handler
+    );
+
+    void sendToPlayer(ServerPlayer player, CustomPacketPayload payload);
+
+    Collection<ServerPlayer> playersTracking(ServerLevel level, BlockPos pos);
+
+    default boolean hasTrackingPlayers(ServerLevel level, BlockPos pos) {
+        return !playersTracking(level, pos).isEmpty();
+    }
+
+    Collection<ServerPlayer> playersAround(ServerLevel level, Vec3 center, double radius);
+
+    void registerBeforeBlockBreak(BeforeBlockBreakHandler handler);
+
+    void registerAfterBlockBreak(AfterBlockBreakHandler handler);
+
+    void registerAttackBlock(AttackBlockHandler handler);
+
+    void registerUseBlock(UseBlockHandler handler);
+
+    void modifyCreativeTab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeTabOutput> modifier);
+
+    void registerCompostable(ItemLike item, float chance);
+
+    void registerStrippable(Block input, Block stripped);
+
+    void registerFlammable(Block block, int burnOdds, int spreadOdds);
+
+    BlockSetType registerBlockSetType(Identifier id);
+
+    WoodType registerWoodType(Identifier id, BlockSetType setType);
+
+    <T extends BlockEntity> BlockEntityType<T> buildBlockEntityType(
+            BlockEntityFactory<T> factory,
+            Block... blocks
+    );
+
+    <T extends Mob> void registerSpawnPlacement(
+            EntityType<T> type,
+            SpawnPlacementType placement,
+            Heightmap.Types heightmap,
+            SpawnPredicate<T> predicate
+    );
+
+    void registerDefaultAttributes(
+            EntityType<? extends LivingEntity> type,
+            Supplier<AttributeSupplier.Builder> attributes
+    );
+
+    @FunctionalInterface
+    interface AfterSaveHandler {
+        void onAfterSave(MinecraftServer server, boolean flush, boolean force);
+    }
+
+    @FunctionalInterface
+    interface CommandRegistrationHandler {
+        void register(
+                CommandDispatcher<CommandSourceStack> dispatcher,
+                CommandBuildContext buildContext,
+                Commands.CommandSelection selection
+        );
+    }
+
+    interface ServerPlayContext {
+        MinecraftServer server();
+
+        ServerPlayer player();
+    }
+
+    @FunctionalInterface
+    interface BeforeBlockBreakHandler {
+        boolean allowBreak(
+                Level world,
+                Player player,
+                BlockPos pos,
+                BlockState state,
+                @Nullable BlockEntity blockEntity
+        );
+    }
+
+    @FunctionalInterface
+    interface AfterBlockBreakHandler {
+        void onBreak(
+                Level world,
+                Player player,
+                BlockPos pos,
+                BlockState state,
+                @Nullable BlockEntity blockEntity
+        );
+    }
+
+    @FunctionalInterface
+    interface AttackBlockHandler {
+        InteractionResult onAttack(
+                Player player,
+                Level world,
+                InteractionHand hand,
+                BlockPos pos,
+                Direction direction
+        );
+    }
+
+    @FunctionalInterface
+    interface UseBlockHandler {
+        InteractionResult onUse(
+                Player player,
+                Level world,
+                InteractionHand hand,
+                BlockHitResult hitResult
+        );
+    }
+
+    interface CreativeTabOutput {
+        void accept(ItemLike item);
+    }
+
+    @FunctionalInterface
+    interface BlockEntityFactory<T extends BlockEntity> {
+        T create(BlockPos pos, BlockState state);
+    }
+
+    @FunctionalInterface
+    interface SpawnPredicate<T extends net.minecraft.world.entity.Entity> {
+        boolean test(
+                EntityType<T> type,
+                ServerLevelAccessor level,
+                EntitySpawnReason reason,
+                BlockPos pos,
+                RandomSource random
+        );
+    }
+}

--- a/src/main/java/com/adamkali/dwm/platform/DwmPlatform.java
+++ b/src/main/java/com/adamkali/dwm/platform/DwmPlatform.java
@@ -24,7 +24,7 @@ import net.minecraft.world.entity.SpawnPlacementType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.ItemLike;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.ServerLevelAccessor;
 import net.minecraft.world.level.block.Block;

--- a/src/main/java/com/adamkali/dwm/platform/DwmServices.java
+++ b/src/main/java/com/adamkali/dwm/platform/DwmServices.java
@@ -1,0 +1,26 @@
+package com.adamkali.dwm.platform;
+
+/**
+ * Holds the loader-installed {@link DwmPlatform}. Entrypoints must call {@link #set(DwmPlatform)}
+ * before any common initialization.
+ */
+public final class DwmServices {
+    private static DwmPlatform platform;
+
+    private DwmServices() {
+    }
+
+    public static void set(DwmPlatform instance) {
+        if (instance == null) {
+            throw new IllegalArgumentException("DwmPlatform must not be null");
+        }
+        platform = instance;
+    }
+
+    public static DwmPlatform get() {
+        if (platform == null) {
+            throw new IllegalStateException("DwmPlatform has not been installed by the loader entrypoint");
+        }
+        return platform;
+    }
+}

--- a/src/main/java/com/adamkali/dwm/platform/fabric/FabricDwmPlatform.java
+++ b/src/main/java/com/adamkali/dwm/platform/fabric/FabricDwmPlatform.java
@@ -15,7 +15,7 @@ import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityT
 import net.fabricmc.fabric.api.object.builder.v1.block.type.BlockSetTypeBuilder;
 import net.fabricmc.fabric.api.object.builder.v1.block.type.WoodTypeBuilder;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
-import net.fabricmc.fabric.api.registry.CompostableItemRegistry;
+import net.fabricmc.fabric.api.registry.CompostableRegistry;
 import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
 import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
 import net.minecraft.core.BlockPos;
@@ -34,7 +34,7 @@ import net.minecraft.world.entity.SpawnPlacementType;
 import net.minecraft.world.entity.SpawnPlacements;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.item.CreativeModeTab;
-import net.minecraft.world.item.ItemLike;
+import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -149,12 +149,13 @@ public final class FabricDwmPlatform implements DwmPlatform {
 
     @Override
     public void modifyCreativeTab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeTabOutput> modifier) {
-        CreativeModeTabEvents.modifyOutputEvent(tab).register(content -> modifier.accept(content::accept));
+        CreativeModeTabEvents.modifyOutputEvent(tab).register(content ->
+                modifier.accept((ItemLike item) -> content.accept(item)));
     }
 
     @Override
     public void registerCompostable(ItemLike item, float chance) {
-        CompostableItemRegistry.INSTANCE.add(item, chance);
+        CompostableRegistry.INSTANCE.add(item, chance);
     }
 
     @Override

--- a/src/main/java/com/adamkali/dwm/platform/fabric/FabricDwmPlatform.java
+++ b/src/main/java/com/adamkali/dwm/platform/fabric/FabricDwmPlatform.java
@@ -1,0 +1,212 @@
+package com.adamkali.dwm.platform.fabric;
+
+import com.adamkali.dwm.platform.DwmPlatform;
+import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.fabricmc.fabric.api.creativetab.v1.CreativeModeTabEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
+import net.fabricmc.fabric.api.event.player.UseBlockCallback;
+import net.fabricmc.fabric.api.networking.v1.PayloadTypeRegistry;
+import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.fabricmc.fabric.api.object.builder.v1.block.entity.FabricBlockEntityTypeBuilder;
+import net.fabricmc.fabric.api.object.builder.v1.block.type.BlockSetTypeBuilder;
+import net.fabricmc.fabric.api.object.builder.v1.block.type.WoodTypeBuilder;
+import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
+import net.fabricmc.fabric.api.registry.CompostableItemRegistry;
+import net.fabricmc.fabric.api.registry.FlammableBlockRegistry;
+import net.fabricmc.fabric.api.registry.StrippableBlockRegistry;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.SpawnPlacementType;
+import net.minecraft.world.entity.SpawnPlacements;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.state.properties.WoodType;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Fabric common/server implementation of {@link DwmPlatform}.
+ */
+public final class FabricDwmPlatform implements DwmPlatform {
+    @Override
+    public void registerServerStarted(Consumer<MinecraftServer> handler) {
+        ServerLifecycleEvents.SERVER_STARTED.register(handler::accept);
+    }
+
+    @Override
+    public void registerAfterSave(AfterSaveHandler handler) {
+        ServerLifecycleEvents.AFTER_SAVE.register(handler::onAfterSave);
+    }
+
+    @Override
+    public void registerServerStopped(Consumer<MinecraftServer> handler) {
+        ServerLifecycleEvents.SERVER_STOPPED.register(handler::accept);
+    }
+
+    @Override
+    public void registerEndServerTick(Consumer<MinecraftServer> handler) {
+        ServerTickEvents.END_SERVER_TICK.register(handler::accept);
+    }
+
+    @Override
+    public void registerCommands(CommandRegistrationHandler handler) {
+        CommandRegistrationCallback.EVENT.register(handler::register);
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerClientboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        PayloadTypeRegistry.clientboundPlay().register(type, codec);
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerServerboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        PayloadTypeRegistry.serverboundPlay().register(type, codec);
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerServerboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ServerPlayContext> handler
+    ) {
+        ServerPlayNetworking.registerGlobalReceiver(type, (payload, context) ->
+                handler.accept(payload, new ServerPlayContext() {
+                    @Override
+                    public MinecraftServer server() {
+                        return context.server();
+                    }
+
+                    @Override
+                    public ServerPlayer player() {
+                        return context.player();
+                    }
+                }));
+    }
+
+    @Override
+    public void sendToPlayer(ServerPlayer player, CustomPacketPayload payload) {
+        ServerPlayNetworking.send(player, payload);
+    }
+
+    @Override
+    public Collection<ServerPlayer> playersTracking(ServerLevel level, BlockPos pos) {
+        return PlayerLookup.tracking(level, pos);
+    }
+
+    @Override
+    public Collection<ServerPlayer> playersAround(ServerLevel level, Vec3 center, double radius) {
+        return PlayerLookup.around(level, center, radius);
+    }
+
+    @Override
+    public void registerBeforeBlockBreak(BeforeBlockBreakHandler handler) {
+        PlayerBlockBreakEvents.BEFORE.register(handler::allowBreak);
+    }
+
+    @Override
+    public void registerAfterBlockBreak(AfterBlockBreakHandler handler) {
+        PlayerBlockBreakEvents.AFTER.register(handler::onBreak);
+    }
+
+    @Override
+    public void registerAttackBlock(AttackBlockHandler handler) {
+        AttackBlockCallback.EVENT.register(handler::onAttack);
+    }
+
+    @Override
+    public void registerUseBlock(UseBlockHandler handler) {
+        UseBlockCallback.EVENT.register(handler::onUse);
+    }
+
+    @Override
+    public void modifyCreativeTab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeTabOutput> modifier) {
+        CreativeModeTabEvents.modifyOutputEvent(tab).register(content -> modifier.accept(content::accept));
+    }
+
+    @Override
+    public void registerCompostable(ItemLike item, float chance) {
+        CompostableItemRegistry.INSTANCE.add(item, chance);
+    }
+
+    @Override
+    public void registerStrippable(Block input, Block stripped) {
+        StrippableBlockRegistry.register(input, stripped);
+    }
+
+    @Override
+    public void registerFlammable(Block block, int burnOdds, int spreadOdds) {
+        FlammableBlockRegistry.getDefaultInstance().add(block, burnOdds, spreadOdds);
+    }
+
+    @Override
+    public BlockSetType registerBlockSetType(Identifier id) {
+        return new BlockSetTypeBuilder().register(id);
+    }
+
+    @Override
+    public WoodType registerWoodType(Identifier id, BlockSetType setType) {
+        return new WoodTypeBuilder().register(id, setType);
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityType<T> buildBlockEntityType(
+            BlockEntityFactory<T> factory,
+            Block... blocks
+    ) {
+        return FabricBlockEntityTypeBuilder.<T>create(factory::create, blocks).build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Mob> void registerSpawnPlacement(
+            EntityType<T> type,
+            SpawnPlacementType placement,
+            Heightmap.Types heightmap,
+            SpawnPredicate<T> predicate
+    ) {
+        SpawnPlacements.register(
+                type,
+                placement,
+                heightmap,
+                (entityType, level, reason, pos, random) ->
+                        predicate.test((EntityType<T>) entityType, level, reason, pos, random)
+        );
+    }
+
+    @Override
+    public void registerDefaultAttributes(
+            EntityType<? extends LivingEntity> type,
+            Supplier<AttributeSupplier.Builder> attributes
+    ) {
+        FabricDefaultAttributeRegistry.register(type, attributes.get());
+    }
+}

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelAudio.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelAudio.java
@@ -1,17 +1,17 @@
 package com.adamkali.dwm.tardis.logic;
 
 import com.adamkali.dwm.network.TravelAudioS2CPayload;
+import com.adamkali.dwm.platform.DwmServices;
 import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
-import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.UUID;
@@ -46,8 +46,8 @@ public final class TardisTravelAudio {
             Identifier exteriorDim = exteriorWorld.dimension().identifier();
             TravelAudioS2CPayload exteriorStop = new TravelAudioS2CPayload(
                     tardisId, TravelAudioS2CPayload.STOP, exteriorDim, exteriorPos, false);
-            for (ServerPlayer player : PlayerLookup.around(exteriorWorld, exteriorPos, EXTERIOR_RANGE)) {
-                ServerPlayNetworking.send(player, exteriorStop);
+            for (ServerPlayer player : DwmServices.get().playersAround(exteriorWorld, Vec3.atCenterOf(exteriorPos), EXTERIOR_RANGE)) {
+                DwmServices.get().sendToPlayer(player, exteriorStop);
             }
         }
 
@@ -62,7 +62,7 @@ public final class TardisTravelAudio {
         for (ServerPlayer player : interior.players()) {
             if (BotiInteriorSampler.isInsideFootprint(player.blockPosition(), origin)
                     || player.blockPosition().closerThan(console, EXTERIOR_RANGE)) {
-                ServerPlayNetworking.send(player, interiorCue);
+                DwmServices.get().sendToPlayer(player, interiorCue);
             }
         }
     }
@@ -81,8 +81,8 @@ public final class TardisTravelAudio {
                 tardisId, TravelAudioS2CPayload.STOP, TardisDimensions.DIMENSION_ID, consolePos(tardisId), true);
 
         if (exteriorWorld != null) {
-            for (ServerPlayer player : PlayerLookup.around(exteriorWorld, pos, EXTERIOR_RANGE)) {
-                ServerPlayNetworking.send(player, exteriorStop);
+            for (ServerPlayer player : DwmServices.get().playersAround(exteriorWorld, Vec3.atCenterOf(pos), EXTERIOR_RANGE)) {
+                DwmServices.get().sendToPlayer(player, exteriorStop);
             }
         }
         ServerLevel interior = server.getLevel(TardisDimensions.TARDIS_WORLD_KEY);
@@ -91,7 +91,7 @@ public final class TardisTravelAudio {
             for (ServerPlayer player : interior.players()) {
                 if (BotiInteriorSampler.isInsideFootprint(player.blockPosition(), origin)
                         || player.blockPosition().closerThan(consolePos(tardisId), EXTERIOR_RANGE)) {
-                    ServerPlayNetworking.send(player, interiorStop);
+                    DwmServices.get().sendToPlayer(player, interiorStop);
                 }
             }
         }
@@ -110,8 +110,8 @@ public final class TardisTravelAudio {
         Identifier exteriorDim = exteriorWorld.dimension().identifier();
         TravelAudioS2CPayload exteriorCue = new TravelAudioS2CPayload(
                 tardisId, action, exteriorDim, exteriorPos, false);
-        for (ServerPlayer player : PlayerLookup.around(exteriorWorld, exteriorPos, EXTERIOR_RANGE)) {
-            ServerPlayNetworking.send(player, exteriorCue);
+        for (ServerPlayer player : DwmServices.get().playersAround(exteriorWorld, Vec3.atCenterOf(exteriorPos), EXTERIOR_RANGE)) {
+            DwmServices.get().sendToPlayer(player, exteriorCue);
         }
 
         BlockPos console = consolePos(tardisId);
@@ -125,7 +125,7 @@ public final class TardisTravelAudio {
         for (ServerPlayer player : interior.players()) {
             if (BotiInteriorSampler.isInsideFootprint(player.blockPosition(), origin)
                     || player.blockPosition().closerThan(console, EXTERIOR_RANGE)) {
-                ServerPlayNetworking.send(player, interiorCue);
+                DwmServices.get().sendToPlayer(player, interiorCue);
             }
         }
     }

--- a/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
@@ -14,7 +14,7 @@ import com.adamkali.dwm.tardis.data.model.TardisWaypoint;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
 import com.adamkali.dwm.tardis.soto.SotoExteriorIndex;
 import com.adamkali.dwm.tardis.portal.PortalStreamSyncService;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
@@ -74,7 +74,7 @@ public final class TardisTravelService {
     }
 
     public static void initialize() {
-        ServerTickEvents.END_SERVER_TICK.register(TardisTravelService::onEndTick);
+        DwmServices.get().registerEndServerTick(TardisTravelService::onEndTick);
     }
 
     /**

--- a/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -19,12 +19,7 @@ import com.adamkali.dwm.tardis.interior.TardisDimensions;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
 import com.adamkali.dwm.tardis.soto.SotoExteriorIndex;
 import com.adamkali.dwm.tardis.soto.SotoExteriorSampler;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
-import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
-import net.fabricmc.fabric.api.event.player.UseBlockCallback;
-import net.fabricmc.fabric.api.networking.v1.PlayerLookup;
-import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import com.adamkali.dwm.platform.DwmServices;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.Identifier;
@@ -65,13 +60,14 @@ public final class PortalStreamSyncService {
     }
 
     public static void initialize() {
-        PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, blockEntity) -> {
+        var platform = DwmServices.get();
+        platform.registerAfterBlockBreak((world, player, pos, state, blockEntity) -> {
             if (!world.isClientSide()) {
                 markDirtyAt(world.dimension(), pos);
             }
         });
 
-        UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
+        platform.registerUseBlock((player, world, hand, hitResult) -> {
             if (!world.isClientSide()) {
                 markDirtyAt(world.dimension(), hitResult.getBlockPos());
                 markDirtyAt(world.dimension(), hitResult.getBlockPos().relative(hitResult.getDirection()));
@@ -79,8 +75,8 @@ public final class PortalStreamSyncService {
             return InteractionResult.PASS;
         });
 
-        ServerTickEvents.END_SERVER_TICK.register(PortalStreamSyncService::onEndTick);
-        ServerLifecycleEvents.SERVER_STOPPED.register(server -> clear());
+        platform.registerEndServerTick(PortalStreamSyncService::onEndTick);
+        platform.registerServerStopped(server -> clear());
     }
 
     public static void clear() {
@@ -221,7 +217,7 @@ public final class PortalStreamSyncService {
         SyncPortalPerfS2CPayload payload = SyncPortalPerfS2CPayload.fromSnapshot(snap);
         for (ServerPlayer viewer : Set.copyOf(TICK_VIEWERS)) {
             if (viewer != null && !viewer.hasDisconnected()) {
-                ServerPlayNetworking.send(viewer, payload);
+                DwmServices.get().sendToPlayer(viewer, payload);
             }
         }
     }
@@ -270,7 +266,7 @@ public final class PortalStreamSyncService {
                         kind, tardisId, revision, ctx.shell(), ctx.atmosphere()
                 );
                 for (ServerPlayer viewer : viewers) {
-                    ServerPlayNetworking.send(viewer, payload);
+                    DwmServices.get().sendToPlayer(viewer, payload);
                     PortalStreamPerfStats.noteMetaPacket();
                 }
             }
@@ -344,12 +340,12 @@ public final class PortalStreamSyncService {
             ServerPlayer player = server.getPlayerList().getPlayer(key.playerId);
             if (player != null) {
                 for (long packed : SENT_CHUNKS.getOrDefault(key, Set.of())) {
-                    ServerPlayNetworking.send(player, new UnloadPortalChunkS2CPayload(
+                    DwmServices.get().sendToPlayer(player, new UnloadPortalChunkS2CPayload(
                             streamKey.kind, streamKey.tardisId, ChunkPos.getX(packed), ChunkPos.getZ(packed)
                     ));
                 }
                 for (UUID entityId : TRACKED_ENTITIES.getOrDefault(key, Set.of())) {
-                    ServerPlayNetworking.send(player, new SyncPortalEntityRemoveS2CPayload(
+                    DwmServices.get().sendToPlayer(player, new SyncPortalEntityRemoveS2CPayload(
                             streamKey.kind, streamKey.tardisId, entityId
                     ));
                     PortalStreamPerfStats.noteEntityRemove();
@@ -367,7 +363,7 @@ public final class PortalStreamSyncService {
             if (interiorWorld != null) {
                 BlockPos doorOrigin = TardisPlotAllocator.plotOrigin(tardisId)
                         .offset(FirstDoctorConsoleRoomLayout.LOCAL_DOOR_ORIGIN);
-                viewers.addAll(PlayerLookup.tracking(interiorWorld, doorOrigin));
+                viewers.addAll(DwmServices.get().playersTracking(interiorWorld, doorOrigin));
             }
         } else {
             TardisDataModel model = TardisDataLoader.get(tardisId);
@@ -376,7 +372,7 @@ public final class PortalStreamSyncService {
                 ServerLevel exteriorWorld = server.getLevel(worldKey);
                 if (exteriorWorld != null) {
                     BlockPos exteriorPos = new BlockPos(model.exteriorX, model.exteriorY, model.exteriorZ);
-                    viewers.addAll(PlayerLookup.tracking(exteriorWorld, exteriorPos));
+                    viewers.addAll(DwmServices.get().playersTracking(exteriorWorld, exteriorPos));
                 }
             }
         }
@@ -394,7 +390,7 @@ public final class PortalStreamSyncService {
 
     private static void sendMeta(ServerPlayer player, SceneContext ctx) {
         int revision = META_REVISIONS.merge(ctx.tardisId(), 1, Integer::sum);
-        ServerPlayNetworking.send(player, SyncPortalMetaS2CPayload.of(
+        DwmServices.get().sendToPlayer(player, SyncPortalMetaS2CPayload.of(
                 ctx.kind(), ctx.tardisId(), revision, ctx.shell(), ctx.atmosphere()
         ));
         PortalStreamPerfStats.noteMetaPacket();
@@ -408,7 +404,7 @@ public final class PortalStreamSyncService {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
                 PortalStreamSample sample = ctx.sampleChunk(cx, cz);
                 PortalStreamPerfStats.noteChunkSample();
-                ServerPlayNetworking.send(
+                DwmServices.get().sendToPlayer(
                         player,
                         SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
                 );
@@ -434,7 +430,7 @@ public final class PortalStreamSyncService {
         for (long packed : Set.copyOf(sent)) {
             if (!desired.contains(packed)) {
                 sent.remove(packed);
-                ServerPlayNetworking.send(player, new UnloadPortalChunkS2CPayload(
+                DwmServices.get().sendToPlayer(player, new UnloadPortalChunkS2CPayload(
                         ctx.kind(), ctx.tardisId(), ChunkPos.getX(packed), ChunkPos.getZ(packed)
                 ));
             }
@@ -447,7 +443,7 @@ public final class PortalStreamSyncService {
             int cz = ChunkPos.getZ(packed);
             PortalStreamSample sample = ctx.sampleChunk(cx, cz);
             PortalStreamPerfStats.noteChunkSample();
-            ServerPlayNetworking.send(
+            DwmServices.get().sendToPlayer(
                     player,
                     SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
             );
@@ -474,7 +470,7 @@ public final class PortalStreamSyncService {
             int cz = ChunkPos.getZ(packed);
             PortalStreamSample sample = ctx.sampleChunk(cx, cz);
             PortalStreamPerfStats.noteChunkSample();
-            ServerPlayNetworking.send(
+            DwmServices.get().sendToPlayer(
                     player,
                     SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
             );
@@ -496,7 +492,7 @@ public final class PortalStreamSyncService {
             }
             liveIds.add(entity.getUUID());
             if (tracked.contains(entity.getUUID())) {
-                ServerPlayNetworking.send(
+                DwmServices.get().sendToPlayer(
                         player,
                         SyncPortalEntityUpdateS2CPayload.fromEntity(ctx.kind(), ctx.tardisId(), entity, ctx.footprintOrigin())
                 );
@@ -507,7 +503,7 @@ public final class PortalStreamSyncService {
                 if (spawn.typeId() == null || spawn.typeId().getPath().isEmpty()) {
                     continue;
                 }
-                ServerPlayNetworking.send(player, spawn);
+                DwmServices.get().sendToPlayer(player, spawn);
                 PortalStreamPerfStats.noteEntitySpawn();
                 tracked.add(entity.getUUID());
             }
@@ -515,7 +511,7 @@ public final class PortalStreamSyncService {
         for (UUID id : Set.copyOf(tracked)) {
             if (!liveIds.contains(id)) {
                 tracked.remove(id);
-                ServerPlayNetworking.send(player, new SyncPortalEntityRemoveS2CPayload(ctx.kind(), ctx.tardisId(), id));
+                DwmServices.get().sendToPlayer(player, new SyncPortalEntityRemoveS2CPayload(ctx.kind(), ctx.tardisId(), id));
                 PortalStreamPerfStats.noteEntityRemove();
             }
         }

--- a/src/test/java/com/adamkali/dwm/ClientTardisTest.java
+++ b/src/test/java/com/adamkali/dwm/ClientTardisTest.java
@@ -1,9 +1,10 @@
 package com.adamkali.dwm;
 
 import com.adamkali.dwm.network.UpdateTardisChameleonC2SPayload;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import com.adamkali.dwm.platform.DwmClientServices;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -16,14 +17,15 @@ class ClientTardisTest {
         UUID tardisId = UUID.randomUUID();
         ClientTardis clientTardis = new ClientTardis(tardisId);
         TardisChameleonVariant variant = TardisChameleonVariant.FOURTH_DOCTOR_BOX;
+        DwmClientPlatform platform = Mockito.mock(DwmClientPlatform.class);
 
-        try (MockedStatic<ClientPlayNetworking> networking = Mockito.mockStatic(ClientPlayNetworking.class);
+        try (MockedStatic<DwmClientServices> services = Mockito.mockStatic(DwmClientServices.class);
              MockedStatic<TardisLogic> logic = Mockito.mockStatic(TardisLogic.class)) {
+            services.when(DwmClientServices::get).thenReturn(platform);
+
             clientTardis.updateChameleonVariant(variant);
 
-            networking.verify(() -> ClientPlayNetworking.send(
-                    new UpdateTardisChameleonC2SPayload(variant.getId(), tardisId)
-            ));
+            Mockito.verify(platform).sendToServer(new UpdateTardisChameleonC2SPayload(variant.getId(), tardisId));
             logic.verifyNoInteractions();
         }
     }

--- a/src/test/java/com/adamkali/dwm/MinecraftTestBootstrap.java
+++ b/src/test/java/com/adamkali/dwm/MinecraftTestBootstrap.java
@@ -1,10 +1,14 @@
 package com.adamkali.dwm;
 
+import com.adamkali.dwm.block.DWMWoodTypes;
+import com.adamkali.dwm.platform.DwmServices;
+import com.adamkali.dwm.platform.fabric.FabricDwmPlatform;
 import net.minecraft.SharedConstants;
 import net.minecraft.server.Bootstrap;
 
 /**
  * Ensures Minecraft registries are bootstrapped for unit tests that touch blocks/items.
+ * Also installs the Fabric {@link DwmServices} platform so shared registration helpers work.
  */
 public final class MinecraftTestBootstrap {
     private static boolean bootstrapped;
@@ -18,6 +22,8 @@ public final class MinecraftTestBootstrap {
         }
         SharedConstants.tryDetectVersion();
         Bootstrap.bootStrap();
+        DwmServices.set(new FabricDwmPlatform());
+        DWMWoodTypes.initialize();
         bootstrapped = true;
     }
 }


### PR DESCRIPTION
## Why this matters

- Shared gameplay cannot move to Forge/NeoForge while it still calls Fabric API directly. This is the loader-neutral SPI those ports sit on, without the 1000-file rename.

## Proposed Implementation

- Introduce `DwmPlatform` / `DwmClientPlatform` and Fabric adapters (`FabricDwmPlatform`, `FabricDwmClientPlatform`).
- Route existing main and client sources through `DwmServices` / `DwmClientServices` (networking, ticks, creative tabs, wood types, HUD, renderers).
- Files stay under `src/`; Fabric remains the only loader. Follow-up PRs extract `dwm-common` and add Forge/NeoForge.

## Problems Encountered / Decisions Made

- Stacked: this PR is the base for `refactor/dwm-common`. Split from #188 so the SPI review is not drowned in the source move.

Made with [Cursor](https://cursor.com)