### PR TITLE
DWM-055 — Found TARDIS starts unfinished

### DIFF
--- a/dwm/docs/feature-stattenheim-remote.md
+++ b/dwm/docs/feature-stattenheim-remote.md
@@ -25,10 +25,11 @@ Give the TARDIS owner a pocket remote that calls their ship to them, with a visi
 3. Sneak and right-click the ground where you want it.
 4. The doors slam shut, then the TARDIS dematerialises from its current exterior and rematerialises at the click, fading in.
 
-Failure overlays: no owned TARDIS, already travelling, cannot land here.
+Failure overlays: no owned TARDIS, already travelling, cannot land here, circuit broken (found Type 40 with a broken remote-summon circuit — smoke puff at the click).
 
 ## Known Constraints
 - The remote is bound by player ownership, not item NBT — anyone holding it summons *their* TARDIS.
+- Found worldgen TARDISes start with a broken remote-summon circuit until repaired.
 - Collision stays solid during the fade. BOTI is skipped while the shell is translucent.
 - Non-sneak use does nothing.
 

--- a/dwm/docs/feature-tardis-block.md
+++ b/dwm/docs/feature-tardis-block.md
@@ -25,6 +25,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 - `TardisBlockEntity` stores `interiorEntrance` / `interiorGenerated`.
 - Exterior return coordinates stored on `TardisDataModel` for exit teleports.
 - First player to enter an unowned TARDIS claims it (`ownerUuid`) if they do not already own one (one TARDIS per player).
+- Worldgen (mineshaft) Type 40s start **unfinished**: same-world biome hops only, stabilisers off, and most console circuits (planet locator, waypoints, player locator, telepathic, fast return, cloak, chameleon, coordinate locks, remote summon) are **broken** — click shows “This circuit is broken” and a smoke puff. They are meant to be repaired (circuit items in a follow-on ticket). Creative `/give` and player-placed ships stay fully working; existing saves without circuit flags stay fully working.
 - `/tardis rebuild` regenerates the owned console room from the current structure template without changing TARDIS UUID or linked data; ops may `/tardis rebuild <uuid>`.
 - Ops `/tardis claim` (permission 2) overwrites ownership to the caller if they do not already own a TARDIS: stand inside an interior, or pass `/tardis claim <uuid>`.
 - Collision entry when the exterior door is open (`doorSwing >= 0.9`); exit via open interior doors.
@@ -78,7 +79,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 
 ## Known Constraints
 - Interior visuals use the shipped `first_doctor_console_room` structure (11×7×17) with decor props; console and interior-door bank are linked to the exterior via `tardisId` on placement.
-- Ownership is first-enter or ops `/tardis claim` (no place-time claim); worldgen TARDISes stay unowned until entered or claimed. `/tardis rebuild` only targets the caller's owned TARDIS (or any UUID for ops).
+- Ownership is first-enter or ops `/tardis claim` (no place-time claim); worldgen TARDISes stay unowned until entered or claimed, and start with broken circuits until repaired. `/tardis rebuild` only targets the caller's owned TARDIS (or any UUID for ops).
 - Door open/closed for entry is server-authoritative; swing animation still updates locally on both sides.
 - Shared exterior BOTI door aperture table per chameleon variant (`PortalAperture`); interior SOTO uses one classic 3×2 opening aperture.
 - Shared single full-window portal FBO: last END_MAIN writer wins when multiple door portals render in one frame (no FBO pooling yet).

--- a/dwm/src/main/generated/assets/dwm/lang/en_us.json
+++ b/dwm/src/main/generated/assets/dwm/lang/en_us.json
@@ -131,6 +131,7 @@
   "dwm.console.chameleon_circuit": "Chameleon circuit",
   "dwm.console.chameleon_selected": "Chameleon: %s",
   "dwm.console.chameleon_unavailable": "Chameleon circuit unavailable",
+  "dwm.console.circuit_broken": "This circuit is broken",
   "dwm.console.cloak_off": "Cloak disengaged",
   "dwm.console.cloak_on": "Cloak engaged",
   "dwm.console.cloak_unavailable": "Cloak unavailable",

--- a/dwm/src/main/java/com/adamkali/dwm/DWMMain.java
+++ b/dwm/src/main/java/com/adamkali/dwm/DWMMain.java
@@ -14,6 +14,7 @@ import com.adamkali.dwm.sound.DWMSounds;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.logic.TardisTravelService;
 import com.adamkali.dwm.tardis.portal.PortalStreamSyncService;
+import com.adamkali.dwm.tardis.worldgen.DWMStructureProcessors;
 import com.mojang.logging.LogUtils;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
