### PR TITLE
feat(screenplay): run scenarios on Fabric, Forge, and NeoForge

### DIFF
--- a/.github/workflows/scenario-tests.yml
+++ b/.github/workflows/scenario-tests.yml
@@ -14,6 +14,10 @@ jobs:
   scenario:
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        loader: [fabric, forge, neoforge]
 
     steps:
       - name: Checkout
@@ -43,12 +47,26 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Run all Screenplay tests
+      - name: Run Screenplay tests (${{ matrix.loader }})
         run: |
           chmod +x ./gradlew
-          ./gradlew runScreenplayTests \
-            -PscreenplayDisplay=xvfb \
-            -PscreenplayTimeout=120
+          case "${{ matrix.loader }}" in
+            fabric)
+              ./gradlew runScreenplayTests \
+                -PscreenplayDisplay=xvfb \
+                -PscreenplayTimeout=120
+              ;;
+            forge)
+              xvfb-run -a ./gradlew -p dwm-loaders :forge:runScreenplayTests \
+                -PscreenplayDisplay=xvfb \
+                -PscreenplayTimeout=120
+              ;;
+            neoforge)
+              xvfb-run -a ./gradlew -p dwm-loaders :neoforge:runScreenplayTests \
+                -PscreenplayDisplay=xvfb \
+                -PscreenplayTimeout=120
+              ;;
+          esac
         env:
           _JAVA_OPTIONS: -Xmx3200m
           GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -57,7 +75,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screenplay-tests
+          name: screenplay-tests-${{ matrix.loader }}
           path: |
             build/screenplay/results/
             build/screenplay/report.xml
@@ -65,6 +83,8 @@ jobs:
             build/screenplay/diagnostics.txt
             build/screenplay/run/screenshots/
             build/screenplay/vanilla-server/logs/
+            dwm-loaders/forge/build/screenplay/
+            dwm-loaders/neoforge/build/screenplay/
           if-no-files-found: ignore
 
   compare-perf:
@@ -84,7 +104,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: perf/current
-          pattern: screenplay-*
+          pattern: screenplay-tests-fabric
           merge-multiple: false
 
       - name: Download latest green main baseline artifacts
@@ -108,9 +128,10 @@ jobs:
             exit 0
           fi
           printf 'run [#%s](%s) on `main`\n' "$RUN_ID" "$RUN_URL" > perf/baseline-label.txt
-          gh run download "$RUN_ID" -D perf/baseline || true
+          gh run download "$RUN_ID" -D perf/baseline -n screenplay-tests-fabric || \
+            gh run download "$RUN_ID" -D perf/baseline -n screenplay-tests || true
 
-      - name: Compare metrics (advisory)
+      - name: Compare metrics (advisory, Fabric)
         run: |
           python3 .github/scripts/compare-scenario-perf.py \
             --current-dir perf/current \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,19 +1,21 @@
 # AGENTS.md
 
 ## Project Snapshot
-- Project type: Minecraft Fabric mod (`fabric-loom`) using Gradle.
+- Project type: Minecraft multi-loader mod (Fabric primary via `fabric-loom`; Forge/NeoForge via `dwm-loaders` included build).
 - Language/runtime baseline: Java 25.
-- Current target stack is defined in `gradle.properties` and `build.gradle` (Minecraft, Yarn mappings, Fabric Loader, Fabric API).
+- Current target stack is defined in `gradle.properties` and `build.gradle` (Minecraft, Yarn mappings, Fabric Loader, Fabric API, Forge, NeoForge).
 - Objective: maximize safe, repeatable AI-agent-driven development with strong automated verification.
 
 ## Repository Map
-- `src/main/java`: Common logic safe on both logical client and logical server (`com.adamkali.dwm.*`).
-- `src/client/java`: Client-only logic (rendering, HUD, client integration).
+- `dwm-common/`: Shared gameplay + client render (loader-neutral; talks through `DwmPlatform` / `DwmClientPlatform`).
+- Root project: Fabric adapters (`platform/fabric`), entrypoints, datagen, GameTests, Screenplay Fabric runs; embeds `dwm-common` sources.
+- `dwm-loaders/`: Included build for `dwm-forge` and `dwm-neoforge` (isolated from Loom); embeds `dwm-common`.
+- `src/main/java` / `src/client/java`: Fabric-only adapters, datagen, GameTests (shared code lives under `dwm-common`).
 - `src/test/java`: JUnit 5 unit tests and scenario compiler/primitive tests.
 - `src/screenplayTests/`: Mod-owned Screenplay YAML scenarios (resources only; not shipped in the mod jar).
-- `src/main/resources`: Common resources (`fabric.mod.json`, data, tags, recipes, lang, worldgen).
+- `src/main/resources`: Fabric metadata (`fabric.mod.json`, mixins, access widener).
 - `src/main/generated/`: Datagen output — commit intentional changes; delete `.cache/` before commit.
-- `src/client/resources`: Hand-maintained client assets (models, blockstates, textures, sounds).
+- `dwm-common/src/*/resources`: Shared assets/data consumed by all loaders.
 - `docs/`: Product-facing feature docs and release policy — read before changing player-visible behaviour.
 - `tools/`: Offline Python scripts (TARDIS SFX generation/analysis); not part of Gradle build.
 - `metadata/`: Modrinth listing (`modrinth.json`, `modrinth-body.md`).
@@ -71,8 +73,13 @@
 
 ## Testing Expectations
 - **Unit tests** (`./gradlew test`): JUnit 5 via `fabric-loader-junit` for logic, codecs, datagen helpers, and scenario compiler/primitives. Included in `./gradlew build` and CI.
-- **GameTests** (`./gradlew runGametest`): Headless dedicated-server in-world tests in `src/main/java/.../gametest/`. Not run by CI today — run locally when GameTest code changes. See `.cursor/skills/fabric-gametest/SKILL.md`.
-- **Screenplay tests** (`./gradlew runScreenplay -Pscreenplay=<id>`): Real Minecraft client driven from YAML (mod scenarios in `src/screenplayTests/resources/tests/` + library demos). Requires a display; CI uses xvfb. See `src/screenplayTests/AGENTS.md` and `screenplay-fabric/README.md`.
+- **GameTests** (`./gradlew runGametest`): Headless dedicated-server in-world tests (Fabric-only). Not run by CI today — run locally when GameTest code changes. See `.cursor/skills/fabric-gametest/SKILL.md`.
+- **Screenplay tests** (real client YAML):
+  - Fabric: `./gradlew runScreenplay -Pscreenplay=<id>` / `./gradlew runScreenplayTests`
+  - Forge: `xvfb-run -a ./gradlew -p dwm-loaders :forge:runScreenplayTests` (ForgeGradle has no Loom `useXvfb`; wrap with `xvfb-run`)
+  - NeoForge: `xvfb-run -a ./gradlew -p dwm-loaders :neoforge:runScreenplayTests` (entry task is `executeScreenplay` to avoid NeoGradle run-type clashes)
+  - Requires a display; CI uses xvfb (`-PscreenplayDisplay=xvfb`). See `src/screenplayTests/AGENTS.md`.
+- **Forge/NeoForge compile**: `./gradlew -p dwm-loaders :forge:compileJava :neoforge:compileJava`
 - Keep test runs reproducible and suitable for unattended agent execution.
 
 ## Automation Pipeline For Agents
@@ -157,6 +164,7 @@ These notes are for agents running in the Cursor Cloud VM. The standard build/te
 - The startup update script runs `./gradlew dependencies -q`, which resolves all configurations and lets Fabric Loom provision Minecraft, Yarn mappings, and remap the mod dependencies. The very first Loom configuration on a cold cache is slow and network-heavy (it decompiles Minecraft and remaps ~50 mods from `maven.fabricmc.net`, `maven.shedaniel.me`, `maven.terraformersmc.com`, and Maven Central); once cached, subsequent Gradle invocations are fast.
 - Running the mod end-to-end without a display: use `./gradlew runGametest`. This boots a real headless Minecraft server, loads the mod, and executes the registered in-world Fabric GameTests (TARDIS door/interior flows and chameleon networking). It is the best headless smoke test of core gameplay.
 - YAML client scenario tests (`./gradlew runScreenplay`) boot a real Fabric client. In this headless VM use `-PscreenplayDisplay=xvfb` (requires `xvfb` / Mesa); `-PscreenplayDisplay=display` needs a real `$DISPLAY`. See `src/screenplayTests/README.md`. Prefer `runGametest` for server-side gameplay smoke tests.
+- Forge/NeoForge compile: `./gradlew -p dwm-loaders :forge:compileJava :neoforge:compileJava`. Screenplay on those loaders: `xvfb-run -a ./gradlew -p dwm-loaders :forge:runScreenplayTests` / `:neoforge:runScreenplayTests` with `-PscreenplayDisplay=xvfb`.
 - `./gradlew runClient` and `./gradlew runServer` start the actual game; `runClient` needs a GUI/display and will not work in the headless VM. Prefer `runGametest` for automated verification.
 - `./gradlew build` also compiles the `client` source set and runs the full JUnit suite, so a green `build` covers both compile and unit-test confidence.
 - `./gradlew runDatagen` writes generated resources under `src/main/generated/` and also leaves an untracked `src/main/generated/.cache/` directory — delete that `.cache` dir before committing to avoid stray churn.

--- a/docs/release-policy.md
+++ b/docs/release-policy.md
@@ -90,8 +90,8 @@ Ship a patch immediately for:
 4. Commit, merge to `main`, then create and push tag `v{minecraft_version}-{mod_version}` (manually, or via the **Create Release Tag** workflow, which tags `promos.latest` from `version.json` on `main` if that tag is missing).
 5. Confirm the **Release** GitHub Actions workflow succeeds:
    - GitHub Release with remapped JAR (+ sources JAR) and notes from `version.json` (`summary` + detailed lists)
-   - Modrinth version upload (Fabric + Minecraft from the tag; Fabric API dependency)
-   - CurseForge file upload (project `355957`; Fabric + Client/Server + Minecraft from the tag; Fabric API required dependency)
+   - Modrinth version upload (Fabric + Forge + NeoForge loaders from the tag; Fabric API for Fabric artifact)
+   - CurseForge file upload (project `355957`; Fabric/Forge/NeoForge + Client/Server + Minecraft from the tag)
    - Discord `#releases` embed (summary + Modrinth and CurseForge links)
 
 ### Required GitHub Actions secrets
@@ -106,7 +106,8 @@ Ship a patch immediately for:
 
 | Workflow | Trigger | Purpose |
 | --- | --- | --- |
-| [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) | `pull_request`, push to `main` | `./gradlew build` (compile + unit tests + version sync check) |
+| [`.github/workflows/ci.yml`](../.github/workflows/ci.yml) | `pull_request`, push to `main` | `./gradlew build` + Forge/NeoForge `compileJava` |
+| [`.github/workflows/scenario-tests.yml`](../.github/workflows/scenario-tests.yml) | `pull_request`, push to `main` | Screenplay matrix: Fabric / Forge / NeoForge under xvfb |
 | [`.github/workflows/create-release-tag.yml`](../.github/workflows/create-release-tag.yml) | `workflow_dispatch` | Create and push `v*` tag from `version.json` `promos.latest` if missing; then dispatch Release |
 | [`.github/workflows/release.yml`](../.github/workflows/release.yml) | push of tags `v*`, or `workflow_dispatch` | Build; publish GitHub Release, Modrinth version, CurseForge file, and Discord announcement from `version.json` |
 | [`.github/workflows/sync-modrinth-project.yml`](../.github/workflows/sync-modrinth-project.yml) | `workflow_dispatch` | PATCH Modrinth project listing from [`metadata/`](../metadata/) (Modrinth only; CurseForge listing stays manual) |

