### PR TITLE
feat(loaders): add Forge and NeoForge DWM adapters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           chmod +x ./gradlew
           ./gradlew build
+          ./gradlew -p dwm-loaders :forge:compileJava :neoforge:compileJava
         env:
           _JAVA_OPTIONS: -Xmx3200m
           GRADLE_OPTS: -Dorg.gradle.daemon=false

--- a/dwm-loaders/forge/build.gradle
+++ b/dwm-loaders/forge/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'net.minecraftforge.gradle' version '[7.0.17,8)'
+    id 'com.adamkali.screenplay'
 }
 
 version = project.mod_version
@@ -25,10 +26,27 @@ minecraft {
         configureEach {
             workingDir = layout.projectDirectory.dir('run')
             systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
+            // Combine classes + resources into one mod layer (avoids FML scanning
+            // build/resources/main alone and failing to find @Mod classes).
+            mods {
+                dwm {
+                    source sourceSets.main
+                }
+            }
         }
+        // Only names present in Forge's launcher runs.json get a mainClass.
+        // Screenplay reuses 'client' (see ScreenplayPlugin forge path).
         register('client')
         register('server')
     }
+}
+
+screenplay {
+    loader = 'forge'
+    testsDir = rootProject.file('../src/screenplayTests/resources/tests')
+    extraTestsDirs = [rootProject.file('../screenplay-common/src/main/resources/tests')]
+    runDir = 'build/screenplay/run'
+    outputDir = 'screenplay'
 }
 
 repositories {
@@ -43,12 +61,18 @@ dependencies {
     implementation 'org.json:json:20240303'
     implementation 'com.github.erosb:everit-json-schema:1.14.4'
     implementation 'com.mixpanel:mixpanel-java:1.5.1'
+    // Screenplay Forge client harness (composite includeBuild + substitution).
+    runtimeOnly "${project.screenplay_maven_group}:screenplay-forge:${project.screenplay_version}"
 }
 
 def dwmCommon = rootProject.file('../dwm-common')
 def rootGenerated = rootProject.file('../src/main/generated')
+def screenplayTests = rootProject.file('../src/screenplayTests/resources')
 
 sourceSets.main {
+    // FML discovers each classpath entry with mods.toml as its own ModFile.
+    // Keep classes + resources in one directory so @Mod and mods.toml share a root.
+    output.resourcesDir = layout.buildDirectory.dir('classes/java/main').get().asFile
     java {
         srcDir new File(dwmCommon, 'src/main/java')
         srcDir new File(dwmCommon, 'src/client/java')
@@ -57,6 +81,8 @@ sourceSets.main {
         srcDir new File(dwmCommon, 'src/main/resources')
         srcDir new File(dwmCommon, 'src/client/resources')
         srcDir rootGenerated
+        // Mod-owned scenarios only — screenplay-forge jar already ships harness demos.
+        srcDir screenplayTests
     }
 }
 
@@ -73,6 +99,21 @@ processResources {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     options.release = 25
+}
+
+// ForgeGradle 7.0.35 + Gradle 9.5: SlimeLauncherMetadata conventions map
+// outputDirectory onto runsJson of the same task; Gradle rejects querying that
+// mapped output during the task action. Rebind via locationOnly.
+tasks.configureEach { task ->
+    if (!task.name.startsWith('slimeLauncherMetadata')) {
+        return
+    }
+    def outputDirectory = task.hasProperty('outputDirectory') ? task.outputDirectory : null
+    def runsJson = task.hasProperty('runsJson') ? task.runsJson : null
+    if (outputDirectory == null || runsJson == null) {
+        return
+    }
+    runsJson.set(outputDirectory.locationOnly.map { dir -> dir.file('launcher/runs.json') })
 }
 
 publishing {

--- a/dwm-loaders/forge/build.gradle
+++ b/dwm-loaders/forge/build.gradle
@@ -1,0 +1,87 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+    id 'net.minecraftforge.gradle' version '[7.0.17,8)'
+}
+
+version = project.mod_version
+group = project.maven_group
+
+base {
+    archivesName = 'dwm-forge'
+}
+
+java {
+    withSourcesJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+minecraft {
+    accessTransformer.from project.file('src/main/resources/META-INF/accesstransformer.cfg')
+
+    runs {
+        configureEach {
+            workingDir = layout.projectDirectory.dir('run')
+            systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
+        }
+        register('client')
+        register('server')
+    }
+}
+
+repositories {
+    minecraft.mavenizer(it)
+    maven fg.forgeMaven
+    maven fg.minecraftLibsMaven
+    mavenCentral()
+}
+
+dependencies {
+    implementation minecraft.dependency("net.minecraftforge:forge:${project.minecraft_version}-${project.forge_version}")
+    implementation 'org.json:json:20240303'
+    implementation 'com.github.erosb:everit-json-schema:1.14.4'
+    implementation 'com.mixpanel:mixpanel-java:1.5.1'
+}
+
+def dwmCommon = rootProject.file('../dwm-common')
+def rootGenerated = rootProject.file('../src/main/generated')
+
+sourceSets.main {
+    java {
+        srcDir new File(dwmCommon, 'src/main/java')
+        srcDir new File(dwmCommon, 'src/client/java')
+    }
+    resources {
+        srcDir new File(dwmCommon, 'src/main/resources')
+        srcDir new File(dwmCommon, 'src/client/resources')
+        srcDir rootGenerated
+    }
+}
+
+processResources {
+    var replaceProperties = [
+            mod_version: project.version
+    ]
+    inputs.properties replaceProperties
+    filesMatching('META-INF/mods.toml') {
+        expand replaceProperties
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release = 25
+}
+
+publishing {
+    publications {
+        create('mavenJava', MavenPublication) {
+            artifactId = 'dwm-forge'
+            from components.java
+        }
+    }
+    repositories {
+    }
+}

--- a/dwm-loaders/forge/src/main/java/com/adamkali/dwm/forge/ForgeDwmMod.java
+++ b/dwm-loaders/forge/src/main/java/com/adamkali/dwm/forge/ForgeDwmMod.java
@@ -1,0 +1,27 @@
+package com.adamkali.dwm.forge;
+
+import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.DwmCommon;
+import com.adamkali.dwm.DwmCommonClient;
+import com.adamkali.dwm.platform.DwmClientServices;
+import com.adamkali.dwm.platform.DwmServices;
+import com.adamkali.dwm.platform.forge.ForgeDwmClientPlatform;
+import com.adamkali.dwm.platform.forge.ForgeDwmPlatform;
+import net.minecraftforge.api.distmarker.Dist;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.loading.FMLLoader;
+
+@Mod(DWMReference.MOD_ID)
+public final class ForgeDwmMod {
+    public ForgeDwmMod() {
+        ForgeDwmPlatform platform = new ForgeDwmPlatform();
+        DwmServices.set(platform);
+        DwmCommon.init();
+        platform.buildNetwork();
+
+        if (FMLLoader.getDist() == Dist.CLIENT) {
+            DwmClientServices.set(new ForgeDwmClientPlatform(platform));
+            DwmCommonClient.init();
+        }
+    }
+}

--- a/dwm-loaders/forge/src/main/java/com/adamkali/dwm/forge/ForgeDwmMod.java
+++ b/dwm-loaders/forge/src/main/java/com/adamkali/dwm/forge/ForgeDwmMod.java
@@ -16,7 +16,10 @@ public final class ForgeDwmMod {
     public ForgeDwmMod() {
         ForgeDwmPlatform platform = new ForgeDwmPlatform();
         DwmServices.set(platform);
+        // Fabric-style Registry.register in DwmCommon needs open vanilla/Forge registries.
+        ForgeRegistryBootstrap.unlockForFabricStyleRegistration();
         DwmCommon.init();
+        ForgeRegistryBootstrap.initBlockStateCachesAfterRegistration();
         platform.buildNetwork();
 
         if (FMLLoader.getDist() == Dist.CLIENT) {

--- a/dwm-loaders/forge/src/main/java/com/adamkali/dwm/forge/ForgeRegistryBootstrap.java
+++ b/dwm-loaders/forge/src/main/java/com/adamkali/dwm/forge/ForgeRegistryBootstrap.java
@@ -1,0 +1,85 @@
+package com.adamkali.dwm.forge;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.core.MappedRegistry;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraftforge.registries.ForgeRegistry;
+import net.minecraftforge.registries.GameData;
+import net.minecraftforge.registries.RegistryManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+
+/**
+ * Opens Forge/vanilla registries so Fabric-style {@code Registry.register} calls in
+ * {@link com.adamkali.dwm.DwmCommon} can run during mod construction.
+ *
+ * <p>Forge locks {@code NamespacedWrapper} against direct vanilla registration and freezes
+ * mapped registries before mod constructors. Until DWM migrates to DeferredRegister /
+ * RegisterEvent, this bootstrap mirrors the window Forge opens around RegisterEvent.
+ *
+ * <p>Early registration can also skip loader bake hooks that call
+ * {@link BlockState#initCache()}; {@link #initBlockStateCachesAfterRegistration()} fills
+ * occlusion shape caches so chunk meshing does not NPE on DWM neighbors.
+ */
+final class ForgeRegistryBootstrap {
+    private static final Logger LOGGER = LoggerFactory.getLogger("dwm");
+
+    private ForgeRegistryBootstrap() {
+    }
+
+    static void unlockForFabricStyleRegistration() {
+        GameData.unfreezeData();
+        for (var entry : RegistryManager.ACTIVE.getRegistries().values()) {
+            if (entry instanceof ForgeRegistry<?> forgeRegistry) {
+                forgeRegistry.unfreeze();
+            }
+        }
+        for (Registry<?> registry : BuiltInRegistries.REGISTRY) {
+            if (registry instanceof MappedRegistry<?> mapped) {
+                mapped.unfreeze();
+            }
+            clearNamespacedWrapperLock(registry);
+        }
+    }
+
+    static void initBlockStateCachesAfterRegistration() {
+        int states = 0;
+        for (Block block : BuiltInRegistries.BLOCK) {
+            Identifier id = BuiltInRegistries.BLOCK.getKey(block);
+            if (id == null || !DWMReference.MOD_ID.equals(id.getNamespace())) {
+                continue;
+            }
+            for (BlockState state : block.getStateDefinition().getPossibleStates()) {
+                state.initCache();
+                states++;
+            }
+        }
+        LOGGER.debug("Initialized occlusion caches for {} DWM block states", states);
+    }
+
+    private static void clearNamespacedWrapperLock(Registry<?> registry) {
+        Class<?> type = registry.getClass();
+        while (type != null && type != Object.class) {
+            try {
+                Field locked = type.getDeclaredField("locked");
+                locked.setAccessible(true);
+                if (locked.getType() == boolean.class && locked.getBoolean(registry)) {
+                    locked.setBoolean(registry, false);
+                    LOGGER.debug("Cleared Forge registry lock on {}", registry.key());
+                }
+                return;
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            } catch (ReflectiveOperationException exception) {
+                LOGGER.warn("Could not clear Forge registry lock on {}: {}", registry.key(), exception.toString());
+                return;
+            }
+        }
+    }
+}

--- a/dwm-loaders/forge/src/main/java/com/adamkali/dwm/platform/forge/ForgeDwmClientPlatform.java
+++ b/dwm-loaders/forge/src/main/java/com/adamkali/dwm/platform/forge/ForgeDwmClientPlatform.java
@@ -1,0 +1,225 @@
+package com.adamkali.dwm.platform.forge;
+
+import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraftforge.client.FramePassManager;
+import net.minecraftforge.client.event.AddFramePassEvent;
+import net.minecraftforge.client.event.AddGuiOverlayLayersEvent;
+import net.minecraftforge.client.event.ClientPlayerNetworkEvent;
+import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.client.gui.overlay.ForgeLayeredDraw;
+import net.minecraftforge.event.GameShuttingDownEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.network.CustomPayloadEvent;
+import net.minecraftforge.network.PacketDistributor;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Forge client implementation of {@link DwmClientPlatform} (Forge 65 / MC 26.2).
+ */
+public final class ForgeDwmClientPlatform implements DwmClientPlatform {
+    private final ForgeDwmPlatform common;
+    private final List<ModelLayerEntry> modelLayers = new CopyOnWriteArrayList<>();
+    private final List<EntityRendererEntry<?>> entityRenderers = new CopyOnWriteArrayList<>();
+    private final List<BlockEntityRendererEntry<?, ?>> blockEntityRenderers = new CopyOnWriteArrayList<>();
+    private final List<HudLayerEntry> hudLayers = new CopyOnWriteArrayList<>();
+    private final List<Consumer<LevelRenderCtx>> startMainHandlers = new CopyOnWriteArrayList<>();
+    private final List<Consumer<LevelRenderCtx>> endMainHandlers = new CopyOnWriteArrayList<>();
+    private final List<Consumer<LevelRenderCtx>> beforeGizmosHandlers = new CopyOnWriteArrayList<>();
+
+    public ForgeDwmClientPlatform(ForgeDwmPlatform common) {
+        this.common = common;
+        EntityRenderersEvent.RegisterLayerDefinitions.BUS.addListener(this::onRegisterLayerDefinitions);
+        EntityRenderersEvent.RegisterRenderers.BUS.addListener(this::onRegisterRenderers);
+        AddGuiOverlayLayersEvent.BUS.addListener(this::onAddGuiOverlayLayers);
+        AddFramePassEvent.BUS.addListener(this::onAddFramePasses);
+    }
+
+    private void onRegisterLayerDefinitions(EntityRenderersEvent.RegisterLayerDefinitions event) {
+        for (ModelLayerEntry entry : modelLayers) {
+            event.registerLayerDefinition(entry.location(), entry.definition()::createLayerDefinition);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void onRegisterRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        for (EntityRendererEntry<?> entry : entityRenderers) {
+            event.registerEntityRenderer((EntityType) entry.type(), entry.factory());
+        }
+        for (BlockEntityRendererEntry<?, ?> entry : blockEntityRenderers) {
+            event.registerBlockEntityRenderer((BlockEntityType) entry.type(), entry.factory());
+        }
+    }
+
+    private void onAddGuiOverlayLayers(AddGuiOverlayLayersEvent event) {
+        ForgeLayeredDraw root = event.getLayeredDraw();
+        for (HudLayerEntry entry : hudLayers) {
+            root.addAbove(
+                    ForgeLayeredDraw.PRE_SLEEP_STACK,
+                    entry.elementId(),
+                    entry.afterVanillaElement(),
+                    entry.extractor()::extract
+            );
+        }
+    }
+
+    private void onAddFramePasses(AddFramePassEvent event) {
+        // Forge 65 replaced RenderLevelStageEvent with frame-graph passes. Approximate
+        // Fabric START_MAIN / END_MAIN / BEFORE_GIZMOS with ordered dwm passes on main.
+        event.addPass(
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "level_start_main"),
+                passDefinition(startMainHandlers)
+        );
+        event.addPass(
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "level_end_main"),
+                passDefinition(endMainHandlers)
+        );
+        event.addPass(
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "level_before_gizmos"),
+                passDefinition(beforeGizmosHandlers)
+        );
+    }
+
+    private static FramePassManager.PassDefinition passDefinition(List<Consumer<LevelRenderCtx>> handlers) {
+        return new FramePassManager.PassDefinition() {
+            @Override
+            public void extracts(
+                    net.minecraft.client.renderer.LevelTargetBundle bundle,
+                    com.mojang.blaze3d.framegraph.FramePass pass,
+                    net.minecraft.client.DeltaTracker deltaTracker
+            ) {
+                bundle.main = pass.readsAndWrites(bundle.main);
+            }
+
+            @Override
+            public void executes(net.minecraft.client.renderer.state.level.LevelRenderState state) {
+                LevelRenderCtx ctx = () -> Minecraft.getInstance().levelRenderer;
+                for (Consumer<LevelRenderCtx> handler : handlers) {
+                    handler.accept(ctx);
+                }
+            }
+        };
+    }
+
+    @Override
+    public void registerEndClientTick(Consumer<Minecraft> handler) {
+        TickEvent.ClientTickEvent.Post.BUS.addListener(event -> handler.accept(Minecraft.getInstance()));
+    }
+
+    @Override
+    public void registerClientStopping(Consumer<Minecraft> handler) {
+        GameShuttingDownEvent.BUS.addListener(event -> handler.accept(Minecraft.getInstance()));
+    }
+
+    @Override
+    public void registerClientDisconnect(BiConsumer<ClientPacketListener, Minecraft> handler) {
+        ClientPlayerNetworkEvent.LoggingOut.BUS.addListener(event -> {
+            Minecraft client = Minecraft.getInstance();
+            ClientPacketListener connection = client.getConnection();
+            if (connection != null) {
+                handler.accept(connection, client);
+            }
+        });
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerClientboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ClientPlayContext> handler
+    ) {
+        BiConsumer<T, CustomPayloadEvent.Context> adapted = (payload, ctx) ->
+                handler.accept(payload, () -> Minecraft.getInstance());
+        common.putClientboundHandler(type, adapted);
+    }
+
+    @Override
+    public void sendToServer(CustomPacketPayload payload) {
+        common.channel().send(payload, PacketDistributor.SERVER.noArg());
+    }
+
+    @Override
+    public void registerModelLayer(ModelLayerLocation location, LayerDefinitionProvider definition) {
+        modelLayers.add(new ModelLayerEntry(location, definition));
+    }
+
+    @Override
+    public <T extends Entity> void registerEntityRenderer(
+            EntityType<? extends T> type,
+            EntityRendererProvider<T> factory
+    ) {
+        entityRenderers.add(new EntityRendererEntry<>(type, factory));
+    }
+
+    @Override
+    public <E extends BlockEntity, S extends BlockEntityRenderState> void registerBlockEntityRenderer(
+            BlockEntityType<? extends E> type,
+            BlockEntityRendererProvider<? super E, ? super S> factory
+    ) {
+        blockEntityRenderers.add(new BlockEntityRendererEntry<>(type, factory));
+    }
+
+    @Override
+    public Identifier hudAnchorCrosshair() {
+        return ForgeLayeredDraw.CROSSHAIR;
+    }
+
+    @Override
+    public Identifier hudAnchorMiscOverlays() {
+        // Forge has no MISC_OVERLAYS; camera overlay is the early HUD slot.
+        return ForgeLayeredDraw.CAMERA_OVERLAY;
+    }
+
+    @Override
+    public void attachHudAfter(Identifier afterVanillaElement, Identifier elementId, HudExtractor extractor) {
+        hudLayers.add(new HudLayerEntry(afterVanillaElement, elementId, extractor));
+    }
+
+    @Override
+    public void registerLevelRenderStartMain(Consumer<LevelRenderCtx> handler) {
+        startMainHandlers.add(handler);
+    }
+
+    @Override
+    public void registerLevelRenderEndMain(Consumer<LevelRenderCtx> handler) {
+        endMainHandlers.add(handler);
+    }
+
+    @Override
+    public void registerLevelRenderBeforeGizmos(Consumer<LevelRenderCtx> handler) {
+        beforeGizmosHandlers.add(handler);
+    }
+
+    private record ModelLayerEntry(ModelLayerLocation location, LayerDefinitionProvider definition) {
+    }
+
+    private record EntityRendererEntry<T extends Entity>(
+            EntityType<? extends T> type,
+            EntityRendererProvider<T> factory
+    ) {
+    }
+
+    private record BlockEntityRendererEntry<E extends BlockEntity, S extends BlockEntityRenderState>(
+            BlockEntityType<? extends E> type,
+            BlockEntityRendererProvider<? super E, ? super S> factory
+    ) {
+    }
+
+    private record HudLayerEntry(Identifier afterVanillaElement, Identifier elementId, HudExtractor extractor) {
+    }
+}

--- a/dwm-loaders/forge/src/main/java/com/adamkali/dwm/platform/forge/ForgeDwmPlatform.java
+++ b/dwm-loaders/forge/src/main/java/com/adamkali/dwm/platform/forge/ForgeDwmPlatform.java
@@ -1,0 +1,441 @@
+package com.adamkali.dwm.platform.forge;
+
+import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.platform.DwmPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.SpawnPlacementType;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraft.world.level.block.FireBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.state.properties.WoodType;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.common.ToolActions;
+import net.minecraftforge.event.BuildCreativeModeTabContentsEvent;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.event.entity.EntityAttributeCreationEvent;
+import net.minecraftforge.event.entity.SpawnPlacementRegisterEvent;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.event.level.BlockEvent;
+import net.minecraftforge.event.level.LevelEvent;
+import net.minecraftforge.event.network.CustomPayloadEvent;
+import net.minecraftforge.event.server.ServerStartedEvent;
+import net.minecraftforge.event.server.ServerStoppedEvent;
+import net.minecraftforge.network.Channel;
+import net.minecraftforge.network.ChannelBuilder;
+import net.minecraftforge.network.PacketDistributor;
+import net.minecraftforge.network.payload.PayloadFlow;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Forge common/server implementation of {@link DwmPlatform} (Forge 65 / MC 26.2).
+ */
+public final class ForgeDwmPlatform implements DwmPlatform {
+    private final List<PendingPayload<?>> clientboundPayloads = new CopyOnWriteArrayList<>();
+    private final List<PendingPayload<?>> serverboundPayloads = new CopyOnWriteArrayList<>();
+    private final Map<CustomPacketPayload.Type<?>, BiConsumer<?, ServerPlayContext>> serverboundHandlers =
+            new ConcurrentHashMap<>();
+    private final Map<CustomPacketPayload.Type<?>, BiConsumer<?, CustomPayloadEvent.Context>> clientboundHandlers =
+            new ConcurrentHashMap<>();
+    private final List<SpawnPlacementEntry<?>> spawnPlacements = new CopyOnWriteArrayList<>();
+    private final List<AttributeEntry> attributes = new CopyOnWriteArrayList<>();
+    private final Map<ResourceKey<CreativeModeTab>, List<Consumer<CreativeTabOutput>>> creativeTabModifiers =
+            new ConcurrentHashMap<>();
+    private final Map<Block, Block> strippables = new ConcurrentHashMap<>();
+
+    private Channel<CustomPacketPayload> channel;
+
+    public ForgeDwmPlatform() {
+        EntityAttributeCreationEvent.BUS.addListener(this::onEntityAttributeCreation);
+        SpawnPlacementRegisterEvent.BUS.addListener(this::onSpawnPlacementRegister);
+        BuildCreativeModeTabContentsEvent.BUS.addListener(this::onBuildCreativeTabs);
+        BlockEvent.BlockToolModificationEvent.BUS.addListener(this::onToolModification);
+    }
+
+    /**
+     * Builds the Forge {@link Channel} after all payload codecs are registered
+     * (call after {@link com.adamkali.dwm.DwmCommon#init()}).
+     */
+    public void buildNetwork() {
+        if (channel != null) {
+            return;
+        }
+
+        var connection = ChannelBuilder
+                .named(Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "main"))
+                .networkProtocolVersion(1)
+                .payloadChannel();
+
+        PayloadFlow<RegistryFriendlyByteBuf, CustomPacketPayload> clientbound =
+                connection.play().clientbound();
+        for (PendingPayload<?> pending : clientboundPayloads) {
+            pending.addClientbound(clientbound, clientboundHandlers);
+        }
+
+        PayloadFlow<RegistryFriendlyByteBuf, CustomPacketPayload> serverbound =
+                clientbound.serverbound();
+        for (PendingPayload<?> pending : serverboundPayloads) {
+            pending.addServerbound(serverbound, serverboundHandlers);
+        }
+
+        channel = serverbound.build();
+    }
+
+    Channel<CustomPacketPayload> channel() {
+        if (channel == null) {
+            buildNetwork();
+        }
+        return channel;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    <T extends CustomPacketPayload> void putClientboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, CustomPayloadEvent.Context> handler
+    ) {
+        clientboundHandlers.put(type, (BiConsumer) handler);
+    }
+
+    private void onEntityAttributeCreation(EntityAttributeCreationEvent event) {
+        for (AttributeEntry entry : attributes) {
+            event.put(entry.type(), entry.attributes().get().build());
+        }
+    }
+
+    private void onSpawnPlacementRegister(SpawnPlacementRegisterEvent event) {
+        for (SpawnPlacementEntry<?> entry : spawnPlacements) {
+            entry.register(event);
+        }
+    }
+
+    private void onBuildCreativeTabs(BuildCreativeModeTabContentsEvent event) {
+        List<Consumer<CreativeTabOutput>> modifiers = creativeTabModifiers.get(event.getTabKey());
+        if (modifiers == null) {
+            return;
+        }
+        CreativeTabOutput output = event::accept;
+        for (Consumer<CreativeTabOutput> modifier : modifiers) {
+            modifier.accept(output);
+        }
+    }
+
+    private boolean onToolModification(BlockEvent.BlockToolModificationEvent event) {
+        if (event.getToolAction() != ToolActions.AXE_STRIP) {
+            return false;
+        }
+        Block stripped = strippables.get(event.getState().getBlock());
+        if (stripped == null) {
+            return false;
+        }
+        event.setFinalState(stripped.withPropertiesOf(event.getState()));
+        return false;
+    }
+
+    @Override
+    public void registerServerStarted(Consumer<MinecraftServer> handler) {
+        ServerStartedEvent.BUS.addListener(event -> handler.accept(event.getServer()));
+    }
+
+    @Override
+    public void registerAfterSave(AfterSaveHandler handler) {
+        LevelEvent.Save.BUS.addListener(event -> {
+            if (event.getLevel() instanceof ServerLevel serverLevel) {
+                handler.onAfterSave(serverLevel.getServer(), true, false);
+            }
+        });
+    }
+
+    @Override
+    public void registerServerStopped(Consumer<MinecraftServer> handler) {
+        ServerStoppedEvent.BUS.addListener(event -> handler.accept(event.getServer()));
+    }
+
+    @Override
+    public void registerEndServerTick(Consumer<MinecraftServer> handler) {
+        TickEvent.ServerTickEvent.Post.BUS.addListener(event -> handler.accept(event.server()));
+    }
+
+    @Override
+    public void registerCommands(CommandRegistrationHandler handler) {
+        RegisterCommandsEvent.BUS.addListener(event ->
+                handler.register(event.getDispatcher(), event.getBuildContext(), event.getCommandSelection()));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerClientboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        clientboundPayloads.add(new PendingPayload<>(type, codec));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerServerboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        serverboundPayloads.add(new PendingPayload<>(type, codec));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends CustomPacketPayload> void registerServerboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ServerPlayContext> handler
+    ) {
+        serverboundHandlers.put(type, (BiConsumer<?, ServerPlayContext>) handler);
+    }
+
+    @Override
+    public void sendToPlayer(ServerPlayer player, CustomPacketPayload payload) {
+        channel().send(payload, PacketDistributor.PLAYER.with(player));
+    }
+
+    @Override
+    public Collection<ServerPlayer> playersTracking(ServerLevel level, BlockPos pos) {
+        return level.getChunkSource().chunkMap.getPlayers(ChunkPos.containing(pos), false);
+    }
+
+    @Override
+    public Collection<ServerPlayer> playersAround(ServerLevel level, Vec3 center, double radius) {
+        double diameter = radius * 2.0;
+        AABB box = AABB.ofSize(center, diameter, diameter, diameter);
+        double radiusSq = radius * radius;
+        List<ServerPlayer> result = new ArrayList<>();
+        for (ServerPlayer player : level.getEntitiesOfClass(ServerPlayer.class, box)) {
+            if (player.distanceToSqr(center) <= radiusSq) {
+                result.add(player);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void registerBeforeBlockBreak(BeforeBlockBreakHandler handler) {
+        BlockEvent.BreakEvent.BUS.addListener(event -> {
+            if (!(event.getLevel() instanceof Level level)) {
+                return false;
+            }
+            BlockEntity blockEntity = level.getBlockEntity(event.getPos());
+            return !handler.allowBreak(level, event.getPlayer(), event.getPos(), event.getState(), blockEntity);
+        });
+    }
+
+    @Override
+    public void registerAfterBlockBreak(AfterBlockBreakHandler handler) {
+        // Forge 65 has no dedicated after-break bus; invoke when BreakEvent is allowed to proceed.
+        BlockEvent.BreakEvent.BUS.addListener(event -> {
+            if (!(event.getLevel() instanceof Level level)) {
+                return;
+            }
+            BlockEntity blockEntity = level.getBlockEntity(event.getPos());
+            handler.onBreak(level, event.getPlayer(), event.getPos(), event.getState(), blockEntity);
+        });
+    }
+
+    @Override
+    public void registerAttackBlock(AttackBlockHandler handler) {
+        PlayerInteractEvent.LeftClickBlock.BUS.addListener(event -> {
+            InteractionResult result = handler.onAttack(
+                    event.getEntity(),
+                    event.getLevel(),
+                    event.getHand(),
+                    event.getPos(),
+                    event.getFace()
+            );
+            return result != InteractionResult.PASS;
+        });
+    }
+
+    @Override
+    public void registerUseBlock(UseBlockHandler handler) {
+        PlayerInteractEvent.RightClickBlock.BUS.addListener(event -> {
+            InteractionResult result = handler.onUse(
+                    event.getEntity(),
+                    event.getLevel(),
+                    event.getHand(),
+                    event.getHitVec()
+            );
+            if (result != InteractionResult.PASS) {
+                event.setCancellationResult(result);
+                return true;
+            }
+            return false;
+        });
+    }
+
+    @Override
+    public void modifyCreativeTab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeTabOutput> modifier) {
+        creativeTabModifiers.computeIfAbsent(tab, key -> new CopyOnWriteArrayList<>()).add(modifier);
+    }
+
+    @Override
+    public void registerCompostable(ItemLike item, float chance) {
+        ComposterBlock.COMPOSTABLES.put(item.asItem(), chance);
+    }
+
+    @Override
+    public void registerStrippable(Block input, Block stripped) {
+        strippables.put(input, stripped);
+    }
+
+    @Override
+    public void registerFlammable(Block block, int burnOdds, int spreadOdds) {
+        ((FireBlock) Blocks.FIRE).setFlammable(block, burnOdds, spreadOdds);
+    }
+
+    @Override
+    public BlockSetType registerBlockSetType(Identifier id) {
+        return BlockSetType.register(new BlockSetType(id.toString()));
+    }
+
+    @Override
+    public WoodType registerWoodType(Identifier id, BlockSetType setType) {
+        return WoodType.register(new WoodType(id.toString(), setType));
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityType<T> buildBlockEntityType(
+            BlockEntityFactory<T> factory,
+            Block... blocks
+    ) {
+        return new BlockEntityType<>(factory::create, Set.of(blocks));
+    }
+
+    @Override
+    public <T extends Mob> void registerSpawnPlacement(
+            EntityType<T> type,
+            SpawnPlacementType placement,
+            Heightmap.Types heightmap,
+            SpawnPredicate<T> predicate
+    ) {
+        spawnPlacements.add(new SpawnPlacementEntry<>(type, placement, heightmap, predicate));
+    }
+
+    @Override
+    public void registerDefaultAttributes(
+            EntityType<? extends LivingEntity> type,
+            Supplier<AttributeSupplier.Builder> attributes
+    ) {
+        this.attributes.add(new AttributeEntry(type, attributes));
+    }
+
+    @Override
+    public void addValidBlockEntityBlock(BlockEntityType<?> type, Block block) {
+        Set<Block> blocks = type.validBlocks;
+        if (!(blocks instanceof java.util.HashSet)) {
+            blocks = new java.util.HashSet<>(blocks);
+            type.validBlocks = blocks;
+        }
+        blocks.add(block);
+    }
+
+    private record PendingPayload<T extends CustomPacketPayload>(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        @SuppressWarnings("unchecked")
+        void addClientbound(
+                PayloadFlow<RegistryFriendlyByteBuf, CustomPacketPayload> flow,
+                Map<CustomPacketPayload.Type<?>, BiConsumer<?, CustomPayloadEvent.Context>> handlers
+        ) {
+            StreamCodec<RegistryFriendlyByteBuf, T> typedCodec =
+                    (StreamCodec<RegistryFriendlyByteBuf, T>) codec;
+            flow.addMain(type, typedCodec, (payload, ctx) -> {
+                BiConsumer<T, CustomPayloadEvent.Context> handler =
+                        (BiConsumer<T, CustomPayloadEvent.Context>) handlers.get(type);
+                if (handler != null) {
+                    handler.accept(payload, ctx);
+                }
+            });
+        }
+
+        @SuppressWarnings("unchecked")
+        void addServerbound(
+                PayloadFlow<RegistryFriendlyByteBuf, CustomPacketPayload> flow,
+                Map<CustomPacketPayload.Type<?>, BiConsumer<?, ServerPlayContext>> handlers
+        ) {
+            StreamCodec<RegistryFriendlyByteBuf, T> typedCodec =
+                    (StreamCodec<RegistryFriendlyByteBuf, T>) codec;
+            BiConsumer<T, ServerPlayContext> handler =
+                    (BiConsumer<T, ServerPlayContext>) handlers.get(type);
+            flow.addMain(type, typedCodec, (payload, ctx) -> {
+                if (handler == null) {
+                    return;
+                }
+                ServerPlayer sender = ctx.getSender();
+                if (sender == null) {
+                    return;
+                }
+                handler.accept(payload, new ServerPlayContext() {
+                    @Override
+                    public MinecraftServer server() {
+                        return sender.level().getServer();
+                    }
+
+                    @Override
+                    public ServerPlayer player() {
+                        return sender;
+                    }
+                });
+            });
+        }
+    }
+
+    private record SpawnPlacementEntry<T extends Mob>(
+            EntityType<T> type,
+            SpawnPlacementType placement,
+            Heightmap.Types heightmap,
+            SpawnPredicate<T> predicate
+    ) {
+        void register(SpawnPlacementRegisterEvent event) {
+            event.register(
+                    type,
+                    placement,
+                    heightmap,
+                    (entityType, level, reason, pos, random) ->
+                            predicate.test(entityType, level, reason, pos, random),
+                    SpawnPlacementRegisterEvent.Operation.REPLACE
+            );
+        }
+    }
+
+    private record AttributeEntry(
+            EntityType<? extends LivingEntity> type,
+            Supplier<AttributeSupplier.Builder> attributes
+    ) {
+    }
+}

--- a/dwm-loaders/forge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/dwm-loaders/forge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,24 @@
+# Matches dwm.accesswidener (NoiseRouterData.overworld, Camera setters)
+public net.minecraft.world.level.levelgen.NoiseRouterData overworld(Lnet/minecraft/core/HolderGetter;Lnet/minecraft/core/HolderGetter;ZZ)Lnet/minecraft/world/level/levelgen/NoiseRouter; # overworld
+public net.minecraft.client.Camera setPosition(DDD)V # setPosition
+public net.minecraft.client.Camera setPosition(Lnet/minecraft/world/phys/Vec3;)V # setPosition
+public net.minecraft.client.Camera setRotation(FF)V # setRotation
+
+# Client special model registration (DwmCommonClient)
+public net.minecraft.client.renderer.special.SpecialModelRenderers ID_MAPPER # ID_MAPPER
+
+# Imperative block property registration (ForgeDwmPlatform)
+public net.minecraft.world.level.block.FireBlock setFlammable(Lnet/minecraft/world/level/block/Block;II)V # setFlammable
+public net.minecraft.world.level.block.ComposterBlock COMPOSTABLES # COMPOSTABLES
+
+# Fabric-API-equivalent private accessors used by dwm-common
+public net.minecraft.world.entity.Interaction setWidth(F)V # setWidth
+public net.minecraft.world.entity.Interaction getWidth()F # getWidth
+public net.minecraft.world.entity.Interaction setHeight(F)V # setHeight
+public net.minecraft.world.entity.Interaction getHeight()F # getHeight
+public net.minecraft.world.entity.Interaction setResponse(Z)V # setResponse
+public net.minecraft.world.item.equipment.ArmorMaterials makeDefense(IIIII)Ljava/util/Map; # makeDefense
+public net.minecraft.client.renderer.RenderPipelines register(Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lcom/mojang/blaze3d/pipeline/RenderPipeline; # register
+
+# Mutable valid-block set for wood-family sign registration
+public-f net.minecraft.world.level.block.entity.BlockEntityType validBlocks # validBlocks

--- a/dwm-loaders/forge/src/main/resources/META-INF/mods.toml
+++ b/dwm-loaders/forge/src/main/resources/META-INF/mods.toml
@@ -1,0 +1,27 @@
+modLoader="javafml"
+loaderVersion="[65,)"
+license="CC0-1.0"
+
+[[mixins]]
+config="dwm.client.mixins.json"
+
+[[mods]]
+modId="dwm"
+version="${mod_version}"
+displayName="Doctor Who Mod"
+authors="adam-k-ali"
+description='''Doctor Who content for Minecraft — TARDISes, Gallifrey, and more.'''
+
+[[dependencies.dwm]]
+modId="forge"
+mandatory=true
+versionRange="[65,)"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.dwm]]
+modId="minecraft"
+mandatory=true
+versionRange="[26.2,26.3)"
+ordering="NONE"
+side="BOTH"

--- a/dwm-loaders/gradle.properties
+++ b/dwm-loaders/gradle.properties
@@ -7,3 +7,5 @@ mod_version=1.4.0
 maven_group=com.adamkali.dwm
 forge_version=65.1.2
 neoforge_version=26.2.0.66
+screenplay_version=1.0.0+26.2
+screenplay_maven_group=com.adamkali.screenplay

--- a/dwm-loaders/gradle.properties
+++ b/dwm-loaders/gradle.properties
@@ -1,0 +1,9 @@
+org.gradle.jvmargs=-Xmx3G
+org.gradle.parallel=true
+org.gradle.configuration-cache=false
+
+minecraft_version=26.2
+mod_version=1.4.0
+maven_group=com.adamkali.dwm
+forge_version=65.1.2
+neoforge_version=26.2.0.66

--- a/dwm-loaders/neoforge/build.gradle
+++ b/dwm-loaders/neoforge/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'net.neoforged.gradle.userdev' version '7.1.38'
+    id 'com.adamkali.screenplay'
 }
 
 version = project.mod_version
@@ -44,12 +45,18 @@ dependencies {
     implementation 'org.json:json:20240303'
     implementation 'com.github.erosb:everit-json-schema:1.14.4'
     implementation 'com.mixpanel:mixpanel-java:1.5.1'
+    // Screenplay NeoForge client harness (composite includeBuild + substitution).
+    runtimeOnly "${project.screenplay_maven_group}:screenplay-neoforge:${project.screenplay_version}"
 }
 
 def dwmCommon = rootProject.file('../dwm-common')
 def rootGenerated = rootProject.file('../src/main/generated')
+def screenplayTests = rootProject.file('../src/screenplayTests/resources')
 
 sourceSets.main {
+    // NeoForge/FML discovers each classpath entry with mods.toml as its own ModFile.
+    // Keep classes + resources in one directory so @Mod and mods.toml share a root.
+    output.resourcesDir = layout.buildDirectory.dir('classes/java/main').get().asFile
     java {
         srcDir new File(dwmCommon, 'src/main/java')
         srcDir new File(dwmCommon, 'src/client/java')
@@ -58,7 +65,17 @@ sourceSets.main {
         srcDir new File(dwmCommon, 'src/main/resources')
         srcDir new File(dwmCommon, 'src/client/resources')
         srcDir rootGenerated
+        // Mod-owned scenarios only — screenplay-neoforge jar already ships harness demos.
+        srcDir screenplayTests
     }
+}
+
+screenplay {
+    loader = 'neoforge'
+    testsDir = rootProject.file('../src/screenplayTests/resources/tests')
+    extraTestsDirs = [rootProject.file('../screenplay-common/src/main/resources/tests')]
+    runDir = 'build/screenplay/run'
+    outputDir = 'screenplay'
 }
 
 processResources {

--- a/dwm-loaders/neoforge/build.gradle
+++ b/dwm-loaders/neoforge/build.gradle
@@ -1,0 +1,88 @@
+plugins {
+    id 'java-library'
+    id 'maven-publish'
+    id 'net.neoforged.gradle.userdev' version '7.1.38'
+}
+
+version = project.mod_version
+group = project.maven_group
+
+base {
+    archivesName = 'dwm-neoforge'
+}
+
+java {
+    withSourcesJar()
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
+}
+
+minecraft {
+    accessTransformers.file project.file('src/main/resources/META-INF/accesstransformer.cfg')
+}
+
+runs {
+    configureEach {
+        workingDirectory project.layout.projectDirectory.dir('run').dir(name)
+        systemProperty 'forge.logging.markers', 'REGISTRIES'
+        systemProperty 'forge.logging.console.level', 'debug'
+        modSource project.sourceSets.main
+    }
+    client {
+    }
+    server {
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation "net.neoforged:neoforge:${project.neoforge_version}"
+    implementation 'org.json:json:20240303'
+    implementation 'com.github.erosb:everit-json-schema:1.14.4'
+    implementation 'com.mixpanel:mixpanel-java:1.5.1'
+}
+
+def dwmCommon = rootProject.file('../dwm-common')
+def rootGenerated = rootProject.file('../src/main/generated')
+
+sourceSets.main {
+    java {
+        srcDir new File(dwmCommon, 'src/main/java')
+        srcDir new File(dwmCommon, 'src/client/java')
+    }
+    resources {
+        srcDir new File(dwmCommon, 'src/main/resources')
+        srcDir new File(dwmCommon, 'src/client/resources')
+        srcDir rootGenerated
+    }
+}
+
+processResources {
+    var replaceProperties = [
+            mod_version: project.version
+    ]
+    inputs.properties replaceProperties
+    filesMatching(['META-INF/neoforge.mods.toml']) {
+        expand replaceProperties
+    }
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
+    options.release = 25
+}
+
+publishing {
+    publications {
+        create('mavenJava', MavenPublication) {
+            artifactId = 'dwm-neoforge'
+            from components.java
+        }
+    }
+    repositories {
+    }
+}

--- a/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/neoforge/NeoForgeDwmMod.java
+++ b/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/neoforge/NeoForgeDwmMod.java
@@ -1,0 +1,26 @@
+package com.adamkali.dwm.neoforge;
+
+import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.DwmCommon;
+import com.adamkali.dwm.DwmCommonClient;
+import com.adamkali.dwm.platform.DwmClientServices;
+import com.adamkali.dwm.platform.DwmServices;
+import com.adamkali.dwm.platform.neoforge.NeoForgeDwmClientPlatform;
+import com.adamkali.dwm.platform.neoforge.NeoForgeDwmPlatform;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.fml.loading.FMLEnvironment;
+
+@Mod(DWMReference.MOD_ID)
+public final class NeoForgeDwmMod {
+    public NeoForgeDwmMod(IEventBus modBus) {
+        DwmServices.set(new NeoForgeDwmPlatform(modBus));
+        DwmCommon.init();
+
+        if (FMLEnvironment.getDist() == Dist.CLIENT) {
+            DwmClientServices.set(new NeoForgeDwmClientPlatform(modBus));
+            DwmCommonClient.init();
+        }
+    }
+}

--- a/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/neoforge/NeoForgeDwmMod.java
+++ b/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/neoforge/NeoForgeDwmMod.java
@@ -16,7 +16,11 @@ import net.neoforged.fml.loading.FMLEnvironment;
 public final class NeoForgeDwmMod {
     public NeoForgeDwmMod(IEventBus modBus) {
         DwmServices.set(new NeoForgeDwmPlatform(modBus));
+        // Fabric-style Registry.register in DwmCommon needs open vanilla registries.
+        NeoForgeRegistryBootstrap.unlockForFabricStyleRegistration();
         DwmCommon.init();
+        NeoForgeRegistryBootstrap.syncBlockItemMapAfterRegistration();
+        NeoForgeRegistryBootstrap.initBlockStateCachesAfterRegistration();
 
         if (FMLEnvironment.getDist() == Dist.CLIENT) {
             DwmClientServices.set(new NeoForgeDwmClientPlatform(modBus));

--- a/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/neoforge/NeoForgeRegistryBootstrap.java
+++ b/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/neoforge/NeoForgeRegistryBootstrap.java
@@ -1,0 +1,69 @@
+package com.adamkali.dwm.neoforge;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.item.BlockItem;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.state.BlockState;
+import net.neoforged.neoforge.registries.GameData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Opens NeoForge/vanilla registries so Fabric-style {@code Registry.register} calls in
+ * {@link com.adamkali.dwm.DwmCommon} can run during mod construction, then repairs the
+ * NeoForge block→item map used by {@link Block#asItem()} and block-state shape caches.
+ *
+ * <p>NeoForge freezes mapped registries before mod constructors and populates
+ * {@link GameData#getBlockItemMap()} via item-registry add callbacks. Direct vanilla
+ * registration after {@link GameData#unfreezeData()} can leave that map incomplete,
+ * so creative tabs see {@code minecraft:air} for DWM blocks.
+ *
+ * <p>NeoForge also runs {@link BlockState#initCache()} only for blocks observed by its
+ * registry bake callbacks. Blocks registered during the early unlock window never get
+ * {@code onAdd}, so neighbor occlusion during chunk meshing NPEs on
+ * {@code occlusionShapesByFace}. Call {@link #initBlockStateCachesAfterRegistration()}
+ * after {@link com.adamkali.dwm.DwmCommon#init()}.
+ */
+final class NeoForgeRegistryBootstrap {
+    private static final Logger LOGGER = LoggerFactory.getLogger("dwm");
+
+    private NeoForgeRegistryBootstrap() {
+    }
+
+    static void unlockForFabricStyleRegistration() {
+        // Unfreezes every MappedRegistry in BuiltInRegistries (NeoForge API).
+        GameData.unfreezeData();
+    }
+
+    static void syncBlockItemMapAfterRegistration() {
+        Map<Block, Item> blockToItem = GameData.getBlockItemMap();
+        int synced = 0;
+        for (Item item : BuiltInRegistries.ITEM) {
+            if (item instanceof BlockItem blockItem) {
+                blockItem.registerBlocks(blockToItem, item);
+                synced++;
+            }
+        }
+        LOGGER.debug("Synced {} BlockItem entries into NeoForge block→item map", synced);
+    }
+
+    static void initBlockStateCachesAfterRegistration() {
+        int states = 0;
+        for (Block block : BuiltInRegistries.BLOCK) {
+            Identifier id = BuiltInRegistries.BLOCK.getKey(block);
+            if (id == null || !DWMReference.MOD_ID.equals(id.getNamespace())) {
+                continue;
+            }
+            for (BlockState state : block.getStateDefinition().getPossibleStates()) {
+                state.initCache();
+                states++;
+            }
+        }
+        LOGGER.debug("Initialized occlusion caches for {} DWM block states", states);
+    }
+}

--- a/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/platform/neoforge/NeoForgeDwmClientPlatform.java
+++ b/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/platform/neoforge/NeoForgeDwmClientPlatform.java
@@ -1,0 +1,198 @@
+package com.adamkali.dwm.platform.neoforge;
+
+import com.adamkali.dwm.platform.DwmClientPlatform;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.model.geom.ModelLayerLocation;
+import net.minecraft.client.multiplayer.ClientPacketListener;
+import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider;
+import net.minecraft.client.renderer.blockentity.state.BlockEntityRenderState;
+import net.minecraft.client.renderer.entity.EntityRendererProvider;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.EntityRenderersEvent;
+import net.neoforged.neoforge.client.event.RegisterGuiLayersEvent;
+import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+import net.neoforged.neoforge.client.event.lifecycle.ClientStoppingEvent;
+import net.neoforged.neoforge.client.gui.VanillaGuiLayers;
+import net.neoforged.neoforge.client.network.ClientPacketDistributor;
+import net.neoforged.neoforge.client.network.event.RegisterClientPayloadHandlersEvent;
+import net.neoforged.neoforge.common.NeoForge;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * NeoForge client implementation of {@link DwmClientPlatform}.
+ */
+public final class NeoForgeDwmClientPlatform implements DwmClientPlatform {
+    private final Map<CustomPacketPayload.Type<?>, BiConsumer<?, ClientPlayContext>> clientboundHandlers =
+            new HashMap<>();
+    private final List<ModelLayerEntry> modelLayers = new CopyOnWriteArrayList<>();
+    private final List<EntityRendererEntry<?>> entityRenderers = new CopyOnWriteArrayList<>();
+    private final List<BlockEntityRendererEntry<?, ?>> blockEntityRenderers = new CopyOnWriteArrayList<>();
+    private final List<HudLayerEntry> hudLayers = new CopyOnWriteArrayList<>();
+
+    public NeoForgeDwmClientPlatform(IEventBus modBus) {
+        modBus.addListener(this::onRegisterClientPayloadHandlers);
+        modBus.addListener(this::onRegisterLayerDefinitions);
+        modBus.addListener(this::onRegisterRenderers);
+        modBus.addListener(this::onRegisterGuiLayers);
+    }
+
+    private void onRegisterClientPayloadHandlers(RegisterClientPayloadHandlersEvent event) {
+        for (Map.Entry<CustomPacketPayload.Type<?>, BiConsumer<?, ClientPlayContext>> entry :
+                clientboundHandlers.entrySet()) {
+            registerHandler(event, entry.getKey(), entry.getValue());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T extends CustomPacketPayload> void registerHandler(
+            RegisterClientPayloadHandlersEvent event,
+            CustomPacketPayload.Type<?> type,
+            BiConsumer<?, ClientPlayContext> handler
+    ) {
+        BiConsumer<T, ClientPlayContext> typed = (BiConsumer<T, ClientPlayContext>) handler;
+        event.register((CustomPacketPayload.Type<T>) type, (payload, context) ->
+                typed.accept(payload, () -> Minecraft.getInstance()));
+    }
+
+    private void onRegisterLayerDefinitions(EntityRenderersEvent.RegisterLayerDefinitions event) {
+        for (ModelLayerEntry entry : modelLayers) {
+            event.registerLayerDefinition(entry.location(), entry.definition()::createLayerDefinition);
+        }
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void onRegisterRenderers(EntityRenderersEvent.RegisterRenderers event) {
+        for (EntityRendererEntry<?> entry : entityRenderers) {
+            event.registerEntityRenderer((EntityType) entry.type(), entry.factory());
+        }
+        for (BlockEntityRendererEntry<?, ?> entry : blockEntityRenderers) {
+            event.registerBlockEntityRenderer((BlockEntityType) entry.type(), entry.factory());
+        }
+    }
+
+    private void onRegisterGuiLayers(RegisterGuiLayersEvent event) {
+        for (HudLayerEntry entry : hudLayers) {
+            event.registerAbove(entry.afterVanillaElement(), entry.elementId(), entry.extractor()::extract);
+        }
+    }
+
+    @Override
+    public void registerEndClientTick(Consumer<Minecraft> handler) {
+        NeoForge.EVENT_BUS.addListener((ClientTickEvent.Post event) -> handler.accept(Minecraft.getInstance()));
+    }
+
+    @Override
+    public void registerClientStopping(Consumer<Minecraft> handler) {
+        NeoForge.EVENT_BUS.addListener((ClientStoppingEvent event) -> handler.accept(Minecraft.getInstance()));
+    }
+
+    @Override
+    public void registerClientDisconnect(BiConsumer<ClientPacketListener, Minecraft> handler) {
+        NeoForge.EVENT_BUS.addListener((ClientPlayerNetworkEvent.LoggingOut event) -> {
+            ClientPacketListener connection = Minecraft.getInstance().getConnection();
+            if (connection != null) {
+                handler.accept(connection, Minecraft.getInstance());
+            }
+        });
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerClientboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ClientPlayContext> handler
+    ) {
+        clientboundHandlers.put(type, handler);
+    }
+
+    @Override
+    public void sendToServer(CustomPacketPayload payload) {
+        ClientPacketDistributor.sendToServer(payload);
+    }
+
+    @Override
+    public void registerModelLayer(ModelLayerLocation location, LayerDefinitionProvider definition) {
+        modelLayers.add(new ModelLayerEntry(location, definition));
+    }
+
+    @Override
+    public <T extends Entity> void registerEntityRenderer(
+            EntityType<? extends T> type,
+            EntityRendererProvider<T> factory
+    ) {
+        entityRenderers.add(new EntityRendererEntry<>(type, factory));
+    }
+
+    @Override
+    public <E extends BlockEntity, S extends BlockEntityRenderState> void registerBlockEntityRenderer(
+            BlockEntityType<? extends E> type,
+            BlockEntityRendererProvider<? super E, ? super S> factory
+    ) {
+        blockEntityRenderers.add(new BlockEntityRendererEntry<>(type, factory));
+    }
+
+    @Override
+    public Identifier hudAnchorCrosshair() {
+        return VanillaGuiLayers.CROSSHAIR;
+    }
+
+    @Override
+    public Identifier hudAnchorMiscOverlays() {
+        // NeoForge has no MISC_OVERLAYS; camera overlays are the early HUD slot.
+        return VanillaGuiLayers.CAMERA_OVERLAYS;
+    }
+
+    @Override
+    public void attachHudAfter(Identifier afterVanillaElement, Identifier elementId, HudExtractor extractor) {
+        hudLayers.add(new HudLayerEntry(afterVanillaElement, elementId, extractor));
+    }
+
+    @Override
+    public void registerLevelRenderStartMain(Consumer<LevelRenderCtx> handler) {
+        NeoForge.EVENT_BUS.addListener((RenderLevelStageEvent.AfterSky event) ->
+                handler.accept(event::getLevelRenderer));
+    }
+
+    @Override
+    public void registerLevelRenderEndMain(Consumer<LevelRenderCtx> handler) {
+        NeoForge.EVENT_BUS.addListener((RenderLevelStageEvent.AfterTranslucentBlocks event) ->
+                handler.accept(event::getLevelRenderer));
+    }
+
+    @Override
+    public void registerLevelRenderBeforeGizmos(Consumer<LevelRenderCtx> handler) {
+        NeoForge.EVENT_BUS.addListener((RenderLevelStageEvent.AfterLevel event) ->
+                handler.accept(event::getLevelRenderer));
+    }
+
+    private record ModelLayerEntry(ModelLayerLocation location, LayerDefinitionProvider definition) {
+    }
+
+    private record EntityRendererEntry<T extends Entity>(
+            EntityType<? extends T> type,
+            EntityRendererProvider<T> factory
+    ) {
+    }
+
+    private record BlockEntityRendererEntry<E extends BlockEntity, S extends BlockEntityRenderState>(
+            BlockEntityType<? extends E> type,
+            BlockEntityRendererProvider<? super E, ? super S> factory
+    ) {
+    }
+
+    private record HudLayerEntry(Identifier afterVanillaElement, Identifier elementId, HudExtractor extractor) {
+    }
+}

--- a/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/platform/neoforge/NeoForgeDwmPlatform.java
+++ b/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/platform/neoforge/NeoForgeDwmPlatform.java
@@ -1,0 +1,400 @@
+package com.adamkali.dwm.platform.neoforge;
+
+import com.adamkali.dwm.platform.DwmPlatform;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.RegistryFriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.SpawnPlacementType;
+import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
+import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.ItemLike;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.ComposterBlock;
+import net.minecraft.world.level.block.FireBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import net.minecraft.world.level.block.state.properties.BlockSetType;
+import net.minecraft.world.level.block.state.properties.WoodType;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+import net.neoforged.bus.api.EventPriority;
+import net.neoforged.bus.api.IEventBus;
+import net.neoforged.neoforge.common.ItemAbilities;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.BuildCreativeModeTabContentsEvent;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.entity.EntityAttributeCreationEvent;
+import net.neoforged.neoforge.event.entity.RegisterSpawnPlacementsEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+import net.neoforged.neoforge.event.level.BlockDropsEvent;
+import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.LevelEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
+import net.neoforged.neoforge.event.server.ServerStartedEvent;
+import net.neoforged.neoforge.event.server.ServerStoppedEvent;
+import net.neoforged.neoforge.event.tick.ServerTickEvent;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * NeoForge common/server implementation of {@link DwmPlatform}.
+ */
+public final class NeoForgeDwmPlatform implements DwmPlatform {
+    private final List<PendingClientboundPayload<?>> clientboundPayloads = new CopyOnWriteArrayList<>();
+    private final List<PendingServerboundPayload<?>> serverboundPayloads = new CopyOnWriteArrayList<>();
+    private final Map<CustomPacketPayload.Type<?>, BiConsumer<?, ServerPlayContext>> serverboundHandlers =
+            new HashMap<>();
+    private final List<SpawnPlacementEntry<?>> spawnPlacements = new CopyOnWriteArrayList<>();
+    private final List<AttributeEntry> attributes = new CopyOnWriteArrayList<>();
+    private final Map<ResourceKey<CreativeModeTab>, List<Consumer<CreativeTabOutput>>> creativeTabModifiers =
+            new HashMap<>();
+    private final Map<Block, Block> strippables = new ConcurrentHashMap<>();
+    private final Map<BlockEntityType<?>, List<Block>> blockEntityValidBlocks = new HashMap<>();
+
+    public NeoForgeDwmPlatform(IEventBus modBus) {
+        modBus.addListener(this::onRegisterPayloads);
+        modBus.addListener(this::onRegisterSpawnPlacements);
+        modBus.addListener(this::onEntityAttributeCreation);
+        modBus.addListener(this::onBuildCreativeTabs);
+        modBus.addListener(this::onBlockEntityTypeAddBlocks);
+        NeoForge.EVENT_BUS.addListener(this::onBlockToolModification);
+    }
+
+    private void onBlockEntityTypeAddBlocks(net.neoforged.neoforge.event.BlockEntityTypeAddBlocksEvent event) {
+        for (Map.Entry<BlockEntityType<?>, List<Block>> entry : blockEntityValidBlocks.entrySet()) {
+            event.modify(entry.getKey(), entry.getValue().toArray(Block[]::new));
+        }
+    }
+
+    private void onBlockToolModification(BlockEvent.BlockToolModificationEvent event) {
+        if (event.getItemAbility() != ItemAbilities.AXE_STRIP) {
+            return;
+        }
+        Block stripped = strippables.get(event.getState().getBlock());
+        if (stripped != null) {
+            event.setFinalState(stripped.withPropertiesOf(event.getState()));
+        }
+    }
+
+    private void onRegisterPayloads(RegisterPayloadHandlersEvent event) {
+        PayloadRegistrar registrar = event.registrar("1");
+        for (PendingClientboundPayload<?> pending : clientboundPayloads) {
+            pending.register(registrar);
+        }
+        for (PendingServerboundPayload<?> pending : serverboundPayloads) {
+            pending.register(registrar, serverboundHandlers);
+        }
+    }
+
+    private void onRegisterSpawnPlacements(RegisterSpawnPlacementsEvent event) {
+        for (SpawnPlacementEntry<?> entry : spawnPlacements) {
+            entry.register(event);
+        }
+    }
+
+    private void onEntityAttributeCreation(EntityAttributeCreationEvent event) {
+        for (AttributeEntry entry : attributes) {
+            event.put(entry.type(), entry.attributes().get().build());
+        }
+    }
+
+    private void onBuildCreativeTabs(BuildCreativeModeTabContentsEvent event) {
+        List<Consumer<CreativeTabOutput>> modifiers = creativeTabModifiers.get(event.getTabKey());
+        if (modifiers == null) {
+            return;
+        }
+        CreativeTabOutput output = event::accept;
+        for (Consumer<CreativeTabOutput> modifier : modifiers) {
+            modifier.accept(output);
+        }
+    }
+
+    @Override
+    public void registerServerStarted(Consumer<MinecraftServer> handler) {
+        NeoForge.EVENT_BUS.addListener((ServerStartedEvent event) -> handler.accept(event.getServer()));
+    }
+
+    @Override
+    public void registerAfterSave(AfterSaveHandler handler) {
+        NeoForge.EVENT_BUS.addListener((LevelEvent.Save event) -> {
+            if (event.getLevel() instanceof ServerLevel serverLevel) {
+                handler.onAfterSave(serverLevel.getServer(), true, false);
+            }
+        });
+    }
+
+    @Override
+    public void registerServerStopped(Consumer<MinecraftServer> handler) {
+        NeoForge.EVENT_BUS.addListener((ServerStoppedEvent event) -> handler.accept(event.getServer()));
+    }
+
+    @Override
+    public void registerEndServerTick(Consumer<MinecraftServer> handler) {
+        NeoForge.EVENT_BUS.addListener((ServerTickEvent.Post event) -> handler.accept(event.getServer()));
+    }
+
+    @Override
+    public void registerCommands(CommandRegistrationHandler handler) {
+        NeoForge.EVENT_BUS.addListener((RegisterCommandsEvent event) ->
+                handler.register(event.getDispatcher(), event.getBuildContext(), event.getCommandSelection()));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerClientboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        clientboundPayloads.add(new PendingClientboundPayload<>(type, codec));
+    }
+
+    @Override
+    public <T extends CustomPacketPayload> void registerServerboundPayload(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        serverboundPayloads.add(new PendingServerboundPayload<>(type, codec));
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends CustomPacketPayload> void registerServerboundHandler(
+            CustomPacketPayload.Type<T> type,
+            BiConsumer<T, ServerPlayContext> handler
+    ) {
+        serverboundHandlers.put(type, (BiConsumer<?, ServerPlayContext>) handler);
+    }
+
+    @Override
+    public void sendToPlayer(ServerPlayer player, CustomPacketPayload payload) {
+        PacketDistributor.sendToPlayer(player, payload);
+    }
+
+    @Override
+    public Collection<ServerPlayer> playersTracking(ServerLevel level, BlockPos pos) {
+        return level.getChunkSource().chunkMap.getPlayers(ChunkPos.containing(pos), false);
+    }
+
+    @Override
+    public Collection<ServerPlayer> playersAround(ServerLevel level, Vec3 center, double radius) {
+        double diameter = radius * 2.0;
+        AABB box = AABB.ofSize(center, diameter, diameter, diameter);
+        double radiusSq = radius * radius;
+        List<ServerPlayer> result = new ArrayList<>();
+        for (ServerPlayer player : level.getEntitiesOfClass(ServerPlayer.class, box)) {
+            if (player.distanceToSqr(center) <= radiusSq) {
+                result.add(player);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void registerBeforeBlockBreak(BeforeBlockBreakHandler handler) {
+        NeoForge.EVENT_BUS.addListener(EventPriority.HIGH, (BreakBlockEvent event) -> {
+            if (!(event.getLevel() instanceof net.minecraft.world.level.Level level)) {
+                return;
+            }
+            BlockEntity blockEntity = level.getBlockEntity(event.getPos());
+            if (!handler.allowBreak(level, event.getPlayer(), event.getPos(), event.getState(), blockEntity)) {
+                event.setCanceled(true);
+                event.setNotifyClient(true);
+            }
+        });
+    }
+
+    @Override
+    public void registerAfterBlockBreak(AfterBlockBreakHandler handler) {
+        NeoForge.EVENT_BUS.addListener((BlockDropsEvent event) -> {
+            if (!(event.getBreaker() instanceof net.minecraft.world.entity.player.Player player)) {
+                return;
+            }
+            if (!(event.getLevel() instanceof net.minecraft.world.level.Level level)) {
+                return;
+            }
+            handler.onBreak(level, player, event.getPos(), event.getState(), event.getBlockEntity());
+        });
+    }
+
+    @Override
+    public void registerAttackBlock(AttackBlockHandler handler) {
+        NeoForge.EVENT_BUS.addListener((PlayerInteractEvent.LeftClickBlock event) -> {
+            InteractionResult result = handler.onAttack(
+                    event.getEntity(),
+                    event.getLevel(),
+                    event.getHand(),
+                    event.getPos(),
+                    event.getFace()
+            );
+            if (result != InteractionResult.PASS) {
+                event.setCanceled(true);
+            }
+        });
+    }
+
+    @Override
+    public void registerUseBlock(UseBlockHandler handler) {
+        NeoForge.EVENT_BUS.addListener((PlayerInteractEvent.RightClickBlock event) -> {
+            InteractionResult result = handler.onUse(
+                    event.getEntity(),
+                    event.getLevel(),
+                    event.getHand(),
+                    event.getHitVec()
+            );
+            if (result != InteractionResult.PASS) {
+                event.setCanceled(true);
+                event.setCancellationResult(result);
+            }
+        });
+    }
+
+    @Override
+    public void modifyCreativeTab(ResourceKey<CreativeModeTab> tab, Consumer<CreativeTabOutput> modifier) {
+        creativeTabModifiers.computeIfAbsent(tab, key -> new CopyOnWriteArrayList<>()).add(modifier);
+    }
+
+    @Override
+    public void registerCompostable(ItemLike item, float chance) {
+        ComposterBlock.COMPOSTABLES.put(item.asItem(), chance);
+    }
+
+    @Override
+    public void registerStrippable(Block input, Block stripped) {
+        strippables.put(input, stripped);
+    }
+
+    @Override
+    public void registerFlammable(Block block, int burnOdds, int spreadOdds) {
+        ((FireBlock) Blocks.FIRE).setFlammable(block, burnOdds, spreadOdds);
+    }
+
+    @Override
+    public void addValidBlockEntityBlock(BlockEntityType<?> type, Block block) {
+        blockEntityValidBlocks.computeIfAbsent(type, key -> new CopyOnWriteArrayList<>()).add(block);
+    }
+
+    @Override
+    public BlockSetType registerBlockSetType(Identifier id) {
+        return BlockSetType.register(new BlockSetType(id.toString()));
+    }
+
+    @Override
+    public WoodType registerWoodType(Identifier id, BlockSetType setType) {
+        return WoodType.register(new WoodType(id.toString(), setType));
+    }
+
+    @Override
+    public <T extends BlockEntity> BlockEntityType<T> buildBlockEntityType(
+            BlockEntityFactory<T> factory,
+            Block... blocks
+    ) {
+        return new BlockEntityType<>(factory::create, Set.of(blocks));
+    }
+
+    @Override
+    public <T extends Mob> void registerSpawnPlacement(
+            EntityType<T> type,
+            SpawnPlacementType placement,
+            Heightmap.Types heightmap,
+            SpawnPredicate<T> predicate
+    ) {
+        spawnPlacements.add(new SpawnPlacementEntry<>(type, placement, heightmap, predicate));
+    }
+
+    @Override
+    public void registerDefaultAttributes(
+            EntityType<? extends LivingEntity> type,
+            Supplier<AttributeSupplier.Builder> attributes
+    ) {
+        this.attributes.add(new AttributeEntry(type, attributes));
+    }
+
+    private record PendingClientboundPayload<T extends CustomPacketPayload>(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        void register(PayloadRegistrar registrar) {
+            registrar.playToClient(type, codec);
+        }
+    }
+
+    private record PendingServerboundPayload<T extends CustomPacketPayload>(
+            CustomPacketPayload.Type<T> type,
+            StreamCodec<? super RegistryFriendlyByteBuf, T> codec
+    ) {
+        @SuppressWarnings("unchecked")
+        void register(
+                PayloadRegistrar registrar,
+                Map<CustomPacketPayload.Type<?>, BiConsumer<?, ServerPlayContext>> handlers
+        ) {
+            BiConsumer<T, ServerPlayContext> handler =
+                    (BiConsumer<T, ServerPlayContext>) handlers.get(type);
+            if (handler == null) {
+                registrar.playToServer(type, codec, (payload, context) -> {
+                });
+                return;
+            }
+            registrar.playToServer(type, codec, (payload, context) ->
+                    handler.accept(payload, new ServerPlayContext() {
+                        @Override
+                        public MinecraftServer server() {
+                            return ((ServerPlayer) context.player()).level().getServer();
+                        }
+
+                        @Override
+                        public ServerPlayer player() {
+                            return (ServerPlayer) context.player();
+                        }
+                    }));
+        }
+    }
+
+    private record SpawnPlacementEntry<T extends Mob>(
+            EntityType<T> type,
+            SpawnPlacementType placement,
+            Heightmap.Types heightmap,
+            SpawnPredicate<T> predicate
+    ) {
+        void register(RegisterSpawnPlacementsEvent event) {
+            event.register(
+                    type,
+                    placement,
+                    heightmap,
+                    (entityType, level, reason, pos, random) ->
+                            predicate.test(entityType, level, reason, pos, random),
+                    RegisterSpawnPlacementsEvent.Operation.REPLACE
+            );
+        }
+    }
+
+    private record AttributeEntry(
+            EntityType<? extends LivingEntity> type,
+            Supplier<AttributeSupplier.Builder> attributes
+    ) {
+    }
+}

--- a/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/platform/neoforge/NeoForgeDwmPlatform.java
+++ b/dwm-loaders/neoforge/src/main/java/com/adamkali/dwm/platform/neoforge/NeoForgeDwmPlatform.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.SpawnPlacementType;
 import net.minecraft.world.entity.ai.attributes.AttributeSupplier;
 import net.minecraft.world.item.CreativeModeTab;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.ItemLike;
 import net.minecraft.world.level.block.Block;
@@ -129,7 +130,16 @@ public final class NeoForgeDwmPlatform implements DwmPlatform {
         if (modifiers == null) {
             return;
         }
-        CreativeTabOutput output = event::accept;
+        CreativeTabOutput output = item -> {
+            if (item == null) {
+                return;
+            }
+            ItemStack stack = new ItemStack(item);
+            if (stack.isEmpty()) {
+                return;
+            }
+            event.accept(stack);
+        };
         for (Consumer<CreativeTabOutput> modifier : modifiers) {
             modifier.accept(output);
         }

--- a/dwm-loaders/neoforge/src/main/resources/META-INF/accesstransformer.cfg
+++ b/dwm-loaders/neoforge/src/main/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,21 @@
+# Matches dwm.accesswidener (NoiseRouterData.overworld, Camera setters)
+public net.minecraft.world.level.levelgen.NoiseRouterData overworld(Lnet/minecraft/core/HolderGetter;Lnet/minecraft/core/HolderGetter;ZZ)Lnet/minecraft/world/level/levelgen/NoiseRouter; # overworld
+public net.minecraft.client.Camera setPosition(DDD)V # setPosition
+public net.minecraft.client.Camera setPosition(Lnet/minecraft/world/phys/Vec3;)V # setPosition
+public net.minecraft.client.Camera setRotation(FF)V # setRotation
+
+# Client special model registration (DwmCommonClient)
+public net.minecraft.client.renderer.special.SpecialModelRenderers ID_MAPPER # ID_MAPPER
+
+# Imperative block property registration (NeoForgeDwmPlatform)
+public net.minecraft.world.level.block.FireBlock setFlammable(Lnet/minecraft/world/level/block/Block;II)V # setFlammable
+public net.minecraft.world.level.block.ComposterBlock COMPOSTABLES # COMPOSTABLES
+
+# Shared gameplay that Fabric access-widens via Loom / Fabric API
+public net.minecraft.world.entity.Interaction setWidth(F)V # setWidth
+public net.minecraft.world.entity.Interaction getWidth()F # getWidth
+public net.minecraft.world.entity.Interaction setHeight(F)V # setHeight
+public net.minecraft.world.entity.Interaction getHeight()F # getHeight
+public net.minecraft.world.entity.Interaction setResponse(Z)V # setResponse
+public net.minecraft.world.item.equipment.ArmorMaterials makeDefense(IIIII)Ljava/util/Map; # makeDefense
+public net.minecraft.client.renderer.RenderPipelines register(Lcom/mojang/blaze3d/pipeline/RenderPipeline;)Lcom/mojang/blaze3d/pipeline/RenderPipeline; # register

--- a/dwm-loaders/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/dwm-loaders/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -1,0 +1,27 @@
+modLoader="javafml"
+loaderVersion="[4,)"
+license="CC0-1.0"
+
+[[mixins]]
+config="dwm.client.mixins.json"
+
+[[mods]]
+modId="dwm"
+version="${mod_version}"
+displayName="Doctor Who Mod"
+authors="adam-k-ali"
+description='''Doctor Who content for Minecraft — TARDISes, Gallifrey, and more.'''
+
+[[dependencies.dwm]]
+modId="neoforge"
+type="required"
+versionRange="[26.2,)"
+ordering="NONE"
+side="BOTH"
+
+[[dependencies.dwm]]
+modId="minecraft"
+type="required"
+versionRange="[26.2]"
+ordering="NONE"
+side="BOTH"

--- a/dwm-loaders/settings.gradle
+++ b/dwm-loaders/settings.gradle
@@ -1,0 +1,23 @@
+pluginManagement {
+	repositories {
+		maven {
+			name = 'Forge'
+			url = 'https://maven.minecraftforge.net/'
+		}
+		maven {
+			name = 'NeoForged'
+			url = 'https://maven.neoforged.net/releases'
+		}
+		mavenCentral()
+		gradlePluginPortal()
+	}
+}
+
+plugins {
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
+}
+
+rootProject.name = 'dwm-loaders'
+
+include 'forge'
+include 'neoforge'

--- a/dwm-loaders/settings.gradle
+++ b/dwm-loaders/settings.gradle
@@ -8,9 +8,14 @@ pluginManagement {
 			name = 'NeoForged'
 			url = 'https://maven.neoforged.net/releases'
 		}
+		maven {
+			name = 'Fabric'
+			url = 'https://maven.fabricmc.net/'
+		}
 		mavenCentral()
 		gradlePluginPortal()
 	}
+	includeBuild('../screenplay-gradle-plugin')
 }
 
 plugins {
@@ -18,6 +23,15 @@ plugins {
 }
 
 rootProject.name = 'dwm-loaders'
+
+// Project dirs are named forge/neoforge; published artifactIds are screenplay-*.
+// Explicit substitution is required — automatic matching uses project name, not archivesName.
+includeBuild('../screenplay-loaders') {
+	dependencySubstitution {
+		substitute module('com.adamkali.screenplay:screenplay-forge') using project(':forge')
+		substitute module('com.adamkali.screenplay:screenplay-neoforge') using project(':neoforge')
+	}
+}
 
 include 'forge'
 include 'neoforge'

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,6 +24,7 @@ plugins {
 includeBuild('screenplay-gradle-plugin')
 // Isolate Forge/NeoGradle from Fabric Loom runs (NeoGradle treats custom Loom run names as run types).
 includeBuild('screenplay-loaders')
+includeBuild('dwm-loaders')
 
 include 'dwm-common'
 include 'screenplay-common'


### PR DESCRIPTION
## Why this matters

- Players on Forge and NeoForge cannot load DWM today. These adapters implement the SPI and keep Fabric-style registration working on both loaders.

## Proposed Implementation

- Add `dwm-loaders` (included build) with `ForgeDwmPlatform` / `NeoForgeDwmPlatform` and matching client platforms.
- Unlock vanilla registries for Fabric-style `Registry.register`, sync NeoForge block→item maps, and call `BlockState.initCache()` after early registration so neighbor meshing does not NPE.
- CI compiles both loader projects: `./gradlew -p dwm-loaders :forge:compileJava :neoforge:compileJava`.

## Problems Encountered / Decisions Made

- Stacked on `refactor/dwm-common`. Forge and NeoForge stay in one PR because later registry/cache fixes and shared `dwm-loaders` Gradle are coupled.
- Screenplay plugin wiring is in the loader Gradle files so they compile; the three-loader CI matrix lands in the next PR.
- Split from #188.

Made with [Cursor](https://cursor.com)