@@ -35,6 +36,7 @@ public class DWMMain implements ModInitializer {
         DWMItems.initialize();
         DWMBlockEntities.initialize();
         DWMSounds.initialize();
+        DWMStructureProcessors.initialize();
         ServerPayloadTypeRegistry.initialize();
         PortalStreamSyncService.initialize();
         TardisTravelService.initialize();

--- a/dwm/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
+++ b/dwm/src/main/java/com/adamkali/dwm/block/FirstDoctorConsoleBlock.java
@@ -10,6 +10,7 @@ import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisExteriorLocation;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
 import com.adamkali.dwm.tardis.logic.CloakLogic;
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
 import com.adamkali.dwm.tardis.logic.CoordinateLockLogic;
 import com.adamkali.dwm.tardis.logic.DoorLockLogic;
 import com.adamkali.dwm.tardis.logic.ExteriorEnvironmentReadout;
@@ -181,6 +182,12 @@ public class FirstDoctorConsoleBlock extends BaseEntityBlock {
         UUID tardisId = console.getTardisId();
         if (tardisId == null) {
             player.sendOverlayMessage(Component.translatable(unavailableKey(target)));
+            return InteractionResult.CONSUME;
+        }
+
+        TardisDataModel model = TardisDataLoader.get(tardisId);
+        Direction facing = world.getBlockState(pos).getValue(FACING);
+        if (CircuitFittedLogic.refuseBrokenConsole(model, target, player, world, pos, facing)) {
             return InteractionResult.CONSUME;
         }
 

--- a/dwm/src/main/java/com/adamkali/dwm/block/TardisBlock.java
+++ b/dwm/src/main/java/com/adamkali/dwm/block/TardisBlock.java
@@ -4,8 +4,12 @@ import com.adamkali.dwm.block.entities.DWMBlockEntities;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.network.OpenTardisChameleonScreen;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.interior.TardisEntryGate;
 import com.adamkali.dwm.tardis.interior.TardisInteriorService;
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.mojang.serialization.MapCodec;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
@@ -97,7 +101,13 @@ public class TardisBlock extends BaseEntityBlock {
                 }
             }
         } else if (!world.isClientSide() && DWMConfig.getBoolean(DWMConfig.ENABLE_CHAMELEON_GUI)) {
-            ServerPlayNetworking.send((ServerPlayer) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
+            TardisDataModel model = TardisDataLoader.get(tardisBlockEntity.getTardisId());
+            if (CircuitFittedLogic.isBroken(model, TardisCircuit.CHAMELEON)
+                    && world instanceof ServerLevel serverLevel) {
+                CircuitFittedLogic.refuseBrokenAtBlock(player, serverLevel, pos);
+            } else {
+                ServerPlayNetworking.send((ServerPlayer) player, new OpenTardisChameleonScreen(tardisBlockEntity.getTardisId()));
+            }
         }
 
         return InteractionResult.SUCCESS;

--- a/dwm/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
+++ b/dwm/src/main/java/com/adamkali/dwm/block/entities/TardisBlockEntity.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.sound.DWMSounds;
 import com.adamkali.dwm.tardis.boti.BotiPlotIndex;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
 import com.adamkali.dwm.tardis.interior.TardisInteriorPreloadService;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
@@ -31,9 +32,12 @@ import net.minecraft.world.level.storage.ValueInput;
 import net.minecraft.world.level.storage.ValueOutput;
 
 public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<TardisBlockEntity> {
+    public static final String WORLDGEN_FOUND_KEY = "worldgenFound";
+
     private UUID tardisId;
     private @Nullable BlockPos interiorEntrance;
     private boolean interiorGenerated;
+    private boolean worldgenFound;
     private boolean syncedCloaked;
     private String syncedTravelPhase = TardisTravelPhase.IDLE.name();
     private long syncedPhaseGameTime;
@@ -84,11 +88,12 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
     @Override
     protected void saveAdditional(ValueOutput output) {
         if (this.tardisId == null) {
-            this.tardisId = TardisDataLoader.create().uuid;
+            this.tardisId = createLinkedModel().uuid;
         }
 
         output.store("tardisId", UUIDUtil.CODEC, this.tardisId);
         output.putBoolean("interiorGenerated", this.interiorGenerated);
+        output.putBoolean(WORLDGEN_FOUND_KEY, this.worldgenFound);
         output.putBoolean("syncedCloaked", this.syncedCloaked);
         output.putString("syncedTravelPhase", this.syncedTravelPhase);
         output.putLong("syncedPhaseGameTime", this.syncedPhaseGameTime);
@@ -107,6 +112,7 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
 
         this.tardisId = input.read("tardisId", UUIDUtil.CODEC).orElse(null);
         this.interiorGenerated = input.getBooleanOr("interiorGenerated", false);
+        this.worldgenFound = input.getBooleanOr(WORLDGEN_FOUND_KEY, false);
         this.syncedCloaked = input.getBooleanOr("syncedCloaked", false);
         this.syncedTravelPhase = input.getStringOr("syncedTravelPhase", TardisTravelPhase.IDLE.name());
         this.syncedPhaseGameTime = input.getLongOr("syncedPhaseGameTime", 0L);
@@ -123,10 +129,26 @@ public class TardisBlockEntity extends BlockEntity implements BlockEntityTicker<
 
     public UUID getTardisId() {
         if (tardisId == null) {
-            tardisId = TardisDataLoader.create().uuid;
+            tardisId = createLinkedModel().uuid;
             setChanged();
         }
         return tardisId;
+    }
+
+    private TardisDataModel createLinkedModel() {
+        return worldgenFound
+                ? TardisDataLoader.createFoundUnfinished()
+                : TardisDataLoader.create();
+    }
+
+    public boolean isWorldgenFound() {
+        return worldgenFound;
+    }
+
+    /** Marks this exterior as a worldgen Type 40 (tests / structure processor). */
+    public void setWorldgenFound(boolean worldgenFound) {
+        this.worldgenFound = worldgenFound;
+        setChanged();
     }
 
     public @Nullable UUID getTardisIdOrNull() {

--- a/dwm/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
+++ b/dwm/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
@@ -68,6 +68,7 @@ public class DWMLanguageProvider extends FabricLanguageProvider {
         t.add("dwm.stattenheim.in_progress", "TARDIS is already travelling");
         t.add("dwm.stattenheim.invalid_landing", "Cannot land here");
         t.add("dwm.stattenheim.unavailable", "Cannot summon the TARDIS");
+        t.add("dwm.console.circuit_broken", "This circuit is broken");
     }
 
     private static void addBuildingBlocks(TranslationBuilder t) {

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/CircuitFittedGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/CircuitFittedGameTests.java
@@ -1,0 +1,226 @@
+package com.adamkali.dwm.gametest;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.block.FirstDoctorConsoleBlock;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
+import com.adamkali.dwm.block.entities.TardisBlockEntity;
+import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
+import com.adamkali.dwm.tardis.logic.StabiliserLogic;
+import com.adamkali.dwm.tardis.logic.TardisLogic;
+import com.adamkali.dwm.tardis.logic.TardisOwnershipLogic;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.storage.LevelResource;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.List;
+import java.util.UUID;
+
+public class CircuitFittedGameTests {
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void worldgenFound_claimKeepsBrokenCircuits(GameTestHelper context) {
+        TardisDataLoader.tardisSaveDirectory = context.getLevel().getServer()
+                .getWorldPath(LevelResource.ROOT)
+                .resolve("gametest_tardis_data");
+
+        BlockPos tardisRel = new BlockPos(1, 2, 1);
+        context.setBlock(tardisRel, DWMBlocks.TARDIS_BLOCK);
+        BlockPos tardisAbs = context.absolutePos(tardisRel);
+        if (!(context.getLevel().getBlockEntity(tardisAbs) instanceof TardisBlockEntity tardis)) {
+            throw new AssertionError("Expected TardisBlockEntity");
+        }
+        tardis.setWorldgenFound(true);
+        UUID tardisId = tardis.getTardisId();
+        TardisDataModel model = TardisDataLoader.get(tardisId);
+        if (model == null) {
+            throw new AssertionError("Expected TARDIS data model");
+        }
+        if (CircuitFittedLogic.isFitted(model, TardisCircuit.PLANET_LOCATOR)) {
+            throw new AssertionError("Worldgen found ship should have broken planet locator");
+        }
+        if (StabiliserLogic.isEnabled(model)) {
+            throw new AssertionError("Worldgen found ship should start with stabilisers off");
+        }
+
+        Player player = context.makeMockPlayer(GameType.SURVIVAL);
+        if (!TardisOwnershipLogic.tryClaimOnEnter(tardisId, player.getUUID())) {
+            throw new AssertionError("Expected claim to succeed");
+        }
+        if (CircuitFittedLogic.isFitted(model, TardisCircuit.PLANET_LOCATOR)) {
+            throw new AssertionError("Claim must not repair circuits");
+        }
+
+        BlockPos consoleRel = new BlockPos(4, 2, 4);
+        BlockPos consoleAbs = context.absolutePos(consoleRel);
+        context.setBlock(
+                consoleRel,
+                DWMBlocks.FIRST_DOCTOR_CONSOLE.defaultBlockState()
+                        .setValue(FirstDoctorConsoleBlock.FACING, Direction.NORTH)
+        );
+        if (!(context.getLevel().getBlockEntity(consoleAbs) instanceof FirstDoctorConsoleBlockEntity console)) {
+            throw new AssertionError("Expected FirstDoctorConsoleBlockEntity");
+        }
+        console.setTardisId(tardisId);
+        model.setExteriorLocation(
+                context.getLevel().dimension().identifier().toString(),
+                tardisAbs.getX(),
+                tardisAbs.getY(),
+                tardisAbs.getZ(),
+                0
+        );
+        model.selectedDimension = "minecraft:the_nether";
+        String beforeDim = model.selectedDimension;
+
+        context.runAtTickTime(1, () -> {
+            List<ConsoleControlInteractionEntity> planet = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(consoleAbs).inflate(2.5),
+                    entity -> entity.isBoundTo(consoleAbs)
+                            && entity.getLookTarget() == LookTarget.PLANET_LOCATOR
+            );
+            if (planet.isEmpty()) {
+                throw new AssertionError("Expected planet locator control entity");
+            }
+            InteractionResult planetResult = planet.getFirst().interact(
+                    player,
+                    InteractionHand.MAIN_HAND,
+                    Vec3.ZERO
+            );
+            if (planetResult != InteractionResult.CONSUME && planetResult != InteractionResult.SUCCESS) {
+                throw new AssertionError("Expected broken planet locator to consume, got " + planetResult);
+            }
+            if (!beforeDim.equals(model.selectedDimension)) {
+                throw new AssertionError("Broken planet locator must not change selectedDimension");
+            }
+            String effective = TardisLogic.effectiveDestinationDimension(model);
+            if ("minecraft:the_nether".equals(effective)) {
+                throw new AssertionError("Broken planet locator must ignore selectedDimension, got " + effective);
+            }
+
+            List<ConsoleControlInteractionEntity> biome = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(consoleAbs).inflate(2.5),
+                    entity -> entity.isBoundTo(consoleAbs)
+                            && entity.getLookTarget() == LookTarget.BIOME_SELECTOR
+            );
+            if (biome.isEmpty()) {
+                throw new AssertionError("Expected biome selector control entity");
+            }
+            InteractionResult biomeResult = biome.getFirst().interact(
+                    player,
+                    InteractionHand.MAIN_HAND,
+                    Vec3.ZERO
+            );
+            if (biomeResult != InteractionResult.SUCCESS && biomeResult != InteractionResult.CONSUME) {
+                throw new AssertionError("Biome selector should still respond, got " + biomeResult);
+            }
+
+            List<ConsoleControlInteractionEntity> stabilisers = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(consoleAbs).inflate(2.5),
+                    entity -> entity.isBoundTo(consoleAbs)
+                            && entity.getLookTarget() == LookTarget.STABILISERS
+            );
+            if (stabilisers.isEmpty()) {
+                throw new AssertionError("Expected stabilisers control entity");
+            }
+            boolean before = StabiliserLogic.isEnabled(model);
+            stabilisers.getFirst().interact(player, InteractionHand.MAIN_HAND, Vec3.ZERO);
+            if (StabiliserLogic.isEnabled(model) != before) {
+                throw new AssertionError("Broken stabilisers must not toggle");
+            }
+
+            context.succeed();
+        });
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void playerPlaced_isFullyFitted(GameTestHelper context) {
+        TardisDataLoader.tardisSaveDirectory = context.getLevel().getServer()
+                .getWorldPath(LevelResource.ROOT)
+                .resolve("gametest_tardis_data");
+
+        BlockPos tardisRel = new BlockPos(1, 2, 1);
+        context.setBlock(tardisRel, DWMBlocks.TARDIS_BLOCK);
+        BlockPos tardisAbs = context.absolutePos(tardisRel);
+        if (!(context.getLevel().getBlockEntity(tardisAbs) instanceof TardisBlockEntity tardis)) {
+            throw new AssertionError("Expected TardisBlockEntity");
+        }
+        UUID tardisId = tardis.getTardisId();
+        TardisDataModel model = TardisDataLoader.get(tardisId);
+        if (model == null) {
+            throw new AssertionError("Expected TARDIS data model");
+        }
+        for (TardisCircuit circuit : TardisCircuit.values()) {
+            if (!CircuitFittedLogic.isFitted(model, circuit)) {
+                throw new AssertionError("Player-placed ship must have fitted " + circuit);
+            }
+        }
+        if (!StabiliserLogic.isEnabled(model)) {
+            throw new AssertionError("Player-placed ship must start with stabilisers on");
+        }
+
+        BlockPos consoleRel = new BlockPos(4, 2, 4);
+        BlockPos consoleAbs = context.absolutePos(consoleRel);
+        context.setBlock(
+                consoleRel,
+                DWMBlocks.FIRST_DOCTOR_CONSOLE.defaultBlockState()
+                        .setValue(FirstDoctorConsoleBlock.FACING, Direction.NORTH)
+        );
+        if (!(context.getLevel().getBlockEntity(consoleAbs) instanceof FirstDoctorConsoleBlockEntity console)) {
+            throw new AssertionError("Expected FirstDoctorConsoleBlockEntity");
+        }
+        console.setTardisId(tardisId);
+        model.setExteriorLocation(
+                context.getLevel().dimension().identifier().toString(),
+                tardisAbs.getX(),
+                tardisAbs.getY(),
+                tardisAbs.getZ(),
+                0
+        );
+
+        context.runAtTickTime(1, () -> {
+            Player player = context.makeMockPlayer(GameType.SURVIVAL);
+            List<ConsoleControlInteractionEntity> planet = context.getLevel().getEntitiesOfClass(
+                    ConsoleControlInteractionEntity.class,
+                    new AABB(consoleAbs).inflate(2.5),
+                    entity -> entity.isBoundTo(consoleAbs)
+                            && entity.getLookTarget() == LookTarget.PLANET_LOCATOR
+            );
+            if (planet.isEmpty()) {
+                throw new AssertionError("Expected planet locator control entity");
+            }
+            String before = model.selectedDimension;
+            InteractionResult result = planet.getFirst().interact(
+                    player,
+                    InteractionHand.MAIN_HAND,
+                    Vec3.ZERO
+            );
+            if (result != InteractionResult.SUCCESS && result != InteractionResult.CONSUME) {
+                throw new AssertionError("Fitted planet locator should respond, got " + result);
+            }
+            // Dimension may or may not change depending on available worlds; must not be treated as broken.
+            if (CircuitFittedLogic.isBroken(model, TardisCircuit.PLANET_LOCATOR)) {
+                throw new AssertionError("Player-placed planet locator must stay fitted");
+            }
+            if (before != null && before.equals(model.selectedDimension)
+                    && TardisLogic.getSelectedDimension(tardisId) == null) {
+                // No-op is fine when only one dimension is loaded.
+            }
+            context.succeed();
+        });
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/item/StattenheimRemoteItem.java
+++ b/dwm/src/main/java/com/adamkali/dwm/item/StattenheimRemoteItem.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.item;
 
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
 import com.adamkali.dwm.tardis.logic.TardisSummonLogic;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
@@ -35,6 +36,10 @@ public class StattenheimRemoteItem extends Item {
                 context.getClickedPos(),
                 context.getClickedFace()
         );
+        if (result == TardisSummonLogic.Result.CIRCUIT_BROKEN) {
+            CircuitFittedLogic.refuseBrokenAtBlock(player, serverLevel, context.getClickedPos());
+            return InteractionResult.CONSUME;
+        }
         player.sendOverlayMessage(Component.translatable(TardisSummonLogic.overlayKey(result)));
         return InteractionResult.SUCCESS;
     }

--- a/dwm/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
+++ b/dwm/src/main/java/com/adamkali/dwm/network/ServerPayloadTypeRegistry.java
@@ -2,9 +2,11 @@ package com.adamkali.dwm.network;
 
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisWaypoint;
 import com.adamkali.dwm.tardis.boti.BotiPlotIndex;
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
 import com.adamkali.dwm.tardis.logic.PlayerLocatorLogic;
 import com.adamkali.dwm.tardis.logic.TardisLogic;
 import com.adamkali.dwm.tardis.logic.TardisTravelService;
@@ -78,6 +80,9 @@ public class ServerPayloadTypeRegistry {
                 LOGGER.warn("Rejected chameleon update for unknown tardisId {} from {}", payload.tardisId(), playerName);
                 return false;
             }
+            if (CircuitFittedLogic.isBroken(tardis, TardisCircuit.CHAMELEON)) {
+                return false;
+            }
 
             TardisChameleonVariant variant = TardisChameleonVariant.fromId(payload.variantId());
             TardisLogic.setVariant(payload.tardisId(), variant);
@@ -90,6 +95,9 @@ public class ServerPayloadTypeRegistry {
 
     static boolean safelyHandleSaveWaypoint(SaveWaypointC2SPayload payload, ServerPlayer player) {
         if (!validateConsoleAction(payload.tardisId(), player)) {
+            return false;
+        }
+        if (!requireCircuit(payload.tardisId(), TardisCircuit.WAYPOINTS)) {
             return false;
         }
         Optional<TardisWaypoint> saved = TardisLogic.saveWaypoint(payload.tardisId(), payload.name());
@@ -113,6 +121,9 @@ public class ServerPayloadTypeRegistry {
         if (!validateConsoleAction(payload.tardisId(), player)) {
             return false;
         }
+        if (!requireCircuit(payload.tardisId(), TardisCircuit.WAYPOINTS)) {
+            return false;
+        }
         boolean deleted = TardisLogic.deleteWaypoint(payload.tardisId(), payload.waypointId());
         if (!deleted) {
             player.sendOverlayMessage(Component.translatable("dwm.console.waypoint_delete_failed"));
@@ -126,6 +137,9 @@ public class ServerPayloadTypeRegistry {
         if (!validateConsoleAction(payload.tardisId(), player)) {
             return false;
         }
+        if (!requireCircuit(payload.tardisId(), TardisCircuit.WAYPOINTS)) {
+            return false;
+        }
         boolean renamed = TardisLogic.renameWaypoint(payload.tardisId(), payload.waypointId(), payload.name());
         if (!renamed) {
             player.sendOverlayMessage(Component.translatable("dwm.console.waypoint_rename_failed"));
@@ -137,6 +151,9 @@ public class ServerPayloadTypeRegistry {
 
     static boolean safelyHandleSelectWaypoint(SelectWaypointC2SPayload payload, ServerPlayer player) {
         if (!validateConsoleAction(payload.tardisId(), player)) {
+            return false;
+        }
+        if (!requireCircuit(payload.tardisId(), TardisCircuit.WAYPOINTS)) {
             return false;
         }
         boolean selected = TardisLogic.selectWaypoint(payload.tardisId(), payload.waypointId());
@@ -154,6 +171,9 @@ public class ServerPayloadTypeRegistry {
 
     static boolean safelyHandleSelectPlayer(SelectPlayerC2SPayload payload, ServerPlayer player) {
         if (!validateConsoleAction(payload.tardisId(), player)) {
+            return false;
+        }
+        if (!requireCircuit(payload.tardisId(), TardisCircuit.PLAYER_LOCATOR)) {
             return false;
         }
         if (payload.playerUuid() != null
@@ -176,6 +196,11 @@ public class ServerPayloadTypeRegistry {
             player.sendOverlayMessage(Component.translatable("dwm.console.player_locator_selected"));
         }
         return true;
+    }
+
+    private static boolean requireCircuit(UUID tardisId, TardisCircuit circuit) {
+        TardisDataModel model = TardisDataLoader.get(tardisId);
+        return CircuitFittedLogic.isFitted(model, circuit);
     }
 
     private static boolean validateConsoleAction(UUID tardisId, ServerPlayer player) {

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/data/TardisDataLoader.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.jetbrains.annotations.NotNull;
@@ -148,6 +149,17 @@ public class TardisDataLoader {
         TardisDataModel model = new TardisDataModel();
         tardisData.put(model.uuid, model);
 
+        return model;
+    }
+
+    /**
+     * Creates a found Type 40 profile: broken circuits, stabilisers off.
+     * Used when a worldgen TARDIS exterior first assigns its UUID.
+     */
+    public static TardisDataModel createFoundUnfinished() {
+        TardisDataModel model = new TardisDataModel();
+        CircuitFittedLogic.applyFoundUnfinished(model);
+        tardisData.put(model.uuid, model);
         return model;
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/data/model/TardisCircuit.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/data/model/TardisCircuit.java
@@ -1,0 +1,17 @@
+package com.adamkali.dwm.tardis.data.model;
+
+/**
+ * Console / remote circuits that can be fitted (working) or broken on a found Type 40.
+ */
+public enum TardisCircuit {
+    PLANET_LOCATOR,
+    WAYPOINTS,
+    PLAYER_LOCATOR,
+    TELEPATHIC,
+    FAST_RETURN,
+    CLOAK,
+    CHAMELEON,
+    COORDINATE_LOCKS,
+    STABILISERS,
+    REMOTE_SUMMON
+}

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/data/model/TardisDataModel.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/data/model/TardisDataModel.java
@@ -99,6 +99,21 @@ public class TardisDataModel {
      */
     public @Nullable UUID ownerUuid;
 
+    /**
+     * Circuit fitted flags. Boxed so Gson loads of older saves (missing field) stay
+     * working via null — see {@link com.adamkali.dwm.tardis.logic.CircuitFittedLogic}.
+     */
+    public Boolean planetLocatorFitted;
+    public Boolean waypointsFitted;
+    public Boolean playerLocatorFitted;
+    public Boolean telepathicFitted;
+    public Boolean fastReturnFitted;
+    public Boolean cloakFitted;
+    public Boolean chameleonFitted;
+    public Boolean coordinateLocksFitted;
+    public Boolean stabilisersFitted;
+    public Boolean remoteSummonFitted;
+
     private transient boolean needsSaving = false;
 
     /**
@@ -117,6 +132,16 @@ public class TardisDataModel {
         this.locationHistory = new ArrayList<>();
         this.selectedFastReturnIndex = 0;
         this.stabilisersEnabled = Boolean.TRUE;
+        this.planetLocatorFitted = Boolean.TRUE;
+        this.waypointsFitted = Boolean.TRUE;
+        this.playerLocatorFitted = Boolean.TRUE;
+        this.telepathicFitted = Boolean.TRUE;
+        this.fastReturnFitted = Boolean.TRUE;
+        this.cloakFitted = Boolean.TRUE;
+        this.chameleonFitted = Boolean.TRUE;
+        this.coordinateLocksFitted = Boolean.TRUE;
+        this.stabilisersFitted = Boolean.TRUE;
+        this.remoteSummonFitted = Boolean.TRUE;
     }
 
     public TardisTravelPhase getTravelPhase() {
@@ -224,7 +249,18 @@ public class TardisDataModel {
                 + ", travelDestinationBiome=" + travelDestinationBiome
                 + ", travelDestinationDimension=" + travelDestinationDimension
                 + ", travelDestinationMode=" + travelDestinationMode
-                + ", ownerUuid=" + ownerUuid + ']';
+                + ", ownerUuid=" + ownerUuid
+                + ", planetLocatorFitted=" + planetLocatorFitted
+                + ", waypointsFitted=" + waypointsFitted
+                + ", playerLocatorFitted=" + playerLocatorFitted
+                + ", telepathicFitted=" + telepathicFitted
+                + ", fastReturnFitted=" + fastReturnFitted
+                + ", cloakFitted=" + cloakFitted
+                + ", chameleonFitted=" + chameleonFitted
+                + ", coordinateLocksFitted=" + coordinateLocksFitted
+                + ", stabilisersFitted=" + stabilisersFitted
+                + ", remoteSummonFitted=" + remoteSummonFitted
+                + ']';
     }
 
     @Override
@@ -263,7 +299,17 @@ public class TardisDataModel {
                     && this.travelDestinationZ == other.travelDestinationZ
                     && this.travelDestinationRotation == other.travelDestinationRotation
                     && Objects.equals(this.travelTargetPlayerUuid, other.travelTargetPlayerUuid)
-                    && Objects.equals(this.ownerUuid, other.ownerUuid);
+                    && Objects.equals(this.ownerUuid, other.ownerUuid)
+                    && Objects.equals(this.planetLocatorFitted, other.planetLocatorFitted)
+                    && Objects.equals(this.waypointsFitted, other.waypointsFitted)
+                    && Objects.equals(this.playerLocatorFitted, other.playerLocatorFitted)
+                    && Objects.equals(this.telepathicFitted, other.telepathicFitted)
+                    && Objects.equals(this.fastReturnFitted, other.fastReturnFitted)
+                    && Objects.equals(this.cloakFitted, other.cloakFitted)
+                    && Objects.equals(this.chameleonFitted, other.chameleonFitted)
+                    && Objects.equals(this.coordinateLocksFitted, other.coordinateLocksFitted)
+                    && Objects.equals(this.stabilisersFitted, other.stabilisersFitted)
+                    && Objects.equals(this.remoteSummonFitted, other.remoteSummonFitted);
         }
         return false;
     }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/CircuitFittedLogic.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/CircuitFittedLogic.java
@@ -1,0 +1,219 @@
+package com.adamkali.dwm.tardis.logic;
+
+import com.adamkali.dwm.block.FirstDoctorConsoleControls;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import org.jetbrains.annotations.Nullable;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.core.particles.ParticleTypes;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+
+/**
+ * Per-TARDIS circuit fitted flags: missing/null/true means working; false means broken.
+ * Found worldgen ships start unfinished; creative/{@code /give}/legacy saves stay fully fitted.
+ */
+public final class CircuitFittedLogic {
+    public static final String CIRCUIT_BROKEN_KEY = "dwm.console.circuit_broken";
+
+    private static final int SMOKE_COUNT = 8;
+    private static final double SMOKE_SPREAD = 0.12;
+    private static final double SMOKE_SPEED = 0.02;
+
+    private CircuitFittedLogic() {
+    }
+
+    /**
+     * {@code null} (legacy Gson) and {@code true} both mean the circuit works.
+     */
+    public static boolean isFitted(@Nullable TardisDataModel model, @Nullable TardisCircuit circuit) {
+        if (model == null || circuit == null) {
+            return true;
+        }
+        Boolean flag = flagOf(model, circuit);
+        return flag == null || flag;
+    }
+
+    public static boolean isBroken(@Nullable TardisDataModel model, @Nullable TardisCircuit circuit) {
+        return !isFitted(model, circuit);
+    }
+
+    public static void setFitted(@Nullable TardisDataModel model, @Nullable TardisCircuit circuit, boolean fitted) {
+        if (model == null || circuit == null) {
+            return;
+        }
+        writeFlag(model, circuit, fitted);
+        model.setChanged();
+    }
+
+    /** All circuits working; stabilisers on. Used for {@code /give} and new player-placed ships. */
+    public static void applyFullyFitted(@Nullable TardisDataModel model) {
+        if (model == null) {
+            return;
+        }
+        for (TardisCircuit circuit : TardisCircuit.values()) {
+            writeFlag(model, circuit, true);
+        }
+        model.stabilisersEnabled = Boolean.TRUE;
+        model.setChanged();
+    }
+
+    /**
+     * Found Type 40 profile: listed circuits broken, stabilisers off.
+     * Biome dial, materialisation lever, readers, and door lock stay usable.
+     */
+    public static void applyFoundUnfinished(@Nullable TardisDataModel model) {
+        if (model == null) {
+            return;
+        }
+        for (TardisCircuit circuit : TardisCircuit.values()) {
+            writeFlag(model, circuit, false);
+        }
+        model.stabilisersEnabled = Boolean.FALSE;
+        model.setChanged();
+    }
+
+    /**
+     * Maps a console look target to its circuit, or empty when the control is always available.
+     */
+    public static java.util.Optional<TardisCircuit> circuitFor(LookTarget target) {
+        if (target == null) {
+            return java.util.Optional.empty();
+        }
+        return switch (target) {
+            case PLANET_LOCATOR -> java.util.Optional.of(TardisCircuit.PLANET_LOCATOR);
+            case WAYPOINT_SELECTOR -> java.util.Optional.of(TardisCircuit.WAYPOINTS);
+            case PLAYER_LOCATOR -> java.util.Optional.of(TardisCircuit.PLAYER_LOCATOR);
+            case TELEPATHIC_CIRCUIT -> java.util.Optional.of(TardisCircuit.TELEPATHIC);
+            case FAST_RETURN -> java.util.Optional.of(TardisCircuit.FAST_RETURN);
+            case CLOAK -> java.util.Optional.of(TardisCircuit.CLOAK);
+            case CHAMELEON_CIRCUIT -> java.util.Optional.of(TardisCircuit.CHAMELEON);
+            case COORDINATE_LOCK_X, COORDINATE_LOCK_Y, COORDINATE_LOCK_Z ->
+                    java.util.Optional.of(TardisCircuit.COORDINATE_LOCKS);
+            case STABILISERS -> java.util.Optional.of(TardisCircuit.STABILISERS);
+            case BIOME_SELECTOR, MATERIALISATION_LEVER, OXYGEN_READER, PRESSURE_READER,
+                 TEMPERATURE_READER, RADIATION_READER, REFUELER, DOOR_LOCK, NONE ->
+                    java.util.Optional.empty();
+        };
+    }
+
+    /**
+     * Overlay + smoke for a broken console control. No click sound.
+     *
+     * @return {@code true} when the control was refused as broken
+     */
+    public static boolean refuseBrokenConsole(
+            @Nullable TardisDataModel model,
+            LookTarget target,
+            Player player,
+            Level world,
+            BlockPos consolePos,
+            Direction facing
+    ) {
+        java.util.Optional<TardisCircuit> circuit = circuitFor(target);
+        if (circuit.isEmpty() || isFitted(model, circuit.get())) {
+            return false;
+        }
+        player.sendOverlayMessage(Component.translatable(CIRCUIT_BROKEN_KEY));
+        if (world instanceof ServerLevel serverLevel) {
+            AABB box = FirstDoctorConsoleControls.worldBoxForTarget(target, consolePos, facing);
+            Vec3 center = box.getCenter();
+            spawnBrokenSmoke(serverLevel, center.x, center.y, center.z);
+        }
+        return true;
+    }
+
+    /**
+     * Overlay + smoke at a world position (remote, exterior chameleon GUI).
+     */
+    public static void refuseBrokenAt(
+            Player player,
+            @Nullable ServerLevel world,
+            double x,
+            double y,
+            double z
+    ) {
+        player.sendOverlayMessage(Component.translatable(CIRCUIT_BROKEN_KEY));
+        if (world != null) {
+            spawnBrokenSmoke(world, x, y, z);
+        }
+    }
+
+    public static void refuseBrokenAtBlock(Player player, @Nullable ServerLevel world, BlockPos pos) {
+        refuseBrokenAt(
+                player,
+                world,
+                pos.getX() + 0.5,
+                pos.getY() + 0.75,
+                pos.getZ() + 0.5
+        );
+    }
+
+    public static void spawnBrokenSmoke(ServerLevel world, double x, double y, double z) {
+        world.sendParticles(
+                ParticleTypes.SMOKE,
+                x,
+                y,
+                z,
+                SMOKE_COUNT,
+                SMOKE_SPREAD,
+                SMOKE_SPREAD,
+                SMOKE_SPREAD,
+                SMOKE_SPEED
+        );
+        world.sendParticles(
+                ParticleTypes.LARGE_SMOKE,
+                x,
+                y,
+                z,
+                2,
+                SMOKE_SPREAD,
+                SMOKE_SPREAD,
+                SMOKE_SPREAD,
+                SMOKE_SPEED
+        );
+    }
+
+    /** Pure: smoke spawn origin for a console control box center (testable without a world). */
+    public static Vec3 smokeOriginForControl(LookTarget target, BlockPos consolePos, Direction facing) {
+        return FirstDoctorConsoleControls.worldBoxForTarget(target, consolePos, facing).getCenter();
+    }
+
+    private static @Nullable Boolean flagOf(TardisDataModel model, TardisCircuit circuit) {
+        return switch (circuit) {
+            case PLANET_LOCATOR -> model.planetLocatorFitted;
+            case WAYPOINTS -> model.waypointsFitted;
+            case PLAYER_LOCATOR -> model.playerLocatorFitted;
+            case TELEPATHIC -> model.telepathicFitted;
+            case FAST_RETURN -> model.fastReturnFitted;
+            case CLOAK -> model.cloakFitted;
+            case CHAMELEON -> model.chameleonFitted;
+            case COORDINATE_LOCKS -> model.coordinateLocksFitted;
+            case STABILISERS -> model.stabilisersFitted;
+            case REMOTE_SUMMON -> model.remoteSummonFitted;
+        };
+    }
+
+    private static void writeFlag(TardisDataModel model, TardisCircuit circuit, boolean fitted) {
+        Boolean value = fitted;
+        switch (circuit) {
+            case PLANET_LOCATOR -> model.planetLocatorFitted = value;
+            case WAYPOINTS -> model.waypointsFitted = value;
+            case PLAYER_LOCATOR -> model.playerLocatorFitted = value;
+            case TELEPATHIC -> model.telepathicFitted = value;
+            case FAST_RETURN -> model.fastReturnFitted = value;
+            case CLOAK -> model.cloakFitted = value;
+            case CHAMELEON -> model.chameleonFitted = value;
+            case COORDINATE_LOCKS -> model.coordinateLocksFitted = value;
+            case STABILISERS -> model.stabilisersFitted = value;
+            case REMOTE_SUMMON -> model.remoteSummonFitted = value;
+        }
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/CoordinateLockLogic.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/CoordinateLockLogic.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.tardis.logic;
 
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import net.minecraft.core.BlockPos;
 import org.jetbrains.annotations.Nullable;
@@ -60,7 +61,10 @@ public final class CoordinateLockLogic {
         if (resolved == null) {
             return null;
         }
-        if (model == null || !model.hasExteriorLocation || !anyLocked(model)) {
+        if (model == null
+                || !model.hasExteriorLocation
+                || !anyLocked(model)
+                || CircuitFittedLogic.isBroken(model, TardisCircuit.COORDINATE_LOCKS)) {
             return resolved;
         }
         int x = model.lockX ? model.exteriorX : resolved.getX();

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisLogic.java
@@ -7,6 +7,7 @@ import com.adamkali.dwm.sound.DWMSounds;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.DestinationMode;
 import com.adamkali.dwm.tardis.data.model.TardisChameleonVariant;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
@@ -341,11 +342,15 @@ public class TardisLogic {
 
     /**
      * Destination dimension used for biome listing and travel: {@code selectedDimension} when set,
-     * otherwise {@code exteriorDimension}.
+     * otherwise {@code exteriorDimension}. When the planet locator circuit is broken, always uses
+     * the exterior dimension (same-world hops only).
      */
     public static @Nullable String effectiveDestinationDimension(@Nullable TardisDataModel tardis) {
         if (tardis == null) {
             return null;
+        }
+        if (!CircuitFittedLogic.isFitted(tardis, TardisCircuit.PLANET_LOCATOR)) {
+            return tardis.exteriorDimension;
         }
         if (tardis.selectedDimension != null && !tardis.selectedDimension.isBlank()) {
             return tardis.selectedDimension;

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisSummonLogic.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisSummonLogic.java
@@ -2,6 +2,7 @@ package com.adamkali.dwm.tardis.logic;
 
 import com.adamkali.dwm.tardis.TardisExteriorFacing;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
 import net.minecraft.core.BlockPos;
@@ -25,7 +26,8 @@ public final class TardisSummonLogic {
         NO_TARDIS,
         IN_PROGRESS,
         INVALID_LANDING,
-        UNAVAILABLE
+        UNAVAILABLE,
+        CIRCUIT_BROKEN
     }
 
     public static String overlayKey(Result result) {
@@ -35,6 +37,7 @@ public final class TardisSummonLogic {
             case IN_PROGRESS -> "dwm.stattenheim.in_progress";
             case INVALID_LANDING -> "dwm.stattenheim.invalid_landing";
             case UNAVAILABLE -> "dwm.stattenheim.unavailable";
+            case CIRCUIT_BROKEN -> CircuitFittedLogic.CIRCUIT_BROKEN_KEY;
         };
     }
 
@@ -44,6 +47,9 @@ public final class TardisSummonLogic {
     public static Result preview(@Nullable TardisDataModel model) {
         if (model == null) {
             return Result.NO_TARDIS;
+        }
+        if (CircuitFittedLogic.isBroken(model, TardisCircuit.REMOTE_SUMMON)) {
+            return Result.CIRCUIT_BROKEN;
         }
         TardisTravelPhase phase = model.getTravelPhase();
         if (phase == TardisTravelPhase.DEMATERIALISING || phase == TardisTravelPhase.MATERIALISING) {

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelService.java
@@ -7,6 +7,7 @@ import com.adamkali.dwm.sound.DWMSounds;
 import com.adamkali.dwm.tardis.TardisExteriorFacing;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.DestinationMode;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisExteriorLocation;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
@@ -692,10 +693,14 @@ public final class TardisTravelService {
                         && !model.selectedBiome.isBlank()
                         && LandingSiteLogic.parseBiome(model.selectedBiome).isPresent();
             }
-            case WAYPOINT -> WaypointLogic.find(model, model.selectedWaypointId).isPresent();
-            case PLAYER -> model.selectedPlayerUuid != null;
-            case FAST_RETURN -> FastReturnLogic.hasSelection(model);
-            case TELEPATHIC -> TelepathicCircuitLogic.hasSelection(model);
+            case WAYPOINT -> CircuitFittedLogic.isFitted(model, TardisCircuit.WAYPOINTS)
+                    && WaypointLogic.find(model, model.selectedWaypointId).isPresent();
+            case PLAYER -> CircuitFittedLogic.isFitted(model, TardisCircuit.PLAYER_LOCATOR)
+                    && model.selectedPlayerUuid != null;
+            case FAST_RETURN -> CircuitFittedLogic.isFitted(model, TardisCircuit.FAST_RETURN)
+                    && FastReturnLogic.hasSelection(model);
+            case TELEPATHIC -> CircuitFittedLogic.isFitted(model, TardisCircuit.TELEPATHIC)
+                    && TelepathicCircuitLogic.hasSelection(model);
         };
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/worldgen/DWMStructureProcessors.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/worldgen/DWMStructureProcessors.java
@@ -1,0 +1,25 @@
+package com.adamkali.dwm.tardis.worldgen;
+
+import com.adamkali.dwm.DWMReference;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
+
+public final class DWMStructureProcessors {
+    private DWMStructureProcessors() {
+    }
+
+    public static void initialize() {
+        register("tardis_worldgen_marker", TardisWorldgenMarkerProcessor.MAP_CODEC);
+    }
+
+    private static void register(String path, MapCodec<? extends StructureProcessor> codec) {
+        Registry.register(
+                BuiltInRegistries.STRUCTURE_PROCESSOR,
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path),
+                codec
+        );
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/worldgen/TardisWorldgenMarkerProcessor.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/worldgen/TardisWorldgenMarkerProcessor.java
@@ -1,0 +1,52 @@
+package com.adamkali.dwm.tardis.worldgen;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.block.entities.TardisBlockEntity;
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Marks worldgen-placed TARDIS exteriors so first UUID assignment creates an unfinished Type 40.
+ */
+public final class TardisWorldgenMarkerProcessor implements StructureProcessor {
+    public static final TardisWorldgenMarkerProcessor INSTANCE = new TardisWorldgenMarkerProcessor();
+    public static final MapCodec<TardisWorldgenMarkerProcessor> MAP_CODEC =
+            MapCodec.unit(() -> INSTANCE);
+
+    private TardisWorldgenMarkerProcessor() {
+    }
+
+    @Override
+    public StructureTemplate.@Nullable StructureBlockInfo processBlock(
+            LevelReader level,
+            BlockPos targetPosition,
+            BlockPos referencePos,
+            BlockPos templateRelativePos,
+            StructureTemplate.StructureBlockInfo processedBlockInfo,
+            StructurePlaceSettings settings
+    ) {
+        if (!processedBlockInfo.state().is(DWMBlocks.TARDIS_BLOCK)) {
+            return processedBlockInfo;
+        }
+        CompoundTag nbt = processedBlockInfo.nbt() == null
+                ? new CompoundTag()
+                : processedBlockInfo.nbt().copy();
+        nbt.putBoolean(TardisBlockEntity.WORLDGEN_FOUND_KEY, true);
+        return new StructureTemplate.StructureBlockInfo(
+                processedBlockInfo.pos(),
+                processedBlockInfo.state(),
+                nbt
+        );
+    }
+
+    @Override
+    public MapCodec<TardisWorldgenMarkerProcessor> codec() {
+        return MAP_CODEC;
+    }
+}

--- a/dwm/src/main/resources/data/dwm/worldgen/processor_list/tardis_worldgen_marker.json
+++ b/dwm/src/main/resources/data/dwm/worldgen/processor_list/tardis_worldgen_marker.json
@@ -1,0 +1,7 @@
+{
+  "processors": [
+    {
+      "processor_type": "dwm:tardis_worldgen_marker"
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/worldgen/template_pool/tardis_block.json
+++ b/dwm/src/main/resources/data/dwm/worldgen/template_pool/tardis_block.json
@@ -7,7 +7,7 @@
         "element_type": "minecraft:single_pool_element",
         "location": "dwm:tardis_block",
         "projection": "rigid",
-        "processors": "minecraft:empty"
+        "processors": "dwm:tardis_worldgen_marker"
       }
     }
   ]

--- a/dwm/src/main/resources/fabric.mod.json
+++ b/dwm/src/main/resources/fabric.mod.json
@@ -39,6 +39,7 @@
       "com.adamkali.dwm.gametest.SonicInteractionGameTests",
       "com.adamkali.dwm.gametest.StattenheimRemoteGameTests",
       "com.adamkali.dwm.gametest.ConsoleControlInteractionGameTests",
+      "com.adamkali.dwm.gametest.CircuitFittedGameTests",
       "com.adamkali.dwm.gametest.BroakirGameTests",
       "com.adamkali.dwm.gametest.FlutterwingGameTests",
       "com.adamkali.dwm.gametest.MewingDogGameTests",

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/data/model/TardisDataModelExteriorTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/data/model/TardisDataModelExteriorTest.java
@@ -1,7 +1,9 @@
 package com.adamkali.dwm.tardis.data.model;
 
 import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.logic.CircuitFittedLogic;
 import com.adamkali.dwm.tardis.logic.StabiliserLogic;
 import com.google.gson.Gson;
 import java.util.UUID;
@@ -181,5 +183,26 @@ class TardisDataModelExteriorTest {
 
         TardisDataModel legacy = gson.fromJson("{\"uuid\":\"" + model.uuid + "\"}", TardisDataModel.class);
         assertNull(legacy.ownerUuid);
+    }
+
+    @Test
+    void circuitFlags_serializeThroughGsonAndLegacyNullMeansFitted() {
+        TardisDataModel model = new TardisDataModel();
+        model.planetLocatorFitted = Boolean.FALSE;
+        model.waypointsFitted = Boolean.FALSE;
+        model.remoteSummonFitted = Boolean.TRUE;
+
+        Gson gson = new Gson();
+        TardisDataModel loaded = gson.fromJson(gson.toJson(model), TardisDataModel.class);
+
+        assertFalse(CircuitFittedLogic.isFitted(loaded, TardisCircuit.PLANET_LOCATOR));
+        assertFalse(CircuitFittedLogic.isFitted(loaded, TardisCircuit.WAYPOINTS));
+        assertTrue(CircuitFittedLogic.isFitted(loaded, TardisCircuit.REMOTE_SUMMON));
+        assertEquals(model, loaded);
+
+        TardisDataModel legacy = gson.fromJson("{\"uuid\":\"" + model.uuid + "\"}", TardisDataModel.class);
+        for (TardisCircuit circuit : TardisCircuit.values()) {
+            assertTrue(CircuitFittedLogic.isFitted(legacy, circuit), circuit.name());
+        }
     }
 }

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/logic/CircuitFittedLogicTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/logic/CircuitFittedLogicTest.java
@@ -1,0 +1,164 @@
+package com.adamkali.dwm.tardis.logic;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.adamkali.dwm.block.FirstDoctorConsoleControls.LookTarget;
+import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.DestinationMode;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
+import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.data.model.TardisWaypoint;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CircuitFittedLogicTest {
+    @TempDir
+    Path tempDir;
+
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        TardisDataLoader.tardisSaveDirectory = tempDir;
+        clearCache();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        clearCache();
+        TardisDataLoader.tardisSaveDirectory = null;
+    }
+
+    @Test
+    void create_isFullyFittedWithStabilisersOn() {
+        TardisDataModel model = TardisDataLoader.create();
+        for (TardisCircuit circuit : TardisCircuit.values()) {
+            assertTrue(CircuitFittedLogic.isFitted(model, circuit), circuit.name());
+        }
+        assertTrue(StabiliserLogic.isEnabled(model));
+    }
+
+    @Test
+    void createFoundUnfinished_breaksListedCircuitsAndDisablesStabilisers() {
+        TardisDataModel model = TardisDataLoader.createFoundUnfinished();
+        for (TardisCircuit circuit : TardisCircuit.values()) {
+            assertFalse(CircuitFittedLogic.isFitted(model, circuit), circuit.name());
+            assertTrue(CircuitFittedLogic.isBroken(model, circuit), circuit.name());
+        }
+        assertFalse(StabiliserLogic.isEnabled(model));
+        assertEquals(DestinationMode.BIOME, model.getDestinationMode());
+    }
+
+    @Test
+    void isFitted_nullFlagMeansWorking() {
+        TardisDataModel model = new TardisDataModel();
+        model.planetLocatorFitted = null;
+        assertTrue(CircuitFittedLogic.isFitted(model, TardisCircuit.PLANET_LOCATOR));
+    }
+
+    @Test
+    void setFitted_repairsBrokenCircuit() {
+        TardisDataModel model = TardisDataLoader.createFoundUnfinished();
+        CircuitFittedLogic.setFitted(model, TardisCircuit.WAYPOINTS, true);
+        assertTrue(CircuitFittedLogic.isFitted(model, TardisCircuit.WAYPOINTS));
+        assertFalse(CircuitFittedLogic.isFitted(model, TardisCircuit.PLANET_LOCATOR));
+    }
+
+    @Test
+    void circuitFor_mapsConsoleTargets() {
+        assertEquals(
+                TardisCircuit.PLANET_LOCATOR,
+                CircuitFittedLogic.circuitFor(LookTarget.PLANET_LOCATOR).orElseThrow()
+        );
+        assertEquals(
+                TardisCircuit.COORDINATE_LOCKS,
+                CircuitFittedLogic.circuitFor(LookTarget.COORDINATE_LOCK_Y).orElseThrow()
+        );
+        assertTrue(CircuitFittedLogic.circuitFor(LookTarget.BIOME_SELECTOR).isEmpty());
+        assertTrue(CircuitFittedLogic.circuitFor(LookTarget.MATERIALISATION_LEVER).isEmpty());
+        assertTrue(CircuitFittedLogic.circuitFor(LookTarget.DOOR_LOCK).isEmpty());
+    }
+
+    @Test
+    void smokeOriginForControl_isControlBoxCenter() {
+        BlockPos pos = new BlockPos(10, 64, -3);
+        Vec3 origin = CircuitFittedLogic.smokeOriginForControl(
+                LookTarget.PLANET_LOCATOR,
+                pos,
+                Direction.NORTH
+        );
+        assertEquals(
+                com.adamkali.dwm.block.FirstDoctorConsoleControls
+                        .worldBoxForTarget(LookTarget.PLANET_LOCATOR, pos, Direction.NORTH)
+                        .getCenter(),
+                origin
+        );
+    }
+
+    @Test
+    void claimDoesNotUpgradeFoundUnfinished() {
+        TardisDataModel model = TardisDataLoader.createFoundUnfinished();
+        UUID player = UUID.randomUUID();
+        assertTrue(TardisOwnershipLogic.tryClaimOnEnter(model.uuid, player));
+        assertEquals(player, model.ownerUuid);
+        assertFalse(CircuitFittedLogic.isFitted(model, TardisCircuit.PLANET_LOCATOR));
+        assertFalse(StabiliserLogic.isEnabled(model));
+    }
+
+    @Test
+    void hasValidDestination_blocksBrokenModes() {
+        TardisDataModel model = TardisDataLoader.createFoundUnfinished();
+        model.setExteriorLocation("minecraft:overworld", 0, 64, 0, 0);
+        model.selectedBiome = "minecraft:plains";
+        model.setDestinationMode(DestinationMode.BIOME);
+        assertTrue(TardisTravelService.hasValidDestinationSelection(model));
+
+        model.setDestinationMode(DestinationMode.WAYPOINT);
+        model.selectedWaypointId = UUID.randomUUID();
+        model.getWaypoints().add(new TardisWaypoint(
+                model.selectedWaypointId, "Pad", "minecraft:overworld", 1, 64, 1, 0
+        ));
+        assertFalse(TardisTravelService.hasValidDestinationSelection(model));
+    }
+
+    @Test
+    void effectiveDestination_ignoresSelectedDimensionWhenPlanetLocatorBroken() {
+        TardisDataModel model = TardisDataLoader.createFoundUnfinished();
+        model.setExteriorLocation("minecraft:overworld", 0, 64, 0, 0);
+        model.selectedDimension = "minecraft:the_nether";
+        assertEquals("minecraft:overworld", TardisLogic.effectiveDestinationDimension(model));
+    }
+
+    @Test
+    void summonPreview_circuitBrokenWhenRemoteBroken() {
+        TardisDataModel model = TardisDataLoader.createFoundUnfinished();
+        model.setExteriorLocation("minecraft:overworld", 0, 64, 0, 0);
+        assertEquals(TardisSummonLogic.Result.CIRCUIT_BROKEN, TardisSummonLogic.preview(model));
+        assertEquals(
+                CircuitFittedLogic.CIRCUIT_BROKEN_KEY,
+                TardisSummonLogic.overlayKey(TardisSummonLogic.Result.CIRCUIT_BROKEN)
+        );
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void clearCache() throws Exception {
+        Field field = TardisDataLoader.class.getDeclaredField("tardisData");
+        field.setAccessible(true);
+        ((HashMap<?, ?>) field.get(null)).clear();
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/logic/TardisSummonLogicTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/logic/TardisSummonLogicTest.java
@@ -2,6 +2,7 @@ package com.adamkali.dwm.tardis.logic;
 
 import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
+import com.adamkali.dwm.tardis.data.model.TardisCircuit;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisTravelPhase;
 import net.minecraft.core.BlockPos;
@@ -99,6 +100,18 @@ class TardisSummonLogicTest {
     void overlayKey_mapsEachResult() {
         assertEquals("dwm.stattenheim.no_tardis", TardisSummonLogic.overlayKey(TardisSummonLogic.Result.NO_TARDIS));
         assertEquals("dwm.stattenheim.summoned", TardisSummonLogic.overlayKey(TardisSummonLogic.Result.SUMMONED));
+        assertEquals(
+                CircuitFittedLogic.CIRCUIT_BROKEN_KEY,
+                TardisSummonLogic.overlayKey(TardisSummonLogic.Result.CIRCUIT_BROKEN)
+        );
+    }
+
+    @Test
+    void preview_circuitBrokenWhenRemoteSummonBroken() {
+        TardisDataModel model = TardisDataLoader.create();
+        model.setExteriorLocation("minecraft:overworld", 0, 64, 0, 0);
+        CircuitFittedLogic.setFitted(model, TardisCircuit.REMOTE_SUMMON, false);
+        assertEquals(TardisSummonLogic.Result.CIRCUIT_BROKEN, TardisSummonLogic.preview(model));
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- Survival progression needs a found Type 40 that feels unfinished; first enter currently unlocks every destination mode with nothing left to repair.
- Gives DWM-060 a clear install rail without nerfing creative `/give` ships or existing saves.

## Proposed Implementation

- Persist per-TARDIS boxed `*Fitted` circuit flags (legacy/missing = working); worldgen exteriors marked via `dwm:tardis_worldgen_marker` and created with `createFoundUnfinished()`.
- Found ships: same-world biome hops only, stabilisers off; broken console/remote/chameleon interactions overlay “This circuit is broken” and spawn smoke.
- Gate travel modes, C2S waypoint/player/chameleon payloads, and Stattenheim summon when circuits are broken.
- Unit tests, GameTests (`CircuitFittedGameTests`), lang/docs updates.

## Problems Encountered / Decisions Made

- Used a custom structure processor (NBT-only) instead of RuleProcessor `append_static` so exterior rotation is preserved.
- Persistence keeps `*Fitted` naming for DWM-060 repair; player-facing copy says broken.
- `create()` does not call `applyFullyFitted` so new models stay clean for save dirty-tracking.


Made with [Cursor](https://cursor.com)