--- a/screenplay-common/src/main/java/com/adamkali/screenplay/CreateWorldProcess.java
+++ b/screenplay-common/src/main/java/com/adamkali/screenplay/CreateWorldProcess.java
@@ -1,11 +1,16 @@
 package com.adamkali.screenplay;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.ConfirmScreen;
 import net.minecraft.client.gui.screens.LevelLoadingScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.worldselection.ConfirmExperimentalFeaturesScreen;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
 import net.minecraft.client.gui.screens.worldselection.WorldCreationUiState;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.MouseButtonInfo;
 import net.minecraft.core.Holder;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
@@ -13,6 +18,9 @@ import net.minecraft.world.Difficulty;
 import net.minecraft.world.level.levelgen.presets.WorldPreset;
 import org.slf4j.Logger;
 
+import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
+
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -152,12 +160,109 @@ public final class CreateWorldProcess {
             created = true;
             return false;
         }
+        if (dismissConfirmationIfPresent(client)) {
+            return false;
+        }
         if (isWorldReady(client)) {
             logger.info("World is ready");
             completed = true;
             return true;
         }
         return false;
+    }
+
+    private boolean dismissConfirmationIfPresent(Minecraft client) {
+        Screen screen = client.gui.screen();
+        if (screen == null) {
+            return false;
+        }
+        if (screen instanceof ConfirmScreen confirmScreen) {
+            if (acceptConfirmScreen(confirmScreen)) {
+                logger.info("Accepted {}", screen.getClass().getSimpleName());
+                return true;
+            }
+        }
+        if (screen instanceof ConfirmExperimentalFeaturesScreen
+                || screen.getClass().getSimpleName().contains("Confirm")) {
+            if (acceptBooleanConsumer(screen) || clickProceedButton(screen)) {
+                logger.info("Accepted confirmation screen {}", screen.getClass().getName());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean acceptConfirmScreen(ConfirmScreen screen) {
+        try {
+            Field callbackField = ConfirmScreen.class.getDeclaredField("callback");
+            callbackField.setAccessible(true);
+            Object callback = callbackField.get(screen);
+            if (callback instanceof BooleanConsumer consumer) {
+                consumer.accept(true);
+                return true;
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // Fall through.
+        }
+        try {
+            Field yesField = ConfirmScreen.class.getDeclaredField("yesButton");
+            yesField.setAccessible(true);
+            Object yes = yesField.get(screen);
+            if (yes instanceof Button button) {
+                return clickButton(screen, button);
+            }
+        } catch (ReflectiveOperationException ignored) {
+            // Fall through.
+        }
+        return clickProceedButton(screen);
+    }
+
+    private static boolean acceptBooleanConsumer(Screen screen) {
+        Class<?> type = screen.getClass();
+        while (type != null && type != Object.class) {
+            for (Field field : type.getDeclaredFields()) {
+                if (!BooleanConsumer.class.isAssignableFrom(field.getType())) {
+                    continue;
+                }
+                try {
+                    field.setAccessible(true);
+                    Object value = field.get(screen);
+                    if (value instanceof BooleanConsumer consumer) {
+                        consumer.accept(true);
+                        return true;
+                    }
+                } catch (ReflectiveOperationException ignored) {
+                    // try next field
+                }
+            }
+            type = type.getSuperclass();
+        }
+        return false;
+    }
+
+    private static boolean clickProceedButton(Screen screen) {
+        for (var child : screen.children()) {
+            if (!(child instanceof Button button) || !button.visible || !button.active) {
+                continue;
+            }
+            String message = button.getMessage().getString().toLowerCase(Locale.ROOT);
+            if (message.contains("cancel") || message.contains("no") || message.contains("back")) {
+                continue;
+            }
+            if (clickButton(screen, button)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean clickButton(Screen screen, Button button) {
+        MouseButtonEvent event = new MouseButtonEvent(
+                button.getX() + button.getWidth() / 2.0,
+                button.getY() + button.getHeight() / 2.0,
+                new MouseButtonInfo(0, 0)
+        );
+        return screen.mouseClicked(event, false);
     }
 
     private static void applySettings(WorldCreationUiState uiState, Map<String, Object> arguments) {
@@ -238,10 +343,16 @@ public final class CreateWorldProcess {
         if (screen == null) {
             return false;
         }
-        if (screen instanceof CreateWorldScreen || screen instanceof LevelLoadingScreen) {
+        if (screen instanceof CreateWorldScreen
+                || screen instanceof LevelLoadingScreen
+                || screen instanceof ConfirmScreen
+                || screen instanceof ConfirmExperimentalFeaturesScreen) {
             return true;
         }
         String simpleName = screen.getClass().getSimpleName();
-        return simpleName.contains("Loading") || simpleName.contains("Receiving") || simpleName.contains("Progress");
+        return simpleName.contains("Loading")
+                || simpleName.contains("Receiving")
+                || simpleName.contains("Progress")
+                || simpleName.contains("Confirm");
     }
 }

--- a/screenplay-common/src/main/java/com/adamkali/screenplay/ScenarioCatalog.java
+++ b/screenplay-common/src/main/java/com/adamkali/screenplay/ScenarioCatalog.java
@@ -30,22 +30,78 @@ public final class ScenarioCatalog {
     }
 
     public static ScenarioCatalog loadFromResources(ClassLoader classLoader) {
-        Enumeration<URL> roots;
-        try {
-            roots = classLoader.getResources("tests");
-        } catch (IOException exception) {
-            throw new ScenarioException("Could not enumerate scenario resource directories named 'tests'", exception);
-        }
-        if (!roots.hasMoreElements()) {
+        List<URL> rootUrls = discoverResourceRoots(classLoader);
+        if (rootUrls.isEmpty()) {
             throw new ScenarioException("Could not find the scenario resource directory 'tests'");
         }
 
         Map<String, ScenarioDocument> tests = new LinkedHashMap<>();
         Map<String, ScenarioDocument> commands = new LinkedHashMap<>();
-        while (roots.hasMoreElements()) {
-            URL rootUrl = roots.nextElement();
+        java.util.HashSet<String> seenRoots = new java.util.HashSet<>();
+        for (URL rootUrl : rootUrls) {
             Path root = toPath(rootUrl);
+            String rootKey;
+            try {
+                rootKey = root.toAbsolutePath().normalize().toString();
+            } catch (RuntimeException ignored) {
+                rootKey = rootUrl.toString();
+            }
+            if (!seenRoots.add(rootKey)) {
+                continue;
+            }
             loadInto(root, tests, commands);
+        }
+        return new ScenarioCatalog(tests, commands);
+    }
+
+    /**
+     * Loads scenarios from explicit filesystem roots and/or classpath {@code tests/} resources.
+     * Filesystem roots are preferred for NeoForge ModClassLoader isolation (mod scenarios live
+     * in another mod jar) and when Gradle passes {@code screenplay.tests-dirs}.
+     */
+    public static ScenarioCatalog load(List<Path> filesystemRoots, ClassLoader... classLoaders) {
+        Map<String, ScenarioDocument> tests = new LinkedHashMap<>();
+        Map<String, ScenarioDocument> commands = new LinkedHashMap<>();
+        java.util.HashSet<String> seenRoots = new java.util.HashSet<>();
+
+        if (filesystemRoots != null) {
+            for (Path root : filesystemRoots) {
+                if (root == null || !Files.isDirectory(root)) {
+                    continue;
+                }
+                String rootKey = root.toAbsolutePath().normalize().toString();
+                if (!seenRoots.add(rootKey)) {
+                    continue;
+                }
+                loadInto(root, tests, commands);
+            }
+        }
+
+        if (classLoaders != null) {
+            java.util.HashSet<ClassLoader> seenLoaders = new java.util.HashSet<>();
+            for (ClassLoader classLoader : classLoaders) {
+                if (classLoader == null || !seenLoaders.add(classLoader)) {
+                    continue;
+                }
+                for (URL rootUrl : discoverResourceRoots(classLoader)) {
+                    Path root = toPath(rootUrl);
+                    String rootKey;
+                    try {
+                        rootKey = root.toAbsolutePath().normalize().toString();
+                    } catch (RuntimeException ignored) {
+                        rootKey = rootUrl.toString();
+                    }
+                    if (!seenRoots.add(rootKey)) {
+                        continue;
+                    }
+                    loadInto(root, tests, commands);
+                }
+            }
+        }
+
+        if (tests.isEmpty() && commands.isEmpty()) {
+            throw new ScenarioException("Could not find any scenario resources under filesystem roots "
+                    + filesystemRoots + " or classpath 'tests'");
         }
         return new ScenarioCatalog(tests, commands);
     }
@@ -55,6 +111,61 @@ public final class ScenarioCatalog {
         Map<String, ScenarioDocument> commands = new LinkedHashMap<>();
         loadInto(root, tests, commands);
         return new ScenarioCatalog(tests, commands);
+    }
+
+    /**
+     * NeoForge's ModClassLoader often fails to enumerate directory resources via
+     * {@link ClassLoader#getResources(String)} for {@code "tests"}, even when YAML files
+     * inside that directory are readable. Fall back to known marker files and derive the root.
+     */
+    private static List<URL> discoverResourceRoots(ClassLoader classLoader) {
+        List<URL> roots = new ArrayList<>();
+        java.util.HashSet<String> seen = new java.util.HashSet<>();
+        try {
+            Enumeration<URL> directories = classLoader.getResources("tests");
+            while (directories.hasMoreElements()) {
+                URL url = directories.nextElement();
+                if (seen.add(url.toExternalForm())) {
+                    roots.add(url);
+                }
+            }
+            if (!roots.isEmpty()) {
+                return roots;
+            }
+            // Marker files present in screenplay-common and typical mod scenario packs.
+            String[] markers = {
+                    "tests/createWorld.yaml",
+                    "tests/placeBlock.yaml",
+                    "tests/placeAndOpenTardis.yaml",
+                    "tests/joinVanillaServer.yaml"
+            };
+            for (String marker : markers) {
+                Enumeration<URL> files = classLoader.getResources(marker);
+                while (files.hasMoreElements()) {
+                    URL fileUrl = files.nextElement();
+                    URL rootUrl = parentResourceUrl(fileUrl);
+                    if (seen.add(rootUrl.toExternalForm())) {
+                        roots.add(rootUrl);
+                    }
+                }
+            }
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not enumerate scenario resource directories named 'tests'", exception);
+        }
+        return roots;
+    }
+
+    private static URL parentResourceUrl(URL fileUrl) {
+        String external = fileUrl.toExternalForm();
+        int slash = external.lastIndexOf('/');
+        if (slash <= 0) {
+            throw new ScenarioException("Could not derive scenario root from resource URL: " + fileUrl);
+        }
+        try {
+            return java.net.URI.create(external.substring(0, slash)).toURL();
+        } catch (java.net.MalformedURLException exception) {
+            throw new ScenarioException("Could not derive scenario root from resource URL: " + fileUrl, exception);
+        }
     }
 
     private static Path toPath(URL root) {
@@ -96,6 +207,11 @@ public final class ScenarioCatalog {
                                 document.type() == ScenarioDocument.Type.TEST ? tests : commands;
                         ScenarioDocument previous = target.putIfAbsent(document.id(), document);
                         if (previous != null) {
+                            // Overlapping classpath roots (e.g. merged resourcesDir == classesDir)
+                            // can surface the same YAML twice; identical sources are safe to skip.
+                            if (previous.source().equals(document.source())) {
+                                return;
+                            }
                             throw new ScenarioException("Duplicate " + document.type().name().toLowerCase(Locale.ROOT)
                                     + " id '" + document.id() + "' in " + previous.source()
                                     + " and " + document.source());

--- a/screenplay-common/src/main/java/com/adamkali/screenplay/ScenarioRunner.java
+++ b/screenplay-common/src/main/java/com/adamkali/screenplay/ScenarioRunner.java
@@ -23,9 +23,11 @@ final class ScenarioRunner {
     private final List<ScenarioReportWriter.StepResult> results = new ArrayList<>();
 
     private int stepIndex;
-    private long stepStartedNanos;
-    private boolean finished;
+    private volatile long stepStartedNanos;
+    private volatile boolean finished;
     private boolean executing;
+    private String lastScreenDiagnostic;
+    private long lastDiagnosticNanos;
 
     ScenarioRunner(
             ScenarioPlan plan,
@@ -42,12 +44,67 @@ final class ScenarioRunner {
         this.createWorld = new CreateWorldProcess(logger);
     }
 
+    /**
+     * Wall-clock watchdog so scenarios still fail cleanly if client/render ticks stop.
+     */
+    void startWatchdog() {
+        Thread watchdog = new Thread(() -> {
+            while (!finished) {
+                try {
+                    Thread.sleep(1000L);
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+                if (finished) {
+                    continue;
+                }
+                ScenarioPlan.Step timedOutStep;
+                Duration timeout;
+                synchronized (ScenarioRunner.this) {
+                    if (finished || stepStartedNanos == 0L || stepIndex >= plan.steps().size()) {
+                        continue;
+                    }
+                    timedOutStep = plan.steps().get(stepIndex);
+                    timeout = timeoutFor(timedOutStep);
+                    if (System.nanoTime() - stepStartedNanos <= timeout.toNanos()) {
+                        continue;
+                    }
+                }
+                Minecraft client = Minecraft.getInstance();
+                RuntimeException failure = new ScenarioException("Timed out after " + timeout.toSeconds()
+                        + "s waiting for " + timedOutStep.displayName() + " from " + timedOutStep.source()
+                        + " (wall-clock watchdog)");
+                synchronized (ScenarioRunner.this) {
+                    if (finished || stepStartedNanos == 0L || stepIndex >= plan.steps().size()) {
+                        continue;
+                    }
+                    results.add(new ScenarioReportWriter.StepResult(
+                            timedOutStep.displayName(),
+                            System.nanoTime() - stepStartedNanos,
+                            false
+                    ));
+                    finishUnlocked(client, failure);
+                }
+                return;
+            }
+        }, "screenplay-watchdog");
+        watchdog.setDaemon(true);
+        watchdog.start();
+    }
+
     void tick(Minecraft client) {
+        synchronized (this) {
+            tickUnlocked(client);
+        }
+    }
+
+    private void tickUnlocked(Minecraft client) {
         if (finished || executing) {
             return;
         }
         if (stepIndex >= plan.steps().size()) {
-            finish(client, null);
+            finishUnlocked(client, null);
             return;
         }
 
@@ -69,8 +126,10 @@ final class ScenarioRunner {
                 ));
                 stepIndex++;
                 stepStartedNanos = 0L;
+                lastScreenDiagnostic = null;
                 return;
             }
+            maybeLogWaitingDiagnostics(client, step);
             Duration timeout = timeoutFor(step);
             if (System.nanoTime() - stepStartedNanos > timeout.toNanos()) {
                 throw new ScenarioException("Timed out after " + timeout.toSeconds()
@@ -83,8 +142,28 @@ final class ScenarioRunner {
                     System.nanoTime() - stepStartedNanos,
                     false
             ));
-            finish(client, exception);
+            finishUnlocked(client, exception);
         }
+    }
+
+    private void maybeLogWaitingDiagnostics(Minecraft client, ScenarioPlan.Step step) {
+        if (client == null || client.gui == null) {
+            return;
+        }
+        long now = System.nanoTime();
+        if (lastDiagnosticNanos != 0L && now - lastDiagnosticNanos < Duration.ofSeconds(5).toNanos()) {
+            return;
+        }
+        lastDiagnosticNanos = now;
+        Screen screen = client.gui.screen();
+        String screenName = screen == null ? "<none>" : screen.getClass().getName();
+        String overlayName = client.gui.overlay() == null ? "<none>" : client.gui.overlay().getClass().getName();
+        String diagnostic = screenName + "|" + overlayName;
+        if (diagnostic.equals(lastScreenDiagnostic)) {
+            return;
+        }
+        lastScreenDiagnostic = diagnostic;
+        logger.info("Still waiting for {} — screen={}, overlay={}", step.displayName(), screenName, overlayName);
     }
 
     private boolean execute(ScenarioPlan.Step step, Minecraft client) {
@@ -102,6 +181,15 @@ final class ScenarioRunner {
     }
 
     private void finish(Minecraft client, RuntimeException failure) {
+        synchronized (this) {
+            finishUnlocked(client, failure);
+        }
+    }
+
+    private void finishUnlocked(Minecraft client, RuntimeException failure) {
+        if (finished) {
+            return;
+        }
         finished = true;
         vanillaServer.stop();
         String failureMessage = failure == null ? null
@@ -129,7 +217,7 @@ final class ScenarioRunner {
         StringBuilder diagnostics = new StringBuilder();
         diagnostics.append("scenario: ").append(plan.id()).append('\n');
         diagnostics.append("completedSteps: ").append(stepIndex).append('/').append(plan.steps().size()).append('\n');
-        Screen screen = client.gui.screen();
+        Screen screen = client == null || client.gui == null ? null : client.gui.screen();
         diagnostics.append("screen: ")
                 .append(screen == null ? "<none>" : screen.getClass().getName())
                 .append('\n');

--- a/screenplay-common/src/main/java/com/adamkali/screenplay/ScreenplayBootstrap.java
+++ b/screenplay-common/src/main/java/com/adamkali/screenplay/ScreenplayBootstrap.java
@@ -1,11 +1,17 @@
 package com.adamkali.screenplay;
 
 import com.adamkali.screenplay.platform.ScreenplayPlatform;
+import net.minecraft.client.Minecraft;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Shared client bootstrap used by Fabric / Forge / NeoForge entrypoints.
@@ -15,6 +21,8 @@ public final class ScreenplayBootstrap {
     public static final String SCENARIO_PROPERTY = "screenplay";
     public static final String REPORT_PROPERTY = "screenplay.report-file";
     public static final String TIMEOUT_PROPERTY = "screenplay.step-timeout-seconds";
+    /** Path-separator list of filesystem scenario roots (set by the Screenplay Gradle plugin). */
+    public static final String TESTS_DIRS_PROPERTY = "screenplay.tests-dirs";
 
     private static final Logger LOGGER = LoggerFactory.getLogger("Screenplay");
 
@@ -27,11 +35,13 @@ public final class ScreenplayBootstrap {
                 System.getProperty(REPORT_PROPERTY, "build/screenplay/report.xml")
         ));
         try {
-            ScenarioCatalog catalog = ScenarioCatalog.loadFromResources(ScreenplayBootstrap.class.getClassLoader());
+            ScenarioCatalog catalog = loadCatalog();
             ScenarioPlan plan = new ScenarioCompiler(catalog).compile(scenarioId);
             Duration timeout = Duration.ofSeconds(readPositiveLong(TIMEOUT_PROPERTY, 30L));
             ScenarioRunner runner = new ScenarioRunner(plan, reportWriter, timeout, LOGGER);
+            runner.startWatchdog();
             platform.registerEndClientTick(runner::tick);
+            startMainThreadPump(runner);
             LOGGER.info("Loaded scenario '{}' with {} primitive steps", plan.id(), plan.steps().size());
         } catch (RuntimeException exception) {
             LOGGER.error("Could not start scenario '{}'", scenarioId, exception);
@@ -42,6 +52,51 @@ public final class ScreenplayBootstrap {
             }
             System.exit(1);
         }
+    }
+
+    /**
+     * Pump scenario steps onto the Minecraft main thread at ~20 Hz.
+     * Loader tick events can stall under headless Forge/NeoForge while frames still render;
+     * {@link Minecraft#execute(Runnable)} keeps Screenplay advancing regardless.
+     */
+    private static void startMainThreadPump(ScenarioRunner runner) {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "screenplay-pump");
+            thread.setDaemon(true);
+            return thread;
+        });
+        scheduler.scheduleAtFixedRate(() -> {
+            try {
+                Minecraft client = Minecraft.getInstance();
+                if (client != null) {
+                    client.execute(() -> runner.tick(client));
+                }
+            } catch (Throwable ignored) {
+                // Minecraft may not be ready yet; keep pumping.
+            }
+        }, 100L, 50L, TimeUnit.MILLISECONDS);
+    }
+
+    private static ScenarioCatalog loadCatalog() {
+        List<Path> filesystemRoots = readTestsDirs();
+        ClassLoader own = ScreenplayBootstrap.class.getClassLoader();
+        ClassLoader context = Thread.currentThread().getContextClassLoader();
+        return ScenarioCatalog.load(filesystemRoots, own, context);
+    }
+
+    private static List<Path> readTestsDirs() {
+        String raw = System.getProperty(TESTS_DIRS_PROPERTY);
+        if (raw == null || raw.isBlank()) {
+            return List.of();
+        }
+        List<Path> roots = new java.util.ArrayList<>();
+        for (String entry : raw.split(java.util.regex.Pattern.quote(File.pathSeparator))) {
+            if (entry == null || entry.isBlank()) {
+                continue;
+            }
+            roots.add(Path.of(entry.trim()));
+        }
+        return List.copyOf(roots);
     }
 
     private static long readPositiveLong(String property, long defaultValue) {

--- a/screenplay-common/src/main/java/com/adamkali/screenplay/ScreenshotCapture.java
+++ b/screenplay-common/src/main/java/com/adamkali/screenplay/ScreenshotCapture.java
@@ -7,14 +7,22 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.contents.TranslatableContents;
 import org.slf4j.Logger;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Locale;
 import java.util.concurrent.atomic.AtomicReference;
 
 public final class ScreenshotCapture {
     private static final int NO_DOWNSCALE = 1;
+    /** Solid-black 854×480 PNGs from empty FBOs compress to ~17KB; real frames are much larger. */
+    public static final long SUSPECT_BLANK_MAX_BYTES = 40_000L;
+    private static final int MAX_BLANK_RETRIES = 45;
 
     private final Logger logger;
     private final AtomicReference<Object> inFlight = new AtomicReference<>();
+    private int blankRetries;
+    private int settleTicks;
 
     ScreenshotCapture(Logger logger) {
         this.logger = logger;
@@ -36,9 +44,17 @@ public final class ScreenshotCapture {
         return trimmed + ".png";
     }
 
+    public static boolean isSuspectBlankSize(long byteLength) {
+        return byteLength > 0L && byteLength < SUSPECT_BLANK_MAX_BYTES;
+    }
+
     public boolean tick(Minecraft client, String filename) {
         Object current = inFlight.get();
         if (current == null) {
+            if (settleTicks > 0) {
+                settleTicks--;
+                return false;
+            }
             inFlight.set(Pending.INSTANCE);
             try {
                 Screenshot.grab(
@@ -62,12 +78,78 @@ public final class ScreenshotCapture {
         inFlight.set(null);
         logger.info("{}", completed.message());
         if (completed.failed()) {
+            blankRetries = 0;
+            settleTicks = 0;
             throw new ScenarioException("captureScreenshot failed: " + completed.message());
         }
+
+        Path saved = resolveSavedPath(client, filename, completed.path());
+        if (saved != null && isBlankPng(saved) && blankRetries < MAX_BLANK_RETRIES) {
+            blankRetries++;
+            settleTicks = 2;
+            logger.warn(
+                    "captureScreenshot {} looks blank ({}); retrying {}/{}",
+                    saved.getFileName(),
+                    sizeLabel(saved),
+                    blankRetries,
+                    MAX_BLANK_RETRIES
+            );
+            try {
+                Files.deleteIfExists(saved);
+            } catch (IOException ignored) {
+                // Best-effort; next grab may overwrite.
+            }
+            return false;
+        }
+        if (saved != null && isBlankPng(saved)) {
+            blankRetries = 0;
+            settleTicks = 0;
+            throw new ScenarioException(
+                    "captureScreenshot produced a blank/black frame after "
+                            + MAX_BLANK_RETRIES
+                            + " retries: "
+                            + saved
+                            + " ("
+                            + sizeLabel(saved)
+                            + "). Client chunks may not have rendered; check launchGame finished LoadingOverlay.onFinish."
+            );
+        }
+
+        blankRetries = 0;
+        settleTicks = 0;
         if (completed.path() != null) {
             logger.info("captureScreenshot saved {}", completed.path());
         }
         return true;
+    }
+
+    private static Path resolveSavedPath(Minecraft client, String filename, String reportedPath) {
+        if (reportedPath != null && !reportedPath.isBlank()) {
+            return Path.of(reportedPath);
+        }
+        if (filename == null || filename.isBlank() || client.gameDirectory == null) {
+            return null;
+        }
+        return client.gameDirectory.toPath().resolve("screenshots").resolve(filename);
+    }
+
+    private static boolean isBlankPng(Path path) {
+        try {
+            if (!Files.isRegularFile(path)) {
+                return false;
+            }
+            return isSuspectBlankSize(Files.size(path));
+        } catch (IOException ignored) {
+            return false;
+        }
+    }
+
+    private static String sizeLabel(Path path) {
+        try {
+            return Files.size(path) + " bytes";
+        } catch (IOException exception) {
+            return "unreadable";
+        }
     }
 
     private static Completed interpret(Component message) {

--- a/screenplay-common/src/main/java/com/adamkali/screenplay/primitive/LaunchGamePrimitive.java
+++ b/screenplay-common/src/main/java/com/adamkali/screenplay/primitive/LaunchGamePrimitive.java
@@ -1,10 +1,43 @@
 package com.adamkali.screenplay.primitive;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.AccessibilityOnboardingScreen;
+import net.minecraft.client.gui.screens.LoadingOverlay;
+import net.minecraft.client.gui.screens.Overlay;
+import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.input.MouseButtonInfo;
+import net.minecraft.server.packs.resources.ReloadInstance;
 
+import java.lang.reflect.Field;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Consumer;
 
+/**
+ * Waits for the title screen after resource reload.
+ * <p>
+ * Under Forge/NeoForge + xvfb, Minecraft client ticks can stall while render frames still
+ * run, so {@link LoadingOverlay#tick()} (which invokes {@code onFinish}) may never run on
+ * its own. Screenplay therefore drives {@code tick()} from the scenario loop when reload is
+ * done. Clearing the overlay without {@code onFinish} leaves the client half-initialized and
+ * causes later chunk-load timeouts with solid-black screenshots.
+ * <p>
+ * Forge may then show {@code LoadingErrorScreen} for warnings-only loads; that screen's
+ * Continue path sets the current screen to {@code null} so the title screen can appear.
+ */
 public final class LaunchGamePrimitive extends NoArgPrimitive {
+    private static Field loadingOverlayReloadField;
+    private static boolean loadingOverlayReloadFieldResolved;
+    private static Field loadingOverlayFadeOutStartField;
+    private static boolean loadingOverlayFadeOutStartFieldResolved;
+    private static Field loadingOverlayOnFinishField;
+    private static boolean loadingOverlayOnFinishFieldResolved;
+    private static long lastReloadLogNanos;
+
     @Override
     public String name() {
         return "launchGame";
@@ -17,6 +50,217 @@ public final class LaunchGamePrimitive extends NoArgPrimitive {
 
     @Override
     public boolean execute(ScenarioPrimitiveContext context) {
-        return context.screen() instanceof TitleScreen;
+        Minecraft client = context.client();
+        if (client == null || client.gui == null) {
+            return false;
+        }
+
+        Overlay overlay = client.gui.overlay();
+        maybeLogReloadProgress(context, overlay);
+
+        if (overlay instanceof LoadingOverlay loadingOverlay && isReloadDone(overlay)) {
+            // Prefer the real finish path so Minecraft's onFinish callback runs.
+            loadingOverlay.tick();
+            if (hasFadeOutStarted(loadingOverlay) || ensureOnFinishInvoked(loadingOverlay)) {
+                client.gui.setOverlay(null);
+            }
+        }
+
+        if (context.screen() instanceof AccessibilityOnboardingScreen) {
+            client.gui.setScreen(new TitleScreen());
+            return false;
+        }
+        if (dismissLoaderErrorScreenIfPresent(client, context)) {
+            return false;
+        }
+        return context.screen() instanceof TitleScreen && client.gui.overlay() == null;
+    }
+
+    /**
+     * Forge (and similar loaders) can present a warnings-only error screen after reload.
+     * Screenplay stays loader-agnostic: detect by class name and click Continue / proceed.
+     */
+    private static boolean dismissLoaderErrorScreenIfPresent(Minecraft client, ScenarioPrimitiveContext context) {
+        Screen screen = context.screen();
+        if (screen == null) {
+            return false;
+        }
+        String className = screen.getClass().getName();
+        if (!className.endsWith("LoadingErrorScreen") && !className.contains(".LoadingErrorScreen")) {
+            return false;
+        }
+        if (clickContinueButton(screen)) {
+            context.logger().info("Accepted loader warning screen {}", className);
+            return true;
+        }
+        // Warnings-only Forge path: Continue sets screen to null; TitleScreen follows.
+        client.gui.setScreen(null);
+        context.logger().info("Cleared loader warning screen {} (no Continue button matched)", className);
+        return true;
+    }
+
+    private static boolean clickContinueButton(Screen screen) {
+        for (var child : screen.children()) {
+            if (!(child instanceof Button button) || !button.visible || !button.active) {
+                continue;
+            }
+            String message = button.getMessage().getString().toLowerCase(Locale.ROOT);
+            if (!(message.contains("continue") || message.contains("proceed") || message.contains("launch"))) {
+                continue;
+            }
+            MouseButtonEvent event = new MouseButtonEvent(
+                    button.getX() + button.getWidth() / 2.0,
+                    button.getY() + button.getHeight() / 2.0,
+                    new MouseButtonInfo(0, 0)
+            );
+            if (screen.mouseClicked(event, false)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static void maybeLogReloadProgress(ScenarioPrimitiveContext context, Overlay overlay) {
+        long now = System.nanoTime();
+        if (lastReloadLogNanos != 0L && now - lastReloadLogNanos < 5_000_000_000L) {
+            return;
+        }
+        lastReloadLogNanos = now;
+        if (overlay == null) {
+            context.logger().info("launchGame: overlay=<none> screen={}",
+                    context.screen() == null ? "<none>" : context.screen().getClass().getName());
+            return;
+        }
+        try {
+            Field field = resolveReloadField(overlay);
+            if (field == null) {
+                context.logger().info("launchGame: overlay={} (no reload field)", overlay.getClass().getName());
+                return;
+            }
+            Object reload = field.get(overlay);
+            if (reload instanceof ReloadInstance reloadInstance) {
+                context.logger().info("launchGame: overlay={} reloadDone={} progress={} fadeOutStarted={}",
+                        overlay.getClass().getName(),
+                        reloadInstance.isDone(),
+                        reloadInstance.getActualProgress(),
+                        overlay instanceof LoadingOverlay loadingOverlay && hasFadeOutStarted(loadingOverlay));
+            }
+        } catch (ReflectiveOperationException exception) {
+            context.logger().info("launchGame: could not read reload state: {}", exception.toString());
+        }
+    }
+
+    private static boolean isReloadDone(Overlay overlay) {
+        try {
+            Field field = resolveReloadField(overlay);
+            if (field == null) {
+                return false;
+            }
+            Object reload = field.get(overlay);
+            return reload instanceof ReloadInstance reloadInstance && reloadInstance.isDone();
+        } catch (ReflectiveOperationException ignored) {
+            return false;
+        }
+    }
+
+    private static boolean hasFadeOutStarted(LoadingOverlay overlay) {
+        try {
+            Field field = resolveFadeOutStartField();
+            if (field == null) {
+                return false;
+            }
+            return field.getLong(overlay) > -1L;
+        } catch (ReflectiveOperationException ignored) {
+            return false;
+        }
+    }
+
+    /**
+     * Last-resort: if {@link LoadingOverlay#tick()} could not start fade-out (for example
+     * fade-in gate), invoke {@code onFinish} once so client init still completes.
+     */
+    @SuppressWarnings("unchecked")
+    private static boolean ensureOnFinishInvoked(LoadingOverlay overlay) {
+        if (hasFadeOutStarted(overlay)) {
+            return true;
+        }
+        try {
+            Field onFinishField = resolveOnFinishField();
+            Field fadeOutField = resolveFadeOutStartField();
+            if (onFinishField == null || fadeOutField == null) {
+                return false;
+            }
+            Object onFinish = onFinishField.get(overlay);
+            if (!(onFinish instanceof Consumer<?> consumer)) {
+                return false;
+            }
+            Field reloadField = resolveReloadField(overlay);
+            if (reloadField != null) {
+                Object reload = reloadField.get(overlay);
+                if (reload instanceof ReloadInstance reloadInstance) {
+                    reloadInstance.checkExceptions();
+                }
+            }
+            ((Consumer<Optional<Throwable>>) consumer).accept(Optional.empty());
+            fadeOutField.setLong(overlay, System.currentTimeMillis());
+            return true;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
+    private static Field resolveReloadField(Overlay overlay) throws ReflectiveOperationException {
+        if (!loadingOverlayReloadFieldResolved) {
+            loadingOverlayReloadFieldResolved = true;
+            try {
+                Field field = LoadingOverlay.class.getDeclaredField("reload");
+                field.setAccessible(true);
+                loadingOverlayReloadField = field;
+            } catch (NoSuchFieldException ignored) {
+                loadingOverlayReloadField = null;
+            }
+        }
+        if (loadingOverlayReloadField != null) {
+            return loadingOverlayReloadField;
+        }
+        Class<?> type = overlay.getClass();
+        while (type != null && type != Object.class) {
+            try {
+                Field field = type.getDeclaredField("reload");
+                field.setAccessible(true);
+                return field;
+            } catch (NoSuchFieldException ignored) {
+                type = type.getSuperclass();
+            }
+        }
+        return null;
+    }
+
+    private static Field resolveFadeOutStartField() {
+        if (!loadingOverlayFadeOutStartFieldResolved) {
+            loadingOverlayFadeOutStartFieldResolved = true;
+            try {
+                Field field = LoadingOverlay.class.getDeclaredField("fadeOutStart");
+                field.setAccessible(true);
+                loadingOverlayFadeOutStartField = field;
+            } catch (NoSuchFieldException ignored) {
+                loadingOverlayFadeOutStartField = null;
+            }
+        }
+        return loadingOverlayFadeOutStartField;
+    }
+
+    private static Field resolveOnFinishField() {
+        if (!loadingOverlayOnFinishFieldResolved) {
+            loadingOverlayOnFinishFieldResolved = true;
+            try {
+                Field field = LoadingOverlay.class.getDeclaredField("onFinish");
+                field.setAccessible(true);
+                loadingOverlayOnFinishField = field;
+            } catch (NoSuchFieldException ignored) {
+                loadingOverlayOnFinishField = null;
+            }
+        }
+        return loadingOverlayOnFinishField;
     }
 }

--- a/screenplay-common/src/main/resources/tests/joinVanillaServer.yaml
+++ b/screenplay-common/src/main/resources/tests/joinVanillaServer.yaml
@@ -1,6 +1,8 @@
 ---
 name: Join Vanilla Server
 type: test
+# Vanilla dedicated servers reject Forge/NeoForge clients that require those loaders.
+loaders: [fabric]
 ---
 steps:
   - launchGame
@@ -14,7 +16,7 @@ steps:
   - assertAndClick:
     - type: editbox
       name: "Server Address"
-  - keyboardInput: "localhost:25565"
+  - keyboardInput: "127.0.0.1:25565"
   - assertAndClick:
     - type: button
       name: "Join Server"

--- a/screenplay-common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
+++ b/screenplay-common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
@@ -679,8 +679,8 @@ class ScenarioCompilerTest {
         assertEquals("assertVisible", plan.steps().get(6).name());
         assertEquals("click", plan.steps().get(7).name());
         assertEquals("keyboardInput", plan.steps().get(8).name());
-        assertEquals("localhost:25565", plan.steps().get(8).arguments().get("text"));
-        assertEquals("keyboardInput \"localhost:25565\"", plan.steps().get(8).displayName());
+        assertEquals("127.0.0.1:25565", plan.steps().get(8).arguments().get("text"));
+        assertEquals("keyboardInput \"127.0.0.1:25565\"", plan.steps().get(8).displayName());
         assertEquals("waitUntil", plan.steps().get(12).name());
         @SuppressWarnings("unchecked")
         Map<String, Object> notVisible = (Map<String, Object>) plan.steps().get(12).arguments().get("notVisible");
@@ -1262,6 +1262,70 @@ class ScenarioCompilerTest {
         assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(17).displayName());
         assertEquals(40, plan.steps().get(18).arguments().get("ticks"));
         assertEquals("tardis-interior.png", plan.steps().get(19).arguments().get("name"));
+    }
+
+    @Test
+    void loadsFromClasspathWhenDirectoryEnumerationIsEmpty() throws Exception {
+        Path scenarioRoot = Path.of(getClass().getResource("/tests").toURI());
+        ClassLoader directoryBlind = new ClassLoader(null) {
+            @Override
+            public java.util.Enumeration<java.net.URL> getResources(String name) throws java.io.IOException {
+                if ("tests".equals(name)) {
+                    return java.util.Collections.emptyEnumeration();
+                }
+                if (name != null && name.startsWith("tests/")) {
+                    Path file = scenarioRoot.resolve(name.substring("tests/".length()));
+                    if (Files.isRegularFile(file)) {
+                        return java.util.Collections.enumeration(java.util.List.of(file.toUri().toURL()));
+                    }
+                }
+                return java.util.Collections.emptyEnumeration();
+            }
+
+            @Override
+            public java.net.URL getResource(String name) {
+                try {
+                    java.util.Enumeration<java.net.URL> found = getResources(name);
+                    return found.hasMoreElements() ? found.nextElement() : null;
+                } catch (java.io.IOException exception) {
+                    return null;
+                }
+            }
+        };
+
+        ScenarioCatalog catalog = ScenarioCatalog.loadFromResources(directoryBlind);
+
+        assertTrue(catalog.tests().containsKey("createWorld"));
+        assertEquals(4, new ScenarioCompiler(catalog).compile("createWorld").steps().size());
+    }
+
+    @Test
+    void loadsMergedFilesystemRoots(@TempDir Path root) throws Exception {
+        Path harness = root.resolve("harness");
+        Path mod = root.resolve("mod");
+        write(harness.resolve("createWorld.yaml"), """
+                ---
+                name: Create World
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - createWorld
+                """);
+        write(mod.resolve("placeAndOpenTardis.yaml"), """
+                ---
+                name: Place and open TARDIS
+                type: test
+                ---
+                steps:
+                  - launchGame
+                  - openInventory
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(java.util.List.of(harness, mod));
+
+        assertTrue(catalog.tests().containsKey("createWorld"));
+        assertTrue(catalog.tests().containsKey("placeAndOpenTardis"));
     }
 
     private static Path resolveScreenplayTests() {

--- a/screenplay-common/src/test/java/com/adamkali/screenplay/ScreenshotCaptureTest.java
+++ b/screenplay-common/src/test/java/com/adamkali/screenplay/ScreenshotCaptureTest.java
@@ -3,6 +3,7 @@ package com.adamkali.screenplay;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,5 +41,14 @@ class ScreenshotCaptureTest {
 
         assertTrue(slash.getMessage().contains("without path separators"));
         assertTrue(parent.getMessage().contains("without path separators"));
+    }
+
+    @Test
+    void flagsTinyPngsAsSuspectBlankFrames() {
+        assertTrue(ScreenshotCapture.isSuspectBlankSize(16_945L));
+        assertTrue(ScreenshotCapture.isSuspectBlankSize(1L));
+        assertFalse(ScreenshotCapture.isSuspectBlankSize(0L));
+        assertFalse(ScreenshotCapture.isSuspectBlankSize(160_000L));
+        assertFalse(ScreenshotCapture.isSuspectBlankSize(ScreenshotCapture.SUSPECT_BLANK_MAX_BYTES + 1));
     }
 }

--- a/screenplay-docs/docs/reference/commands/captureScreenshot.md
+++ b/screenplay-docs/docs/reference/commands/captureScreenshot.md
@@ -30,7 +30,10 @@ With no arguments, Minecraft chooses a vanilla timestamped filename.
 ## Notes
 
 - The step waits until the file has been written before succeeding.
-- Failure surfaces as a scenario error if screenshot capture reports failure.
+- Tiny PNGs (under ~40KB at the default 854×480 window) are treated as blank/black frames.
+  Screenplay retries capture for a short settle window, then fails the step if the frame stays empty.
+- `runScreenplayTests` clears `build/screenplay/run/screenshots/` before each scenario and
+  fails the suite when archived PNGs still look blank, so CI does not upload leftover or black demos.
 
 ## Related commands
 

--- a/screenplay-gradle-plugin/build.gradle
+++ b/screenplay-gradle-plugin/build.gradle
@@ -20,6 +20,13 @@ dependencies {
     implementation localGroovy()
     // Compile against Loom API when available; plugin detects at runtime.
     compileOnly 'net.fabricmc:fabric-loom:1.17-SNAPSHOT'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.11.4'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test', Test) {
+    useJUnitPlatform()
 }
 
 java {

--- a/screenplay-gradle-plugin/src/main/groovy/com/adamkali/screenplay/gradle/ScreenplayPlugin.groovy
+++ b/screenplay-gradle-plugin/src/main/groovy/com/adamkali/screenplay/gradle/ScreenplayPlugin.groovy
@@ -53,38 +53,58 @@ class ScreenplayPlugin implements Plugin<Project> {
         project.tasks.register('prepareScreenplayRun') {
             group = 'verification'
             description = 'Prepare Screenplay run directory, options.txt, and vanilla server jar path'
-            def optionsFile = project.layout.buildDirectory.file("${extension.outputDir}/run/options.txt")
+            // Game working directory (may differ from outputDir on Forge/NeoForge).
+            def runDirProvider = project.provider {
+                project.file(extension.runDir)
+            }
+            def optionsFile = project.provider {
+                new File(runDirProvider.get(), 'options.txt')
+            }
             def vanillaServerDir = project.layout.buildDirectory.dir("${extension.outputDir}/vanilla-server")
             def jarPathFile = project.layout.buildDirectory.file("${extension.outputDir}/vanilla-server/server-jar.path")
             outputs.file(optionsFile)
             outputs.file(jarPathFile)
             outputs.upToDateWhen { false }
             doLast {
-                project.delete(project.layout.buildDirectory.dir("${extension.outputDir}/run/saves"))
+                def runDir = runDirProvider.get()
+                runDir.mkdirs()
+                project.delete(new File(runDir, 'saves'))
                 project.delete(project.layout.buildDirectory.dir("${extension.outputDir}/vanilla-server/world"))
-                optionsFile.get().asFile.parentFile.mkdirs()
                 def mode = displayMode.get()
                 def options = new StringBuilder("""\
 lang:en_us
 skipMultiplayerWarning:true
 onboardAccessibility:false
+pauseOnLostFocus:false
 """)
                 if (mode == 'xvfb') {
                     options.append("""\
 fullscreen:false
 renderDistance:4
-simulationDistance:4
+simulationDistance:8
 maxFps:30
 enableVsync:false
 guiScale:1
 """)
                 }
-                optionsFile.get().asFile.text = options.toString()
+                optionsFile.get().text = options.toString()
+                // Forge early window (fmlearlywindow) can stall resource reload under xvfb/llvmpipe,
+                // leaving GenericMessageScreen + ForgeLoadingOverlay forever. Disable it for headless runs.
+                if (mode == 'xvfb' && extension.loader in ['forge', 'neoforge']) {
+                    def configDir = new File(runDir, 'config')
+                    configDir.mkdirs()
+                    new File(configDir, 'fml.toml').text = '''\
+earlyWindowControl = false
+earlyWindowProvider = "fmlearlywindow"
+versionCheck = false
+'''
+                }
                 def serverDir = vanillaServerDir.get().asFile
                 serverDir.mkdirs()
-                def serverJar = resolveMinecraftServerJar(project)
+                def serverJar = resolveMinecraftServerJar(project, serverDir)
                 if (serverJar != null) {
                     jarPathFile.get().asFile.text = serverJar.absolutePath
+                    logger.lifecycle("Screenplay vanilla server jar: ${serverJar.absolutePath}")
                 } else {
                     jarPathFile.get().asFile.text = ''
                     logger.warn('Could not resolve Minecraft server jar path for Screenplay vanilla-server harness')
@@ -93,14 +113,83 @@ guiScale:1
         }
     }
 
-    private static File resolveMinecraftServerJar(Project project) {
+    private static File resolveMinecraftServerJar(Project project, File downloadDir) {
         try {
             def loomClass = Class.forName('net.fabricmc.loom.LoomGradleExtension')
             def getMethod = loomClass.getMethod('get', Project)
             def loomExt = getMethod.invoke(null, project)
             def minecraftProvider = loomExt.minecraftProvider
-            return minecraftProvider.minecraftServerJar as File
+            def loomJar = minecraftProvider.minecraftServerJar as File
+            if (loomJar != null && loomJar.isFile()) {
+                return loomJar
+            }
         } catch (Throwable ignored) {
+            // Fall through to non-Loom resolution.
+        }
+        def override = project.findProperty('screenplayServerJar')
+        if (override != null) {
+            def file = project.file(override.toString())
+            if (file.isFile()) {
+                return file
+            }
+        }
+        def userHome = System.getProperty('user.home', '')
+        def version = project.findProperty('minecraft_version')?.toString()
+        if (userHome && version) {
+            def candidates = [
+                    new File("${userHome}/.gradle/caches/fabric-loom/minecraftMaven/net/minecraft/server/${version}/server-${version}.jar"),
+                    new File("${userHome}/.gradle/caches/fabric-loom/${version}/minecraft-server.jar"),
+                    new File("${userHome}/.gradle/caches/fabric-loom/${version}/minecraft-extracted_server.jar"),
+                    new File("${userHome}/.gradle/caches/minecraftforge/forgegradle/mavenizer/caches/minecraft_tasks/${version}/server.jar"),
+                    new File("${userHome}/.gradle/caches/minecraft/${version}/server.jar"),
+                    project.file(".gradle/caches/minecraft/versions/${version}/server.jar"),
+                    project.rootProject.file(".gradle/caches/minecraft/versions/${version}/server.jar"),
+                    // Included-build NeoForge/Forge project caches when run from a sibling.
+                    new File(project.projectDir, ".gradle/caches/minecraft/versions/${version}/server.jar"),
+            ]
+            def found = candidates.find { it != null && it.isFile() }
+            if (found != null) {
+                return found
+            }
+        }
+        if (version) {
+            def downloaded = downloadOfficialServerJar(project, version, downloadDir)
+            if (downloaded != null) {
+                return downloaded
+            }
+        }
+        return null
+    }
+
+    private static File downloadOfficialServerJar(Project project, String version, File downloadDir) {
+        try {
+            def slurper = new groovy.json.JsonSlurper()
+            def manifest = slurper.parse(new URI('https://piston-meta.mojang.com/mc/game/version_manifest_v2.json').toURL())
+            def entry = manifest.versions.find { it.id == version }
+            if (entry == null || entry.url == null) {
+                project.logger.warn("Screenplay: Minecraft version '${version}' not found in Mojang version manifest")
+                return null
+            }
+            def versionJson = slurper.parse(new URI(entry.url.toString()).toURL())
+            def server = versionJson.downloads?.server
+            if (server?.url == null) {
+                project.logger.warn("Screenplay: no official server download for Minecraft '${version}'")
+                return null
+            }
+            downloadDir.mkdirs()
+            def dest = new File(downloadDir, 'server.jar')
+            if (dest.isFile() && dest.length() > 0) {
+                return dest
+            }
+            project.logger.lifecycle("Screenplay: downloading official Minecraft ${version} server jar")
+            dest.withOutputStream { out ->
+                new URI(server.url.toString()).toURL().withInputStream { input ->
+                    out << input
+                }
+            }
+            return dest.isFile() && dest.length() > 0 ? dest : null
+        } catch (Throwable exception) {
+            project.logger.warn("Screenplay: could not download official server jar for ${version}: ${exception.message}")
             return null
         }
     }
@@ -111,6 +200,10 @@ guiScale:1
         def reportFile = project.layout.buildDirectory.file("${extension.outputDir}/report.xml").get().asFile.absolutePath
         def vanillaServerDir = project.layout.buildDirectory.dir("${extension.outputDir}/vanilla-server").get().asFile.absolutePath
         def runDir = extension.runDir
+        def testsDirsProperty = extension.allTestsDirs()
+                .findAll { it != null }
+                .collect { project.file(it).absolutePath }
+                .join(File.pathSeparator)
 
         if (loader == 'fabric') {
             def loom = project.extensions.findByName('loom')
@@ -131,6 +224,9 @@ guiScale:1
             run.property 'screenplay.step-timeout-seconds', timeout.get()
             run.property 'screenplay.report-file', reportFile
             run.property 'screenplay.vanilla-server-dir', vanillaServerDir
+            if (!testsDirsProperty.isBlank()) {
+                run.property 'screenplay.tests-dirs', testsDirsProperty
+            }
             run.runDir runDir
 
             // Stable task name for docs/CI regardless of Loom run config name.
@@ -152,37 +248,83 @@ guiScale:1
                 runsContainer = project.extensions.runs
             }
             if (runsContainer == null) {
-                project.logger.warn("Screenplay: no runs container found for loader '${loader}'")
-                return
+                throw new GradleException("Screenplay: no runs container found for loader '${loader}'")
             }
-            def run = runsContainer.findByName('screenplayClient') ?: runsContainer.findByName('screenplay')
-            if (run == null && runsContainer.metaClass.respondsTo(runsContainer, 'create', String)) {
-                run = runsContainer.create('screenplayClient')
-            } else if (run == null && runsContainer.metaClass.respondsTo(runsContainer, 'register', String)) {
-                run = runsContainer.register('screenplayClient').get()
-            }
+            // Forge launcher runs.json only defines client/server/data/… — custom names
+            // like screenplayClient have no mainClass. NeoGradle also rejects unknown run types.
+            // Both loaders reuse the stock 'client' run for Screenplay.
+            def run = runsContainer.findByName('client')
             if (run == null) {
-                project.logger.warn("Screenplay: could not create '${loader}' run named screenplayClient")
-                return
+                throw new GradleException("Screenplay: could not find a client run for '${loader}'")
             }
-            if (run.hasProperty('workingDirectory')) {
-                run.workingDirectory = project.layout.projectDirectory.dir(runDir)
+            // ForgeGradle: workingDir; NeoGradle: workingDirectory
+            try {
+                if (run.hasProperty('workingDir')) {
+                    run.workingDir.set(project.layout.projectDirectory.dir(runDir))
+                }
+            } catch (Throwable ignored) {
             }
-            if (run.metaClass.respondsTo(run, 'systemProperty', String, Object)) {
+            try {
+                if (run.hasProperty('workingDirectory')) {
+                    run.workingDirectory.set(project.layout.projectDirectory.dir(runDir))
+                }
+            } catch (Throwable ignored) {
+                try {
+                    run.workingDirectory = project.file(runDir)
+                } catch (Throwable ignored2) {
+                }
+            }
+            try {
                 run.systemProperty 'screenplay', scenarioId.get()
                 run.systemProperty 'screenplay.step-timeout-seconds', timeout.get()
                 run.systemProperty 'screenplay.report-file', reportFile
                 run.systemProperty 'screenplay.vanilla-server-dir', vanillaServerDir
+                if (!testsDirsProperty.isBlank()) {
+                    run.systemProperty 'screenplay.tests-dirs', testsDirsProperty
+                }
+            } catch (Throwable ex) {
+                project.logger.warn("Screenplay: could not set system properties on ${loader} run: ${ex.message}")
             }
+
+            // NeoGradle treats any task named run* as a run-type request. Avoid that prefix.
+            def screenplayTaskName = loader == 'neoforge' ? 'executeScreenplay' : 'runScreenplay'
+            def delegateTask = project.tasks.names.contains('runClient') ? 'runClient' : null
+
+            if (project.tasks.findByName(screenplayTaskName) == null) {
+                project.tasks.register(screenplayTaskName) {
+                    group = 'verification'
+                    description = 'Run a Screenplay YAML scenario in the real Minecraft client'
+                    if (delegateTask != null) {
+                        dependsOn delegateTask
+                    } else {
+                        dependsOn 'runClient'
+                    }
+                }
+            }
+            project.extensions.extraProperties.set('screenplayRunTask', screenplayTaskName)
+            project.extensions.extraProperties.set('screenplayDelegateTask', delegateTask ?: 'runClient')
         } catch (Throwable ex) {
-            project.logger.warn("Screenplay could not fully configure ${loader} run: ${ex.message}")
+            throw new GradleException("Screenplay could not configure ${loader} run: ${ex.message}", ex)
         }
     }
 
     private static void configureDisplayOnRunTask(Project project, ScreenplayExtension extension) {
         def displayMode = project.providers.gradleProperty('screenplayDisplay').orElse('display')
+        def screenplayRunTask = project.providers.provider {
+            project.extensions.extraProperties.has('screenplayRunTask')
+                    ? project.extensions.extraProperties.get('screenplayRunTask').toString()
+                    : 'runScreenplay'
+        }
+        def screenplayDelegateTask = project.providers.provider {
+            project.extensions.extraProperties.has('screenplayDelegateTask')
+                    ? project.extensions.extraProperties.get('screenplayDelegateTask').toString()
+                    : 'runScreenplayClient'
+        }
         project.tasks.configureEach { task ->
-            if (!(task.name in ['runScreenplay', 'runScreenplayClient'])) {
+            def runTaskName = screenplayRunTask.get()
+            def delegateName = screenplayDelegateTask.get()
+            def screenplayTasks = [runTaskName, 'runScreenplay', 'runScreenplayClient', 'executeScreenplay', delegateName] as Set
+            if (!(task.name in screenplayTasks)) {
                 return
             }
             task.dependsOn('prepareScreenplayRun')
@@ -191,7 +333,8 @@ guiScale:1
             if (!(mode in ['display', 'xvfb'])) {
                 throw new GradleException("Invalid -PscreenplayDisplay='${mode}'. Allowed values: display, xvfb.")
             }
-            // Loom run tasks are JavaExec; the runScreenplay alias may be a plain DefaultTask.
+            // Loom run tasks are JavaExec with useXvfb; Forge/NeoForge runClient is plain JavaExec.
+            // For loaders without useXvfb, CI/agents should invoke Gradle under xvfb-run so $DISPLAY is set.
             if (task instanceof org.gradle.process.JavaExecSpec) {
                 if (task.hasProperty('useXvfb')) {
                     task.useXvfb = (mode == 'xvfb')
@@ -221,6 +364,21 @@ guiScale:1
                         throw new GradleException(
                                 'screenplayDisplay=xvfb requires xvfb-run on PATH. Install with: apt install xvfb')
                     }
+                    // Only the actual client JavaExec needs $DISPLAY on Forge/NeoForge.
+                    // Fabric's runScreenplay wrapper is a plain task (no useXvfb) that runs
+                    // after runScreenplayClient; do not fail it for missing DISPLAY.
+                    boolean isNonLoomClientExec = (task instanceof org.gradle.process.JavaExecSpec) &&
+                            !task.hasProperty('useXvfb')
+                    if (isNonLoomClientExec) {
+                        def display = System.getenv('DISPLAY')
+                        if (display == null || display.isBlank()) {
+                            throw new GradleException(
+                                    'screenplayDisplay=xvfb on Forge/NeoForge requires $DISPLAY. '
+                                            + 'Invoke Gradle under xvfb-run, e.g. '
+                                            + '`xvfb-run -a ./gradlew -p dwm-loaders :forge:runScreenplayTests '
+                                            + '-PscreenplayDisplay=xvfb`.')
+                        }
+                    }
                 }
             }
         }
@@ -233,45 +391,73 @@ guiScale:1
         def resultsRoot = project.layout.buildDirectory.dir("${extension.outputDir}/results")
         def testsDirs = extension.allTestsDirs()
 
-        def execOps = project.objects.newInstance(ScreenplayExecOps).execOps
-
         project.tasks.register('runScreenplayTests') {
             group = 'verification'
             description = 'Discover all type:test YAML scenarios and run each via runScreenplay'
+            // NeoGradle rejects unknown run* task names during registration of sibling tasks;
+            // runScreenplayTests is fine as a plain task (not mapped to a run config).
 
             doLast {
                 def missing = testsDirs.findAll { !it.isDirectory() }
                 if (missing) {
                     throw new GradleException("Screenplay tests directory not found: ${missing}")
                 }
-                def scenarioIds = discoverScenarioTestIds(testsDirs)
+                def scenarioIds = discoverScenarioTestIds(testsDirs, extension.loader)
                 if (scenarioIds.isEmpty()) {
                     throw new GradleException("No scenario tests (type: test) found under ${testsDirs}")
                 }
-                logger.lifecycle("Discovered ${scenarioIds.size()} Screenplay test(s): ${scenarioIds.join(', ')}")
+                logger.lifecycle("Discovered ${scenarioIds.size()} Screenplay test(s) for loader '${extension.loader}': ${scenarioIds.join(', ')}")
 
-                def gradleWrapper = new File(projectDirFile, 'gradlew')
-                def gradleCommand = gradleWrapper.exists() ? gradleWrapper.absolutePath : 'gradle'
+                def gradleWrapper = findGradleWrapper(projectDirFile)
+                def gradleCommand = gradleWrapper != null ? gradleWrapper.absolutePath : 'gradle'
+                def gradleWorkingDir = gradleWrapper != null ? gradleWrapper.parentFile : projectDirFile
                 def failed = []
                 def resultsDir = resultsRoot.get().asFile
                 project.delete(resultsDir)
                 resultsDir.mkdirs()
 
+                // Warm NeoGradle Minecraft artifact caches before scenarios (with retries) so the
+                // first nested executeScreenplay is less likely to flake on first client.jar download.
+                def cacheTaskNames = project.tasks.names
+                        .findAll { String name -> name.startsWith('cacheVersionExecutable') }
+                        .collect { it.toString() }
+                        .sort()
+                if (!cacheTaskNames.isEmpty()) {
+                    logger.lifecycle("Warming Minecraft artifact caches: ${cacheTaskNames.join(', ')}")
+                    def warmDir = new File(resultsDir, '_cache-warm')
+                    warmDir.mkdirs()
+                    def warmArgs = ScreenplayPlugin.buildNestedLoaderGradleArgs(
+                            gradleCommand, gradleWorkingDir, project, cacheTaskNames)
+                    def warmExit = ScreenplayPlugin.runNestedGradleWithTransientRetries(
+                            warmArgs, gradleWorkingDir, warmDir, 'minecraft-cache-warm', logger)
+                    if (warmExit != 0) {
+                        throw new GradleException(
+                                "Failed to warm Minecraft artifact caches "
+                                        + "(${cacheTaskNames.join(', ')}); exit ${warmExit}")
+                    }
+                }
+
                 scenarioIds.each { String scenarioId ->
                     logger.lifecycle("Running Screenplay test '${scenarioId}'")
-                    def args = [gradleCommand, 'runScreenplay', "-Pscreenplay=${scenarioId}"]
-                    args << "-PscreenplayDisplay=${displayMode.get()}"
+                    def runTask = project.extensions.extraProperties.has('screenplayRunTask')
+                            ? project.extensions.extraProperties.get('screenplayRunTask').toString()
+                            : 'runScreenplay'
+                    def args = ScreenplayPlugin.buildNestedLoaderGradleArgs(
+                            gradleCommand, gradleWorkingDir, project, [runTask.toString()])
+                    args << "-Pscreenplay=${scenarioId}".toString()
+                    args << "-PscreenplayDisplay=${displayMode.get()}".toString()
                     if (timeoutProperty.isPresent()) {
-                        args << "-PscreenplayTimeout=${timeoutProperty.get()}"
+                        args << "-PscreenplayTimeout=${timeoutProperty.get()}".toString()
                     }
-                    def result = execOps.exec {
-                        workingDir projectDirFile
-                        commandLine args
-                        ignoreExitValue = true
-                    }
+
+                    // Avoid archiving leftover screenshots from earlier scenarios in this suite.
+                    project.delete(new File(projectDirFile, "build/${extension.outputDir}/run/screenshots"))
 
                     def archiveDir = new File(resultsDir, scenarioId)
                     archiveDir.mkdirs()
+                    def exitValue = ScreenplayPlugin.runNestedGradleWithTransientRetries(
+                            args, gradleWorkingDir, archiveDir, scenarioId, logger)
+
                     ['report.xml', 'metrics.json', 'diagnostics.txt'].each { String fileName ->
                         def source = new File(projectDirFile, "build/${extension.outputDir}/${fileName}")
                         if (source.isFile()) {
@@ -288,10 +474,25 @@ guiScale:1
                             into new File(archiveDir, 'screenshots')
                         }
                     }
-
-                    if (result.exitValue != 0) {
+                    def blankShots = []
+                    def shotsArchive = new File(archiveDir, 'screenshots')
+                    if (shotsArchive.isDirectory()) {
+                        shotsArchive.eachFile { File file ->
+                            if (file.isFile() && file.name.toLowerCase().endsWith('.png')
+                                    && file.length() > 0L && file.length() < 40000L) {
+                                blankShots << "${file.name} (${file.length()} bytes)"
+                            }
+                        }
+                    }
+                    if (!blankShots.isEmpty()) {
+                        logger.error(
+                                "Screenplay screenshots look blank/black for '${scenarioId}': "
+                                        + blankShots.join(', '))
                         failed << scenarioId
-                        logger.error("Screenplay test '${scenarioId}' failed (exit ${result.exitValue})")
+                        logger.error("Screenplay test '${scenarioId}' failed (blank screenshots)")
+                    } else if (exitValue != 0) {
+                        failed << scenarioId
+                        logger.error("Screenplay test '${scenarioId}' failed (exit ${exitValue})")
                     } else {
                         logger.lifecycle("Screenplay test '${scenarioId}' passed")
                     }
@@ -307,11 +508,154 @@ guiScale:1
         }
     }
 
-    private static List discoverScenarioTestIds(List<File> scenarioTestsRoots) {
+    /**
+     * Builds a nested Gradle command for this loader project.
+     * Included-build consumers (dwm-loaders) are invoked via {@code -p} from the repo root wrapper.
+     */
+    static List<String> buildNestedLoaderGradleArgs(
+            String gradleCommand,
+            File gradleWorkingDir,
+            Project project,
+            List taskNames) {
+        List<String> args = new ArrayList<>()
+        args.add(gradleCommand.toString())
+        def loadersDir = new File(gradleWorkingDir, 'dwm-loaders')
+        if (loadersDir.isDirectory() && project.projectDir.absolutePath.startsWith(loadersDir.absolutePath)) {
+            args.add('-p')
+            args.add('dwm-loaders')
+            taskNames.each { taskName ->
+                args.add("${project.name}:${taskName}".toString())
+            }
+        } else if (project.path != ':') {
+            taskNames.each { taskName ->
+                args.add("${project.path}:${taskName}".toString())
+            }
+        } else {
+            taskNames.each { taskName ->
+                args.add(taskName.toString())
+            }
+        }
+        return args
+    }
+
+    /**
+     * Runs a nested Gradle invocation, retrying when NeoGradle Minecraft artifact cache
+     * downloads flake (e.g. cacheVersionExecutableClient*). Real scenario failures are not retried.
+     */
+    static int runNestedGradleWithTransientRetries(
+            List args,
+            File gradleWorkingDir,
+            File archiveDir,
+            String label,
+            org.gradle.api.logging.Logger logger) {
+        final int maxAttempts = 3
+        int exitValue = 1
+        for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+            def logFile = new File(archiveDir, "nested-gradle-attempt-${attempt}.log")
+            if (attempt > 1) {
+                logger.lifecycle(
+                        "Retrying '${label}' (attempt ${attempt}/${maxAttempts}) "
+                                + 'after transient Gradle cache/download failure')
+                try {
+                    Thread.sleep(2000L * (attempt - 1))
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt()
+                }
+            }
+            exitValue = runNestedGradleStreaming(args, gradleWorkingDir, logFile)
+            if (exitValue == 0) {
+                return 0
+            }
+            def logText = logFile.isFile() ? logFile.getText('UTF-8') : ''
+            if (attempt < maxAttempts && isTransientNestedGradleFailure(logText)) {
+                logger.warn(
+                        "'${label}' hit a transient Minecraft cache/download failure "
+                                + "(attempt ${attempt}/${maxAttempts}); will retry")
+                continue
+            }
+            break
+        }
+        return exitValue
+    }
+
+    private static int runNestedGradleStreaming(List args, File workingDir, File logFile) {
+        logFile.parentFile.mkdirs()
+        // ProcessBuilder requires real Strings (not GString); collect explicitly.
+        List<String> command = new ArrayList<>(args.size())
+        args.each { arg -> command.add(arg.toString()) }
+        def pb = new ProcessBuilder(command)
+        pb.directory(workingDir)
+        pb.redirectErrorStream(true)
+        def process = pb.start()
+        logFile.withOutputStream { fos ->
+            def buffer = new byte[8192]
+            def input = process.inputStream
+            int read
+            while ((read = input.read(buffer)) >= 0) {
+                if (read == 0) {
+                    continue
+                }
+                fos.write(buffer, 0, read)
+                System.out.write(buffer, 0, read)
+            }
+            System.out.flush()
+        }
+        return process.waitFor()
+    }
+
+    /** Visible for tests — NeoGradle/network flakes that should not fail the Screenplay suite. */
+    static boolean isTransientNestedGradleFailure(String logText) {
+        if (logText == null || logText.isBlank()) {
+            return false
+        }
+        // In-game client crashes / scenario failures must never be retried as cache flakes.
+        if (logText.contains('ReportedException')
+                || logText.contains('occlusionShapesByFace')
+                || (logText.contains("Screenplay test '") && logText.contains('failed'))) {
+            return false
+        }
+        // Prefer task-level signals so in-game scenario failures are not retried.
+        if (logText.contains('cacheVersionExecutableClient') && logText.contains('FAILED')) {
+            return true
+        }
+        if (logText.contains('cacheVersionExecutableServer') && logText.contains('FAILED')) {
+            return true
+        }
+        // NeoGradle cache provider only when the stage itself failed — the class name
+        // appears in healthy task graphs and must not retry runClient crashes.
+        if (logText.contains('Failed to execute stage')
+                && logText.contains('MinecraftArtifactFileCacheProvider')) {
+            return true
+        }
+        def networkHints = [
+                'Connection reset',
+                'Read timed out',
+                'SocketTimeoutException',
+                'UnknownHostException',
+                'Could not GET ',
+                'javax.net.ssl.SSLException',
+                'Premature end of Content-Length',
+        ]
+        return networkHints.any { hint -> logText.contains(hint) }
+    }
+
+    private static File findGradleWrapper(File startDir) {
+        File dir = startDir
+        while (dir != null) {
+            def wrapper = new File(dir, 'gradlew')
+            if (wrapper.isFile()) {
+                return wrapper
+            }
+            dir = dir.parentFile
+        }
+        return null
+    }
+
+    private static List discoverScenarioTestIds(List<File> scenarioTestsRoots, String loader) {
         def ids = [] as TreeSet
         scenarioTestsRoots.each { File scenarioTestsRoot ->
             projectFileTree(scenarioTestsRoot).each { File yamlFile ->
-                if (!isScenarioTestYaml(yamlFile)) {
+                if (!isScenarioTestYaml(yamlFile, loader)) {
                     return
                 }
                 def name = yamlFile.name
@@ -335,7 +679,7 @@ guiScale:1
         return files
     }
 
-    private static boolean isScenarioTestYaml(File yamlFile) {
+    private static boolean isScenarioTestYaml(File yamlFile, String loader) {
         def text = yamlFile.getText('UTF-8').replace('\r\n', '\n')
         if (!text.startsWith('---\n')) {
             return false
@@ -344,14 +688,21 @@ guiScale:1
         if (closing < 0) {
             return false
         }
-        return text.substring(4, closing).readLines().any { line ->
-            line.trim() == 'type: test'
+        def frontmatter = text.substring(4, closing).readLines()
+        if (!frontmatter.any { line -> line.trim() == 'type: test' }) {
+            return false
         }
+        // Optional frontmatter: loaders: [fabric, forge] — omit to run on all loaders.
+        def loadersLine = frontmatter.find { line -> line.trim().startsWith('loaders:') }
+        if (loadersLine == null || loader == null || loader.isBlank()) {
+            return true
+        }
+        def allowed = loadersLine.substring(loadersLine.indexOf(':') + 1)
+                .replaceAll(/[\[\]]/, '')
+                .split(',')
+                .collect { it.trim().toLowerCase() }
+                .findAll { !it.isEmpty() }
+        return allowed.isEmpty() || allowed.contains(loader.trim().toLowerCase())
     }
-}
-
-interface ScreenplayExecOps {
-    @javax.inject.Inject
-    org.gradle.process.ExecOperations getExecOps()
 }
 

--- a/screenplay-gradle-plugin/src/test/groovy/com/adamkali/screenplay/gradle/TransientNestedGradleFailureTest.groovy
+++ b/screenplay-gradle-plugin/src/test/groovy/com/adamkali/screenplay/gradle/TransientNestedGradleFailureTest.groovy
@@ -1,0 +1,63 @@
+package com.adamkali.screenplay.gradle
+
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class TransientNestedGradleFailureTest {
+    @Test
+    void detectsNeoForgeClientCacheFailure() {
+        def log = '''
+> Task :neoforge:cacheVersionExecutableClient26.2 FAILED
+Execution failed for task ':neoforge:cacheVersionExecutableClient26.2'
+> Failed to execute stage: Default[outputs=[...], execute=net.neoforged.gradle.common.tasks.MinecraftArtifactFileCacheProvider$$Lambda]
+BUILD FAILED in 50s
+'''
+        assertTrue(ScreenplayPlugin.isTransientNestedGradleFailure(log))
+    }
+
+    @Test
+    void detectsNetworkTimeoutHints() {
+        assertTrue(ScreenplayPlugin.isTransientNestedGradleFailure('Read timed out while downloading client.jar'))
+        assertTrue(ScreenplayPlugin.isTransientNestedGradleFailure('Could not GET https://piston-data.mojang.com/...'))
+    }
+
+    @Test
+    void doesNotRetryInGameScenarioFailures() {
+        def log = '''
+[Screenplay]: Scenario 'createWorld' failed: timed out waiting for world
+BUILD SUCCESSFUL in 2m
+'''
+        assertFalse(ScreenplayPlugin.isTransientNestedGradleFailure(log))
+        assertFalse(ScreenplayPlugin.isTransientNestedGradleFailure(''))
+        assertFalse(ScreenplayPlugin.isTransientNestedGradleFailure(null))
+    }
+
+    @Test
+    void doesNotRetryWhenCacheProviderOnlyAppearsInHealthyTaskGraph() {
+        def log = '''
+> Task :neoforge:cacheVersionExecutableClient26.2 UP-TO-DATE
+net.neoforged.gradle.common.tasks.MinecraftArtifactFileCacheProvider
+Caused by: java.lang.NullPointerException: occlusionShapesByFace is null
+> Task :neoforge:runClient FAILED
+'''
+        assertFalse(ScreenplayPlugin.isTransientNestedGradleFailure(log))
+    }
+
+    @Test
+    void nestedGradleArgsAreRealStringsForProcessBuilder() {
+        // ProcessBuilder requires real Strings; GString elements caused CI arraycopy failures.
+        def gstringTask = "run${'Screenplay'}"
+        List args = new ArrayList()
+        args.add('/workspace/gradlew')
+        args.add(gstringTask)
+        args.add("-Pscreenplay=${'createWorld'}")
+        List<String> command = new ArrayList<>(args.size())
+        args.each { arg -> command.add(arg.toString()) }
+        def pb = new ProcessBuilder(command)
+        assertEquals(3, pb.command().size())
+        assertTrue(pb.command().every { it instanceof String })
+    }
+}

--- a/screenplay-loaders/forge/build.gradle
+++ b/screenplay-loaders/forge/build.gradle
@@ -25,6 +25,11 @@ minecraft {
         configureEach {
             workingDir = layout.projectDirectory.dir('run')
             systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
+            mods {
+                screenplay {
+                    source sourceSets.main
+                }
+            }
         }
         register('client')
     }
@@ -45,6 +50,9 @@ dependencies {
 def screenplayCommon = rootProject.file('../screenplay-common')
 
 sourceSets.main {
+    // FML discovers each classpath entry with mods.toml as its own ModFile.
+    // Keep classes + resources in one directory so @Mod and mods.toml share a root.
+    output.resourcesDir = layout.buildDirectory.dir('classes/java/main').get().asFile
     java {
         srcDir new File(screenplayCommon, 'src/main/java')
     }
@@ -66,6 +74,21 @@ processResources {
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'
     options.release = 25
+}
+
+// ForgeGradle 7.0.35 + Gradle 9.5: SlimeLauncherMetadata conventions map
+// outputDirectory onto runsJson of the same task; Gradle rejects querying that
+// mapped output during the task action. Rebind via locationOnly.
+tasks.configureEach { task ->
+    if (!task.name.startsWith('slimeLauncherMetadata')) {
+        return
+    }
+    def outputDirectory = task.hasProperty('outputDirectory') ? task.outputDirectory : null
+    def runsJson = task.hasProperty('runsJson') ? task.runsJson : null
+    if (outputDirectory == null || runsJson == null) {
+        return
+    }
+    runsJson.set(outputDirectory.locationOnly.map { dir -> dir.file('launcher/runs.json') })
 }
 
 publishing {

--- a/screenplay-loaders/forge/src/main/java/com/adamkali/screenplay/forge/ForgeScreenplayClient.java
+++ b/screenplay-loaders/forge/src/main/java/com/adamkali/screenplay/forge/ForgeScreenplayClient.java
@@ -17,7 +17,13 @@ public final class ForgeScreenplayClient {
     private static final class ForgePlatform implements ScreenplayPlatform {
         @Override
         public void registerEndClientTick(Consumer<Minecraft> tickHandler) {
-            TickEvent.ClientTickEvent.Post.BUS.addListener(event -> tickHandler.accept(Minecraft.getInstance()));
+            // Render ticks fire every frame under xvfb; ClientTickEvent alone can stall during menu load.
+            TickEvent.RenderTickEvent.Post.BUS.addListener(event -> {
+                Minecraft client = Minecraft.getInstance();
+                if (client != null) {
+                    tickHandler.accept(client);
+                }
+            });
         }
     }
 }

--- a/screenplay-loaders/neoforge/build.gradle
+++ b/screenplay-loaders/neoforge/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 def screenplayCommon = rootProject.file('../screenplay-common')
 
 sourceSets.main {
+    // Keep classes + resources in one directory so @Mod and mods.toml share a root
+    // (same as Forge). Helps FML treat the Screenplay harness as a single ModFile.
+    output.resourcesDir = layout.buildDirectory.dir('classes/java/main').get().asFile
     java {
         srcDir new File(screenplayCommon, 'src/main/java')
     }

--- a/screenplay-loaders/neoforge/src/main/java/com/adamkali/screenplay/neoforge/NeoForgeScreenplayClient.java
+++ b/screenplay-loaders/neoforge/src/main/java/com/adamkali/screenplay/neoforge/NeoForgeScreenplayClient.java
@@ -7,7 +7,7 @@ import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.Mod;
-import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.RenderFrameEvent;
 
 import java.util.function.Consumer;
 
@@ -21,9 +21,17 @@ public final class NeoForgeScreenplayClient {
     }
 
     @SubscribeEvent
-    static void onClientTick(ClientTickEvent.Post event) {
+    static void onRenderFrame(RenderFrameEvent.Post event) {
+        // Render frames keep Screenplay advancing under headless/xvfb menu load.
+        dispatch();
+    }
+
+    private static void dispatch() {
         if (tickHandler != null) {
-            tickHandler.accept(Minecraft.getInstance());
+            Minecraft client = Minecraft.getInstance();
+            if (client != null) {
+                tickHandler.accept(client);
+            }
         }
     }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -23,7 +23,12 @@ plugins {
 
 includeBuild('screenplay-gradle-plugin')
 // Isolate Forge/NeoGradle from Fabric Loom runs (NeoGradle treats custom Loom run names as run types).
-includeBuild('screenplay-loaders')
+includeBuild('screenplay-loaders') {
+	dependencySubstitution {
+		substitute module('com.adamkali.screenplay:screenplay-forge') using project(':forge')
+		substitute module('com.adamkali.screenplay:screenplay-neoforge') using project(':neoforge')
+	}
+}
 includeBuild('dwm-loaders')
 
 include 'dwm-common'

--- a/src/screenplayTests/AGENTS.md
+++ b/src/screenplayTests/AGENTS.md
@@ -11,14 +11,12 @@ Full docs (quick start + API reference): https://adam-k-ali.github.io/DWM/
 Also: `screenplay-fabric/README.md`, `metadata/screenplay/modrinth-body.md`, and this directory’s `README.md`.
 
 ## Commands
-- Run a scenario: `./gradlew runScreenplay -Pscreenplay=<yaml-filename-stem>`
-- Run all discovered `type: test` scenarios: `./gradlew runScreenplayTests`
+- Fabric: `./gradlew runScreenplay -Pscreenplay=<yaml-filename-stem>` / `./gradlew runScreenplayTests`
+- Forge: `xvfb-run -a ./gradlew -p dwm-loaders :forge:runScreenplay` / `:forge:runScreenplayTests`
+- NeoForge: `xvfb-run -a ./gradlew -p dwm-loaders :neoforge:executeScreenplay` / `:neoforge:runScreenplayTests`
 - Override step timeout (seconds): `-PscreenplayTimeout=60`
-- Display mode: `-PscreenplayDisplay=display|xvfb` (default `display`)
-- Reports: `build/screenplay/report.xml`, `build/screenplay/metrics.json`, `build/screenplay/diagnostics.txt`
-- Per-scenario archives from `runScreenplayTests`: `build/screenplay/results/<id>/`
-- Screenshots: `build/screenplay/run/screenshots/`
-- Vanilla server harness dir: `build/screenplay/vanilla-server/`
+- Display mode: `-PscreenplayDisplay=display|xvfb` (default `display`). Forge/NeoForge lack Loom `useXvfb` — wrap Gradle with `xvfb-run -a` so `$DISPLAY` is set.
+- Reports: `build/screenplay/` (Fabric) or `dwm-loaders/<loader>/build/screenplay/`
 - Unit tests for the harness: `./gradlew :screenplay-common:test`
 
 ## Conventions
@@ -29,6 +27,6 @@ Also: `screenplay-fabric/README.md`, `metadata/screenplay/modrinth-body.md`, and
 
 ## Common Pitfalls
 - **Display required** — use `-PscreenplayDisplay=xvfb` for headless/CI Linux runs.
-- **CI** — `.github/workflows/scenario-tests.yml` runs `./gradlew runScreenplayTests` with xvfb.
+- **CI** — `.github/workflows/scenario-tests.yml` runs Screenplay on Fabric, Forge, and NeoForge under xvfb (perf compare remains Fabric-primary).
 - Each run deletes saved worlds under `build/screenplay/run/saves` and clears `build/screenplay/vanilla-server/world`.
 - Quote relative coords in YAML: `"~"` not bare `~` (YAML null).


### PR DESCRIPTION
## Why this matters

- Multi-loader Screenplay was shipping solid-black demos, hanging on Forge’s warnings-only `LoadingErrorScreen`, and treating in-game crashes as cache flakes. The CI matrix is only useful once those boots actually finish.

## Proposed Implementation

- Expand the Screenplay CI matrix to Fabric / Forge / NeoForge under xvfb, with includeBuild substitution for the Forge/NeoForge harness.
- Finish `LoadingOverlay` via `tick()`/`onFinish`, dismiss Forge `LoadingErrorScreen` / create-world `ConfirmScreen`, and pump scenarios on the client thread.
- Reject blank/tiny screenshots; do not retry `ReportedException` in-game crashes as Minecraft cache flakes. Limit `joinVanillaServer` to Fabric.

## Problems Encountered / Decisions Made

- Stacked on `feat/dwm-loaders`. This branch’s tree matches `cursor/dwm-multiloader-abc4` / #188; leave #188 open as the backup until the stack merges.
- Force-clearing the loading overlay masked Forge’s warnings screen and skipped chunk init; restoring a proper finish exposed both issues.

Made with [Cursor](https://cursor.com)