### PR TITLE
feat(screenplay): test suite support with shared hooks

### DIFF
--- a/dwm/src/screenplayTests/AGENTS.md
+++ b/dwm/src/screenplayTests/AGENTS.md
@@ -10,11 +10,11 @@ YAML scenarios drive the **real Minecraft client** via Screenplay. Primitives an
 Also: [`screenplay/README.md`](../../../screenplay/README.md), [`screenplay/metadata/modrinth-body.md`](../../../screenplay/metadata/modrinth-body.md), and this directory’s `README.md`.
 
 ## Commands
-- Run a scenario: `./dwm/gradlew runScreenplay -Pscreenplay=<yaml-filename-stem>`
-- Run all discovered `type: test` scenarios: `./dwm/gradlew runScreenplayTests`
+- Run a scenario or suite: `./dwm/gradlew runScreenplay -Pscreenplay=<yaml-filename-stem>`
+- Run all discovered suites + standalone `type: test` scenarios: `./dwm/gradlew runScreenplayTests`
 - Properties: `-PscreenplayDisplay=display|xvfb`, `-PscreenplayTimeout=<seconds>`, optional `-PscreenplayBaselinesDir=<dir>` for screenshot compare
 - Outputs: `dwm/build/screenplay/report.xml`, `metrics.json`, `diagnostics.txt`, screenshots under `dwm/build/screenplay/run/screenshots/`
-- Per-scenario archives from `runScreenplayTests`: `dwm/build/screenplay/results/<id>/`
+- Per-run archives from `runScreenplayTests`: `dwm/build/screenplay/results/<id>/`
 
 ## Harness unit tests
 - Unit tests for the harness: `./screenplay/gradlew :common:test`
@@ -24,6 +24,7 @@ Also: [`screenplay/README.md`](../../../screenplay/README.md), [`screenplay/meta
 - Prefer adding shared primitives upstream in `screenplay/common`; mod-only steps can use `ServiceLoader` registration.
 - Keep scenarios deterministic (`createWorld` defaults include seed `"42"`).
 - Optional `captureScreenshot.compare: true` diffs against CI baselines from green `main` (via `-PscreenplayBaselinesDir`); do not commit PNG goldens.
+- Suites (`type: suite`) share one client session via `before-all` / `before-each` / `after-each` / `after-all` hooks. Suite members that are listed under `tests:` are not also run standalone by `runScreenplayTests`.
 
 ## CI
 - **CI** — `.github/workflows/scenario-tests.yml` runs `./dwm/gradlew runScreenplayTests` (and Screenplay library demos) with xvfb; PRs download main screenshot artifacts for compare.

--- a/dwm/src/screenplayTests/README.md
+++ b/dwm/src/screenplayTests/README.md
@@ -23,16 +23,18 @@ Mod-owned scenarios include `placeAndOpenTardis` (TARDIS door/interior flow) and
 commit baseline PNGs — review screenshot diffs across CI runs or local runs when
 the Field Guide UI changes.
 
-Discover every `type: test` YAML under `resources/tests/` and run each one
-(fresh client per scenario):
+Discover every `type: suite` and standalone `type: test` YAML under
+`resources/tests/`. Suites share one client session; standalone tests still get
+a fresh client each:
 
 ```bash
 ./dwm/gradlew runScreenplayTests
 ./dwm/gradlew runScreenplayTests -PscreenplayDisplay=xvfb -PscreenplayTimeout=120
 ```
 
-`runScreenplayTests` skips `type: command` documents, continues after individual
-failures, and fails the aggregate with the list of failed scenario IDs.
+`runScreenplayTests` skips `type: command` documents and skips `type: test` IDs
+that are listed as members of a discovered suite. It continues after individual
+failures, and fails the aggregate with the list of failed IDs.
 
 The client uses an isolated directory under `build/screenplay/run`. Before
 each run, the harness removes its saved worlds, clears
@@ -111,10 +113,13 @@ Supported frontmatter types are:
 
 - `test` — an executable scenario selected with `-Pscreenplay`.
 - `command` — a reusable composite command.
+- `suite` — one-client group of tests with `before-all` / `before-each` /
+  `after-each` / `after-all` hooks and a `tests:` member list.
 
 The filename stem is the stable ID. For example,
-`subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test or
-command IDs are rejected even when the files are in different directories.
+`subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test,
+command, or suite IDs are rejected even when the files are in different
+directories.
 
 ## Steps and selectors
 

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCatalog.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCatalog.java
@@ -15,18 +15,30 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public final class ScenarioCatalog {
+    private static final Set<String> SUITE_BODY_KEYS = Set.of(
+            "before-all", "before-each", "after-each", "after-all", "tests"
+    );
+
     private final Map<String, ScenarioDocument> tests;
     private final Map<String, ScenarioDocument> commands;
+    private final Map<String, ScenarioDocument> suites;
 
-    private ScenarioCatalog(Map<String, ScenarioDocument> tests, Map<String, ScenarioDocument> commands) {
+    private ScenarioCatalog(
+            Map<String, ScenarioDocument> tests,
+            Map<String, ScenarioDocument> commands,
+            Map<String, ScenarioDocument> suites
+    ) {
         this.tests = Map.copyOf(tests);
         this.commands = Map.copyOf(commands);
+        this.suites = Map.copyOf(suites);
     }
 
     public static ScenarioCatalog loadFromResources(ClassLoader classLoader) {
@@ -42,19 +54,21 @@ public final class ScenarioCatalog {
 
         Map<String, ScenarioDocument> tests = new LinkedHashMap<>();
         Map<String, ScenarioDocument> commands = new LinkedHashMap<>();
+        Map<String, ScenarioDocument> suites = new LinkedHashMap<>();
         while (roots.hasMoreElements()) {
             URL rootUrl = roots.nextElement();
             Path root = toPath(rootUrl);
-            loadInto(root, tests, commands);
+            loadInto(root, tests, commands, suites);
         }
-        return new ScenarioCatalog(tests, commands);
+        return new ScenarioCatalog(tests, commands, suites);
     }
 
     public static ScenarioCatalog load(Path root) {
         Map<String, ScenarioDocument> tests = new LinkedHashMap<>();
         Map<String, ScenarioDocument> commands = new LinkedHashMap<>();
-        loadInto(root, tests, commands);
-        return new ScenarioCatalog(tests, commands);
+        Map<String, ScenarioDocument> suites = new LinkedHashMap<>();
+        loadInto(root, tests, commands, suites);
+        return new ScenarioCatalog(tests, commands, suites);
     }
 
     private static Path toPath(URL root) {
@@ -80,7 +94,8 @@ public final class ScenarioCatalog {
     private static void loadInto(
             Path root,
             Map<String, ScenarioDocument> tests,
-            Map<String, ScenarioDocument> commands
+            Map<String, ScenarioDocument> commands,
+            Map<String, ScenarioDocument> suites
     ) {
         if (!Files.isDirectory(root)) {
             throw new ScenarioException("Scenario root is not a directory: " + root);
@@ -92,8 +107,11 @@ public final class ScenarioCatalog {
                     .sorted()
                     .map(path -> parse(root, path))
                     .forEach(document -> {
-                        Map<String, ScenarioDocument> target =
-                                document.type() == ScenarioDocument.Type.TEST ? tests : commands;
+                        Map<String, ScenarioDocument> target = switch (document.type()) {
+                            case TEST -> tests;
+                            case COMMAND -> commands;
+                            case SUITE -> suites;
+                        };
                         ScenarioDocument previous = target.putIfAbsent(document.id(), document);
                         if (previous != null) {
                             throw new ScenarioException("Duplicate " + document.type().name().toLowerCase(Locale.ROOT)
@@ -114,6 +132,27 @@ public final class ScenarioCatalog {
         return test;
     }
 
+    public ScenarioDocument requireSuite(String id) {
+        ScenarioDocument suite = suites.get(normalizeId(id));
+        if (suite == null) {
+            throw new ScenarioException("Unknown suite '" + id + "'. Available suites: " + suites.keySet());
+        }
+        return suite;
+    }
+
+    public ScenarioDocument.Type resolveExecutableType(String id) {
+        String normalized = normalizeId(id);
+        if (suites.containsKey(normalized)) {
+            return ScenarioDocument.Type.SUITE;
+        }
+        if (tests.containsKey(normalized)) {
+            return ScenarioDocument.Type.TEST;
+        }
+        throw new ScenarioException("Unknown scenario '" + id
+                + "'. Available tests: " + tests.keySet()
+                + "; available suites: " + suites.keySet());
+    }
+
     public ScenarioDocument command(String id) {
         return commands.get(id);
     }
@@ -124,6 +163,10 @@ public final class ScenarioCatalog {
 
     public Map<String, ScenarioDocument> commands() {
         return commands;
+    }
+
+    public Map<String, ScenarioDocument> suites() {
+        return suites;
     }
 
     private static ScenarioDocument parse(Path root, Path path) {
@@ -151,12 +194,103 @@ public final class ScenarioCatalog {
         ScenarioDocument.Type type = switch (rawType) {
             case "test" -> ScenarioDocument.Type.TEST;
             case "command" -> ScenarioDocument.Type.COMMAND;
+            case "suite" -> ScenarioDocument.Type.SUITE;
             default -> throw new ScenarioException(source + ": unsupported frontmatter type '" + rawType + "'");
         };
 
+        if (type == ScenarioDocument.Type.SUITE) {
+            return parseSuite(id, name, body, source);
+        }
+        return parseTestOrCommand(id, name, type, body, source);
+    }
+
+    private static ScenarioDocument parseSuite(String id, String name, Map<String, Object> body, String source) {
+        if (body.containsKey("parameters")) {
+            throw new ScenarioException(source + ": suite documents may not declare parameters");
+        }
+        if (body.containsKey("steps")) {
+            throw new ScenarioException(source
+                    + ": suite documents may not declare steps; use before-all/before-each/after-each/after-all");
+        }
+        for (String key : body.keySet()) {
+            if (!SUITE_BODY_KEYS.contains(key)) {
+                throw new ScenarioException(source + ": unsupported suite body key '" + key + "'");
+            }
+        }
+
+        List<ScenarioDocument.Invocation> beforeAll = parseOptionalHook(body.get("before-all"), source, "before-all");
+        List<ScenarioDocument.Invocation> beforeEach = parseOptionalHook(body.get("before-each"), source, "before-each");
+        List<ScenarioDocument.Invocation> afterEach = parseOptionalHook(body.get("after-each"), source, "after-each");
+        List<ScenarioDocument.Invocation> afterAll = parseOptionalHook(body.get("after-all"), source, "after-all");
+        List<String> testIds = parseTestIds(body.get("tests"), source);
+        return new ScenarioDocument(
+                id,
+                name,
+                ScenarioDocument.Type.SUITE,
+                List.of(),
+                List.of(),
+                beforeAll,
+                beforeEach,
+                afterEach,
+                afterAll,
+                testIds,
+                source
+        );
+    }
+
+    private static ScenarioDocument parseTestOrCommand(
+            String id,
+            String name,
+            ScenarioDocument.Type type,
+            Map<String, Object> body,
+            String source
+    ) {
+        for (String key : body.keySet()) {
+            if (SUITE_BODY_KEYS.contains(key)) {
+                throw new ScenarioException(source + ": only suite documents may declare '" + key + "'");
+            }
+        }
+
         List<ScenarioDocument.Parameter> parameters = parseParameters(body.get("parameters"), source, type);
-        List<ScenarioDocument.Invocation> steps = parseSteps(body.get("steps"), source);
-        return new ScenarioDocument(id, name, type, parameters, steps, source);
+        List<ScenarioDocument.Invocation> steps = parseStepList(body.get("steps"), source, "steps");
+        return new ScenarioDocument(
+                id,
+                name,
+                type,
+                parameters,
+                steps,
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                source
+        );
+    }
+
+    private static List<ScenarioDocument.Invocation> parseOptionalHook(Object value, String source, String key) {
+        if (value == null) {
+            return List.of();
+        }
+        return parseStepList(value, source, key);
+    }
+
+    private static List<String> parseTestIds(Object value, String source) {
+        if (!(value instanceof List<?> values) || values.isEmpty()) {
+            throw new ScenarioException(source + ": 'tests' must be a non-empty list");
+        }
+        Set<String> seen = new LinkedHashSet<>();
+        List<String> testIds = new ArrayList<>();
+        for (Object entry : values) {
+            if (!(entry instanceof String testId) || testId.isBlank()) {
+                throw new ScenarioException(source + ": each suite test id must be a non-empty string");
+            }
+            if (!seen.add(testId)) {
+                throw new ScenarioException(source + ": duplicate suite test id '" + testId + "'");
+            }
+            testIds.add(testId);
+        }
+        return List.copyOf(testIds);
     }
 
     private static List<ScenarioDocument.Parameter> parseParameters(
@@ -191,19 +325,19 @@ public final class ScenarioCatalog {
         return List.copyOf(parameters);
     }
 
-    private static List<ScenarioDocument.Invocation> parseSteps(Object value, String source) {
+    private static List<ScenarioDocument.Invocation> parseStepList(Object value, String source, String field) {
         if (!(value instanceof List<?> values) || values.isEmpty()) {
-            throw new ScenarioException(source + ": 'steps' must be a non-empty list");
+            throw new ScenarioException(source + ": '" + field + "' must be a non-empty list");
         }
         List<ScenarioDocument.Invocation> steps = new ArrayList<>();
         for (Object entry : values) {
-            if (entry instanceof String name) {
-                steps.add(new ScenarioDocument.Invocation(name, Map.of()));
+            if (entry instanceof String stepName) {
+                steps.add(new ScenarioDocument.Invocation(stepName, Map.of()));
                 continue;
             }
-            Map<String, Object> invocation = requireMap(entry, source + " step");
+            Map<String, Object> invocation = requireMap(entry, source + " " + field + " step");
             if (invocation.size() != 1) {
-                throw new ScenarioException(source + ": each step must contain exactly one command");
+                throw new ScenarioException(source + ": each " + field + " step must contain exactly one command");
             }
             Map.Entry<String, Object> command = invocation.entrySet().iterator().next();
             steps.add(new ScenarioDocument.Invocation(

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCompiler.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCompiler.java
@@ -7,6 +7,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -27,6 +28,45 @@ public final class ScenarioCompiler {
         List<ScenarioPlan.Step> expanded = new ArrayList<>();
         expand(test.steps(), test.source(), Map.of(), new ArrayDeque<>(), expanded);
         return new ScenarioPlan(test.id(), test.name(), expanded);
+    }
+
+    public SuitePlan compileSuite(String suiteId) {
+        ScenarioDocument suite = catalog.requireSuite(suiteId);
+        List<ScenarioPlan.Step> beforeAll = expandHook(suite.beforeAll(), suite.source());
+        List<ScenarioPlan.Step> beforeEach = expandHook(suite.beforeEach(), suite.source());
+        List<ScenarioPlan.Step> afterEach = expandHook(suite.afterEach(), suite.source());
+        List<ScenarioPlan.Step> afterAll = expandHook(suite.afterAll(), suite.source());
+
+        Set<String> seen = new LinkedHashSet<>();
+        List<ScenarioPlan> members = new ArrayList<>();
+        for (String testId : suite.testIds()) {
+            if (!seen.add(testId)) {
+                throw new ScenarioException(suite.source() + ": duplicate suite test id '" + testId + "'");
+            }
+            if (catalog.suites().containsKey(testId)) {
+                throw new ScenarioException(suite.source()
+                        + ": suite member '" + testId + "' must be a test, not a suite");
+            }
+            if (catalog.command(testId) != null && !catalog.tests().containsKey(testId)) {
+                throw new ScenarioException(suite.source()
+                        + ": suite member '" + testId + "' must be a test, not a command");
+            }
+            if (!catalog.tests().containsKey(testId)) {
+                throw new ScenarioException(suite.source() + ": unknown suite test '" + testId
+                        + "'. Available tests: " + catalog.tests().keySet());
+            }
+            members.add(compile(testId));
+        }
+        return new SuitePlan(suite.id(), suite.name(), beforeAll, beforeEach, afterEach, afterAll, members);
+    }
+
+    private List<ScenarioPlan.Step> expandHook(List<ScenarioDocument.Invocation> invocations, String source) {
+        if (invocations.isEmpty()) {
+            return List.of();
+        }
+        List<ScenarioPlan.Step> expanded = new ArrayList<>();
+        expand(invocations, source, Map.of(), new ArrayDeque<>(), expanded);
+        return List.copyOf(expanded);
     }
 
     private void expand(

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioDocument.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioDocument.java
@@ -9,11 +9,27 @@ public record ScenarioDocument(
         Type type,
         List<Parameter> parameters,
         List<Invocation> steps,
+        List<Invocation> beforeAll,
+        List<Invocation> beforeEach,
+        List<Invocation> afterEach,
+        List<Invocation> afterAll,
+        List<String> testIds,
         String source
 ) {
+    public ScenarioDocument {
+        parameters = List.copyOf(parameters);
+        steps = List.copyOf(steps);
+        beforeAll = List.copyOf(beforeAll);
+        beforeEach = List.copyOf(beforeEach);
+        afterEach = List.copyOf(afterEach);
+        afterAll = List.copyOf(afterAll);
+        testIds = List.copyOf(testIds);
+    }
+
     public enum Type {
         TEST,
-        COMMAND
+        COMMAND,
+        SUITE
     }
 
     public record Parameter(String name, String type) {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioReportWriter.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioReportWriter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -21,23 +22,46 @@ final class ScenarioReportWriter {
     }
 
     void write(ScenarioPlan plan, List<StepResult> results, String failure, String diagnostics) {
-        try {
-            Files.createDirectories(reportFile.getParent());
-            Files.writeString(reportFile, xml(plan, results, failure), StandardCharsets.UTF_8);
-            Files.writeString(
-                    reportFile.resolveSibling("diagnostics.txt"),
-                    diagnostics == null || diagnostics.isBlank() ? "No diagnostics.\n" : diagnostics,
-                    StandardCharsets.UTF_8
-            );
-            Files.writeString(metricsFile(), metricsJson(plan, results, failure), StandardCharsets.UTF_8);
-        } catch (IOException exception) {
-            throw new ScenarioException("Could not write scenario report to " + reportFile, exception);
-        }
+        writeCases(
+                plan.id(),
+                plan.name(),
+                List.of(new CaseResult(plan.id(), plan.name(), results, failure)),
+                diagnostics,
+                false
+        );
+    }
+
+    void writeSuite(SuitePlan suite, List<CaseResult> cases, String diagnostics) {
+        writeCases(suite.id(), suite.name(), cases, diagnostics, true);
     }
 
     void writeBootstrapFailure(String scenarioId, Throwable failure) {
         ScenarioPlan plan = new ScenarioPlan(scenarioId, scenarioId, List.of());
         write(plan, List.of(), message(failure), message(failure) + "\n");
+    }
+
+    private void writeCases(
+            String id,
+            String name,
+            List<CaseResult> cases,
+            String diagnostics,
+            boolean suite
+    ) {
+        try {
+            Files.createDirectories(reportFile.getParent());
+            Files.writeString(reportFile, xml(name, cases), StandardCharsets.UTF_8);
+            Files.writeString(
+                    reportFile.resolveSibling("diagnostics.txt"),
+                    diagnostics == null || diagnostics.isBlank() ? "No diagnostics.\n" : diagnostics,
+                    StandardCharsets.UTF_8
+            );
+            String metrics = suite
+                    ? suiteMetricsJson(id, name, cases)
+                    : metricsJson(new ScenarioPlan(id, name, List.of()), cases.getFirst().steps(), cases.getFirst().failure());
+            Files.writeString(metricsFile(), metrics, StandardCharsets.UTF_8);
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not write scenario report to " + reportFile, exception);
+        }
     }
 
     static String metricsJson(ScenarioPlan plan, List<StepResult> results, String failure) {
@@ -50,22 +74,71 @@ final class ScenarioReportWriter {
                 .append("  \"passed\": ").append(failure == null).append(",\n")
                 .append("  \"totalMs\": ").append(formatMs(totalNanos)).append(",\n")
                 .append("  \"steps\": [");
+        appendStepsJson(json, results, "    ");
+        json.append("]\n}\n");
+        return json.toString();
+    }
+
+    static String suiteMetricsJson(SuitePlan suite, List<CaseResult> cases) {
+        return suiteMetricsJson(suite.id(), suite.name(), cases);
+    }
+
+    static String suiteMetricsJson(String id, String name, List<CaseResult> cases) {
+        List<StepResult> flattened = new ArrayList<>();
+        for (CaseResult result : cases) {
+            flattened.addAll(result.steps());
+        }
+        long totalNanos = flattened.stream().mapToLong(StepResult::durationNanos).sum();
+        boolean passed = cases.stream().allMatch(result -> result.failure() == null);
+        StringBuilder json = new StringBuilder();
+        json.append("{\n")
+                .append("  \"schemaVersion\": ").append(METRICS_SCHEMA_VERSION).append(",\n")
+                .append("  \"scenarioId\": ").append(jsonString(id)).append(",\n")
+                .append("  \"scenarioName\": ").append(jsonString(name)).append(",\n")
+                .append("  \"suite\": true,\n")
+                .append("  \"passed\": ").append(passed).append(",\n")
+                .append("  \"totalMs\": ").append(formatMs(totalNanos)).append(",\n")
+                .append("  \"cases\": [");
+        for (int i = 0; i < cases.size(); i++) {
+            CaseResult result = cases.get(i);
+            long caseNanos = result.steps().stream().mapToLong(StepResult::durationNanos).sum();
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("\n    {\n")
+                    .append("      \"id\": ").append(jsonString(result.id())).append(",\n")
+                    .append("      \"name\": ").append(jsonString(result.name())).append(",\n")
+                    .append("      \"passed\": ").append(result.failure() == null).append(",\n")
+                    .append("      \"totalMs\": ").append(formatMs(caseNanos)).append(",\n")
+                    .append("      \"steps\": [");
+            appendStepsJson(json, result.steps(), "        ");
+            json.append("]\n    }");
+        }
+        if (!cases.isEmpty()) {
+            json.append('\n').append("  ");
+        }
+        json.append("],\n")
+                .append("  \"steps\": [");
+        appendStepsJson(json, flattened, "    ");
+        json.append("]\n}\n");
+        return json.toString();
+    }
+
+    private static void appendStepsJson(StringBuilder json, List<StepResult> results, String indent) {
         for (int i = 0; i < results.size(); i++) {
             StepResult result = results.get(i);
             if (i > 0) {
                 json.append(',');
             }
-            json.append("\n    {")
+            json.append('\n').append(indent).append('{')
                     .append("\"name\": ").append(jsonString(result.name())).append(", ")
                     .append("\"ms\": ").append(formatMs(result.durationNanos())).append(", ")
                     .append("\"passed\": ").append(result.passed())
                     .append('}');
         }
         if (!results.isEmpty()) {
-            json.append('\n').append("  ");
+            json.append('\n').append(indent, 0, Math.max(0, indent.length() - 2));
         }
-        json.append("]\n}\n");
-        return json.toString();
     }
 
     private static String formatMs(long durationNanos) {
@@ -95,34 +168,49 @@ final class ScenarioReportWriter {
         return escaped.toString();
     }
 
-    private static String xml(ScenarioPlan plan, List<StepResult> results, String failure) {
-        int failureCount = failure == null ? 0 : 1;
-        double duration = results.stream().mapToLong(StepResult::durationNanos).sum() / 1_000_000_000.0;
+    private static String xml(String suiteName, List<CaseResult> cases) {
+        int failureCount = (int) cases.stream().filter(result -> result.failure() != null).count();
+        double duration = cases.stream()
+                .flatMap(result -> result.steps().stream())
+                .mapToLong(StepResult::durationNanos)
+                .sum() / 1_000_000_000.0;
         StringBuilder xml = new StringBuilder();
         xml.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-                .append("<testsuite name=\"").append(escape(plan.name())).append("\" tests=\"1\" failures=\"")
-                .append(failureCount).append("\" time=\"").append(String.format(Locale.ROOT, "%.3f", duration))
-                .append("\">\n")
-                .append("  <testcase classname=\"screenplay\" name=\"").append(escape(plan.id()))
-                .append("\" time=\"").append(String.format(Locale.ROOT, "%.3f", duration)).append("\">");
-        if (failure != null) {
-            xml.append("\n    <failure message=\"").append(escape(failure)).append("\">")
-                    .append(escape(failure)).append("</failure>\n  ");
+                .append("<testsuite name=\"").append(escape(suiteName)).append("\" tests=\"")
+                .append(cases.size()).append("\" failures=\"")
+                .append(failureCount).append("\" time=\"")
+                .append(String.format(Locale.ROOT, "%.3f", duration))
+                .append("\">\n");
+        for (CaseResult result : cases) {
+            double caseDuration = result.steps().stream().mapToLong(StepResult::durationNanos).sum()
+                    / 1_000_000_000.0;
+            xml.append("  <testcase classname=\"screenplay\" name=\"").append(escape(result.id()))
+                    .append("\" time=\"").append(String.format(Locale.ROOT, "%.3f", caseDuration)).append("\">");
+            if (result.failure() != null) {
+                xml.append("\n    <failure message=\"").append(escape(result.failure())).append("\">")
+                        .append(escape(result.failure())).append("</failure>\n  ");
+            }
+            xml.append("</testcase>\n");
         }
-        xml.append("</testcase>\n")
-                .append("  <system-out>").append(escape(stepSummary(results))).append("</system-out>\n")
+        xml.append("  <system-out>").append(escape(stepSummary(cases))).append("</system-out>\n")
                 .append("</testsuite>\n");
         return xml.toString();
     }
 
-    private static String stepSummary(List<StepResult> results) {
+    private static String stepSummary(List<CaseResult> cases) {
         StringBuilder summary = new StringBuilder();
-        for (StepResult result : results) {
-            summary.append(result.passed() ? "PASS " : "FAIL ")
-                    .append(result.name())
-                    .append(" (")
-                    .append(String.format(Locale.ROOT, "%.3fs", result.durationNanos() / 1_000_000_000.0))
-                    .append(")\n");
+        for (CaseResult result : cases) {
+            summary.append('[').append(result.id()).append("]\n");
+            for (StepResult step : result.steps()) {
+                summary.append(step.passed() ? "PASS " : "FAIL ")
+                        .append(step.name())
+                        .append(" (")
+                        .append(String.format(Locale.ROOT, "%.3fs", step.durationNanos() / 1_000_000_000.0))
+                        .append(")\n");
+            }
+            if (result.failure() != null) {
+                summary.append("FAIL ").append(result.failure()).append('\n');
+            }
         }
         return summary.toString();
     }
@@ -140,5 +228,11 @@ final class ScenarioReportWriter {
     }
 
     record StepResult(String name, long durationNanos, boolean passed) {
+    }
+
+    record CaseResult(String id, String name, List<StepResult> steps, String failure) {
+        CaseResult {
+            steps = List.copyOf(steps);
+        }
     }
 }

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioRunner.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioRunner.java
@@ -12,7 +12,18 @@ import java.util.ArrayList;
 import java.util.List;
 
 final class ScenarioRunner {
-    private final ScenarioPlan plan;
+    private enum Phase {
+        BEFORE_ALL,
+        BEFORE_EACH,
+        TEST,
+        AFTER_EACH,
+        AFTER_ALL,
+        DONE
+    }
+
+    private final ScenarioPlan singlePlan;
+    private final SuitePlan suite;
+    private final boolean isSuite;
     private final ScenarioReportWriter reportWriter;
     private final Duration stepTimeout;
     private final WidgetFinder widgetFinder = new WidgetFinder();
@@ -20,12 +31,21 @@ final class ScenarioRunner {
     private final VanillaServerProcess vanillaServer;
     private final CreateWorldProcess createWorld;
     private final Logger logger;
-    private final List<ScenarioReportWriter.StepResult> results = new ArrayList<>();
 
+    private final List<ScenarioReportWriter.CaseResult> cases = new ArrayList<>();
+    private List<ScenarioReportWriter.StepResult> currentSteps = new ArrayList<>();
+    private String currentCaseId;
+    private String currentCaseName;
+    private String currentFailure;
+
+    private Phase phase;
+    private int memberIndex;
     private int stepIndex;
     private long stepStartedNanos;
     private boolean finished;
     private boolean executing;
+    private boolean abortRemaining;
+    private RuntimeException firstFailure;
 
     ScenarioRunner(
             ScenarioPlan plan,
@@ -33,28 +53,62 @@ final class ScenarioRunner {
             Duration stepTimeout,
             Logger logger
     ) {
-        this.plan = plan;
+        this.singlePlan = plan;
+        this.suite = null;
+        this.isSuite = false;
         this.reportWriter = reportWriter;
         this.stepTimeout = stepTimeout;
         this.logger = logger;
         this.screenshotCapture = new ScreenshotCapture(logger);
         this.vanillaServer = new VanillaServerProcess(logger);
         this.createWorld = new CreateWorldProcess(logger);
+        this.phase = Phase.TEST;
+        beginCase(plan.id());
+    }
+
+    ScenarioRunner(
+            SuitePlan suite,
+            ScenarioReportWriter reportWriter,
+            Duration stepTimeout,
+            Logger logger
+    ) {
+        this.singlePlan = null;
+        this.suite = suite;
+        this.isSuite = true;
+        this.reportWriter = reportWriter;
+        this.stepTimeout = stepTimeout;
+        this.logger = logger;
+        this.screenshotCapture = new ScreenshotCapture(logger);
+        this.vanillaServer = new VanillaServerProcess(logger);
+        this.createWorld = new CreateWorldProcess(logger);
+        this.memberIndex = 0;
+        if (!suite.beforeAll().isEmpty()) {
+            this.phase = Phase.BEFORE_ALL;
+            beginCase("before-all");
+        } else if (!suite.beforeEach().isEmpty()) {
+            this.phase = Phase.BEFORE_EACH;
+            beginCase(suite.tests().getFirst().id());
+        } else {
+            this.phase = Phase.TEST;
+            beginCase(suite.tests().getFirst().id());
+        }
     }
 
     void tick(Minecraft client) {
-        if (finished || executing) {
-            return;
-        }
-        if (stepIndex >= plan.steps().size()) {
-            finish(client, null);
+        if (finished || executing || phase == Phase.DONE) {
             return;
         }
 
-        ScenarioPlan.Step step = plan.steps().get(stepIndex);
+        List<ScenarioPlan.Step> steps = currentPhaseSteps();
+        if (stepIndex >= steps.size()) {
+            onPhaseComplete(client);
+            return;
+        }
+
+        ScenarioPlan.Step step = steps.get(stepIndex);
         if (stepStartedNanos == 0L) {
             stepStartedNanos = System.nanoTime();
-            logger.info("Scenario step {}/{}: {}", stepIndex + 1, plan.steps().size(), step.displayName());
+            logger.info("{} step {}/{}: {}", phaseLabel(), stepIndex + 1, steps.size(), step.displayName());
         }
 
         try {
@@ -62,7 +116,7 @@ final class ScenarioRunner {
             boolean completed = execute(step, client);
             executing = false;
             if (completed) {
-                results.add(new ScenarioReportWriter.StepResult(
+                currentSteps.add(new ScenarioReportWriter.StepResult(
                         step.displayName(),
                         System.nanoTime() - stepStartedNanos,
                         true
@@ -78,13 +132,165 @@ final class ScenarioRunner {
             }
         } catch (RuntimeException exception) {
             executing = false;
-            results.add(new ScenarioReportWriter.StepResult(
+            currentSteps.add(new ScenarioReportWriter.StepResult(
                     step.displayName(),
                     System.nanoTime() - stepStartedNanos,
                     false
             ));
-            finish(client, exception);
+            onFailure(client, exception);
         }
+    }
+
+    private void onPhaseComplete(Minecraft client) {
+        switch (phase) {
+            case BEFORE_ALL -> {
+                finishCase();
+                memberIndex = 0;
+                startMember();
+            }
+            case BEFORE_EACH -> {
+                phase = Phase.TEST;
+                stepIndex = 0;
+                stepStartedNanos = 0L;
+            }
+            case TEST -> {
+                if (!isSuite) {
+                    finishCase();
+                    finish(client);
+                    return;
+                }
+                if (!suite.afterEach().isEmpty()) {
+                    phase = Phase.AFTER_EACH;
+                    stepIndex = 0;
+                    stepStartedNanos = 0L;
+                } else {
+                    finishCase();
+                    advanceAfterMember(client);
+                }
+            }
+            case AFTER_EACH -> {
+                finishCase();
+                advanceAfterMember(client);
+            }
+            case AFTER_ALL -> {
+                finishCase();
+                finish(client);
+            }
+            case DONE -> {
+            }
+        }
+    }
+
+    private void onFailure(Minecraft client, RuntimeException exception) {
+        String failureMessage = failureMessage(exception);
+        if (currentFailure == null) {
+            currentFailure = failurePrefix() + failureMessage;
+        }
+        if (firstFailure == null) {
+            firstFailure = exception;
+        }
+
+        if (!isSuite) {
+            finishCase();
+            finish(client);
+            return;
+        }
+
+        switch (phase) {
+            case BEFORE_ALL -> {
+                finishCase();
+                goAfterAll(client);
+            }
+            case BEFORE_EACH, TEST -> {
+                abortRemaining = true;
+                if (!suite.afterEach().isEmpty()) {
+                    phase = Phase.AFTER_EACH;
+                    stepIndex = 0;
+                    stepStartedNanos = 0L;
+                } else {
+                    finishCase();
+                    advanceAfterMember(client);
+                }
+            }
+            case AFTER_EACH -> {
+                abortRemaining = true;
+                finishCase();
+                advanceAfterMember(client);
+            }
+            case AFTER_ALL -> {
+                finishCase();
+                finish(client);
+            }
+            case DONE -> {
+            }
+        }
+    }
+
+    private void startMember() {
+        ScenarioPlan member = suite.tests().get(memberIndex);
+        beginCase(member.id());
+        if (!suite.beforeEach().isEmpty()) {
+            phase = Phase.BEFORE_EACH;
+        } else {
+            phase = Phase.TEST;
+        }
+        stepIndex = 0;
+        stepStartedNanos = 0L;
+    }
+
+    private void advanceAfterMember(Minecraft client) {
+        if (abortRemaining || memberIndex + 1 >= suite.tests().size()) {
+            goAfterAll(client);
+            return;
+        }
+        memberIndex++;
+        startMember();
+    }
+
+    private void goAfterAll(Minecraft client) {
+        if (!suite.afterAll().isEmpty()) {
+            phase = Phase.AFTER_ALL;
+            beginCase("after-all");
+        } else {
+            finish(client);
+        }
+    }
+
+    private void beginCase(String id) {
+        currentCaseId = id;
+        if (!isSuite) {
+            currentCaseName = singlePlan.name();
+        } else if ("before-all".equals(id) || "after-all".equals(id)) {
+            currentCaseName = id;
+        } else {
+            currentCaseName = suite.tests().get(memberIndex).name();
+        }
+        currentSteps = new ArrayList<>();
+        currentFailure = null;
+        stepIndex = 0;
+        stepStartedNanos = 0L;
+    }
+
+    private void finishCase() {
+        cases.add(new ScenarioReportWriter.CaseResult(
+                currentCaseId,
+                currentCaseName,
+                currentSteps,
+                currentFailure
+        ));
+        currentSteps = new ArrayList<>();
+        currentFailure = null;
+    }
+
+    private List<ScenarioPlan.Step> currentPhaseSteps() {
+        return switch (phase) {
+            case BEFORE_ALL -> suite.beforeAll();
+            case BEFORE_EACH -> suite.beforeEach();
+            case TEST -> isSuite ? suite.tests().get(memberIndex).steps() : singlePlan.steps();
+            case AFTER_EACH -> suite.afterEach();
+            case AFTER_ALL -> suite.afterAll();
+            case DONE -> List.of();
+        };
     }
 
     private boolean execute(ScenarioPlan.Step step, Minecraft client) {
@@ -101,34 +307,87 @@ final class ScenarioRunner {
         return primitive == null ? stepTimeout : primitive.timeout(stepTimeout);
     }
 
-    private void finish(Minecraft client, RuntimeException failure) {
+    private void finish(Minecraft client) {
         finished = true;
+        phase = Phase.DONE;
         vanillaServer.stop();
-        String failureMessage = failure == null ? null
-                : failure.getMessage() == null ? failure.getClass().getName() : failure.getMessage();
+        String failureMessage = firstFailure == null ? null
+                : firstFailure.getMessage() == null
+                ? firstFailure.getClass().getName()
+                : firstFailure.getMessage();
         String diagnostics = diagnostics(client, failureMessage);
         try {
-            reportWriter.write(plan, results, failureMessage, diagnostics);
+            if (isSuite) {
+                reportWriter.writeSuite(suite, cases, diagnostics);
+            } else {
+                ScenarioReportWriter.CaseResult only = cases.getFirst();
+                reportWriter.write(singlePlan, only.steps(), only.failure(), diagnostics);
+            }
         } catch (RuntimeException reportFailure) {
             logger.error("Could not write scenario report", reportFailure);
-            if (failure == null) {
-                failure = reportFailure;
+            if (firstFailure == null) {
+                firstFailure = reportFailure;
             }
         }
 
-        int exitCode = failure == null ? 0 : 1;
-        if (failure == null) {
-            logger.info("Scenario '{}' passed ({} steps)", plan.id(), results.size());
+        int exitCode = firstFailure == null && cases.stream().allMatch(result -> result.failure() == null)
+                ? 0 : 1;
+        if (exitCode == 0) {
+            if (isSuite) {
+                logger.info("Suite '{}' passed ({} cases)", suite.id(), cases.size());
+            } else {
+                logger.info("Scenario '{}' passed ({} steps)", singlePlan.id(), cases.getFirst().steps().size());
+            }
+        } else if (isSuite) {
+            logger.error("Suite '{}' failed: {}", suite.id(), failureMessage, firstFailure);
         } else {
-            logger.error("Scenario '{}' failed: {}", plan.id(), failureMessage, failure);
+            logger.error("Scenario '{}' failed: {}", singlePlan.id(), failureMessage, firstFailure);
         }
         System.exit(exitCode);
     }
 
+    private String failurePrefix() {
+        if (!isSuite) {
+            return "";
+        }
+        return switch (phase) {
+            case BEFORE_ALL -> "before-all: ";
+            case BEFORE_EACH -> "before-each: ";
+            case AFTER_EACH -> "after-each: ";
+            case AFTER_ALL -> "after-all: ";
+            case TEST, DONE -> "";
+        };
+    }
+
+    private String failureMessage(RuntimeException failure) {
+        return failure.getMessage() == null ? failure.getClass().getName() : failure.getMessage();
+    }
+
+    private String phaseLabel() {
+        if (!isSuite) {
+            return "Scenario";
+        }
+        return switch (phase) {
+            case BEFORE_ALL -> "Suite before-all";
+            case BEFORE_EACH -> "Suite before-each [" + currentCaseId + "]";
+            case TEST -> "Suite test [" + currentCaseId + "]";
+            case AFTER_EACH -> "Suite after-each [" + currentCaseId + "]";
+            case AFTER_ALL -> "Suite after-all";
+            case DONE -> "Suite";
+        };
+    }
+
     private String diagnostics(Minecraft client, String failure) {
         StringBuilder diagnostics = new StringBuilder();
-        diagnostics.append("scenario: ").append(plan.id()).append('\n');
-        diagnostics.append("completedSteps: ").append(stepIndex).append('/').append(plan.steps().size()).append('\n');
+        if (isSuite) {
+            diagnostics.append("suite: ").append(suite.id()).append('\n');
+            diagnostics.append("phase: ").append(phase).append('\n');
+            diagnostics.append("member: ").append(currentCaseId == null ? "<none>" : currentCaseId).append('\n');
+        } else {
+            diagnostics.append("scenario: ").append(singlePlan.id()).append('\n');
+            diagnostics.append("completedSteps: ").append(stepIndex).append('/')
+                    .append(singlePlan.steps().size()).append('\n');
+        }
         Screen screen = client.gui.screen();
         diagnostics.append("screen: ")
                 .append(screen == null ? "<none>" : screen.getClass().getName())

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenplayBootstrap.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenplayBootstrap.java
@@ -32,11 +32,27 @@ public final class ScreenplayBootstrap {
         ));
         try {
             ScenarioCatalog catalog = ScenarioCatalog.loadFromResources(ScreenplayBootstrap.class.getClassLoader());
-            ScenarioPlan plan = new ScenarioCompiler(catalog).compile(scenarioId);
             Duration timeout = Duration.ofSeconds(readPositiveLong(TIMEOUT_PROPERTY, 30L));
-            ScenarioRunner runner = new ScenarioRunner(plan, reportWriter, timeout, LOGGER);
-            platform.registerEndClientTick(runner::tick);
-            LOGGER.info("Loaded scenario '{}' with {} primitive steps", plan.id(), plan.steps().size());
+            ScenarioDocument.Type type = catalog.resolveExecutableType(scenarioId);
+            if (type == ScenarioDocument.Type.SUITE) {
+                SuitePlan suite = new ScenarioCompiler(catalog).compileSuite(scenarioId);
+                ScenarioRunner runner = new ScenarioRunner(suite, reportWriter, timeout, LOGGER);
+                platform.registerEndClientTick(runner::tick);
+                LOGGER.info(
+                        "Loaded suite '{}' with {} tests (before-all={}, before-each={}, after-each={}, after-all={})",
+                        suite.id(),
+                        suite.tests().size(),
+                        suite.beforeAll().size(),
+                        suite.beforeEach().size(),
+                        suite.afterEach().size(),
+                        suite.afterAll().size()
+                );
+            } else {
+                ScenarioPlan plan = new ScenarioCompiler(catalog).compile(scenarioId);
+                ScenarioRunner runner = new ScenarioRunner(plan, reportWriter, timeout, LOGGER);
+                platform.registerEndClientTick(runner::tick);
+                LOGGER.info("Loaded scenario '{}' with {} primitive steps", plan.id(), plan.steps().size());
+            }
         } catch (RuntimeException exception) {
             LOGGER.error("Could not start scenario '{}'", scenarioId, exception);
             try {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/SuitePlan.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/SuitePlan.java
@@ -1,0 +1,21 @@
+package com.adamkali.screenplay;
+
+import java.util.List;
+
+public record SuitePlan(
+        String id,
+        String name,
+        List<ScenarioPlan.Step> beforeAll,
+        List<ScenarioPlan.Step> beforeEach,
+        List<ScenarioPlan.Step> afterEach,
+        List<ScenarioPlan.Step> afterAll,
+        List<ScenarioPlan> tests
+) {
+    public SuitePlan {
+        beforeAll = List.copyOf(beforeAll);
+        beforeEach = List.copyOf(beforeEach);
+        afterEach = List.copyOf(afterEach);
+        afterAll = List.copyOf(afterAll);
+        tests = List.copyOf(tests);
+    }
+}

--- a/screenplay/common/src/main/resources/tests/creativeWorldSuite.yaml
+++ b/screenplay/common/src/main/resources/tests/creativeWorldSuite.yaml
@@ -1,0 +1,20 @@
+---
+name: Creative World Suite
+type: suite
+---
+before-all:
+  - launchGame
+  - createWorld:
+      worldType: superflat
+      gameMode: creative
+  - closeScreen
+before-each:
+  - runCommand: "/time set day"
+after-each:
+  - closeScreen
+after-all:
+  - captureScreenshot:
+      name: suite-end
+tests:
+  - suitePlaceDirt
+  - suiteCaptureInventory

--- a/screenplay/common/src/main/resources/tests/suiteMembers/suiteCaptureInventory.yaml
+++ b/screenplay/common/src/main/resources/tests/suiteMembers/suiteCaptureInventory.yaml
@@ -1,0 +1,8 @@
+---
+name: Suite Capture Inventory
+type: test
+---
+steps:
+  - openInventory
+  - captureScreenshot:
+      name: suite-inventory

--- a/screenplay/common/src/main/resources/tests/suiteMembers/suitePlaceDirt.yaml
+++ b/screenplay/common/src/main/resources/tests/suiteMembers/suitePlaceDirt.yaml
@@ -1,0 +1,22 @@
+---
+name: Suite Place Dirt
+type: test
+---
+steps:
+  - runCommand: "/give @s minecraft:dirt"
+  - waitUntil:
+      holding: minecraft:dirt
+  - selectHotbar: 0
+  - lookAt:
+      x: "~1"
+      y: "~-1"
+      z: "~"
+  - useItem
+  - waitUntil:
+      block:
+        id: minecraft:dirt
+        x: "~1"
+        y: "~"
+        z: "~"
+  - captureScreenshot:
+      name: suite-placed-dirt

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
@@ -50,11 +50,11 @@ class ScenarioCompilerTest {
     }
 
     @Test
-    void rejectsUnsupportedFrontmatterType(@TempDir Path root) throws Exception {
+    void rejectsUnknownFrontmatterType(@TempDir Path root) throws Exception {
         write(root.resolve("invalid.yaml"), """
                 ---
                 name: Invalid
-                type: suite
+                type: fixture
                 ---
                 steps:
                   - launchGame
@@ -62,7 +62,201 @@ class ScenarioCompilerTest {
 
         ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
 
-        assertTrue(exception.getMessage().contains("unsupported frontmatter type 'suite'"));
+        assertTrue(exception.getMessage().contains("unsupported frontmatter type 'fixture'"));
+    }
+
+    @Test
+    void compilesSuiteHooksAndMembers(@TempDir Path root) throws Exception {
+        write(root.resolve("memberA.yaml"), """
+                ---
+                name: Member A
+                type: test
+                ---
+                steps:
+                  - waitTicks: 1
+                """);
+        write(root.resolve("memberB.yaml"), """
+                ---
+                name: Member B
+                type: test
+                ---
+                steps:
+                  - waitTicks: 2
+                """);
+        write(root.resolve("shared.yaml"), """
+                ---
+                name: Shared
+                type: command
+                ---
+                steps:
+                  - launchGame
+                """);
+        write(root.resolve("worldSuite.yaml"), """
+                ---
+                name: World Suite
+                type: suite
+                ---
+                before-all:
+                  - shared
+                  - createWorld:
+                      worldType: superflat
+                      gameMode: creative
+                before-each:
+                  - runCommand: "/time set day"
+                after-each:
+                  - closeScreen
+                after-all:
+                  - captureScreenshot:
+                      name: suite-end
+                tests:
+                  - memberA
+                  - memberB
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        SuitePlan suite = new ScenarioCompiler(catalog).compileSuite("worldSuite");
+
+        assertEquals(1, catalog.suites().size());
+        assertEquals("World Suite", suite.name());
+        assertEquals(2, suite.beforeAll().size());
+        assertEquals("launchGame", suite.beforeAll().get(0).name());
+        assertEquals("createWorld", suite.beforeAll().get(1).name());
+        assertEquals(1, suite.beforeEach().size());
+        assertEquals("runCommand", suite.beforeEach().get(0).name());
+        assertEquals(1, suite.afterEach().size());
+        assertEquals("closeScreen", suite.afterEach().get(0).name());
+        assertEquals(1, suite.afterAll().size());
+        assertEquals("suite-end.png", suite.afterAll().get(0).arguments().get("name"));
+        assertEquals(2, suite.tests().size());
+        assertEquals("memberA", suite.tests().get(0).id());
+        assertEquals(1, suite.tests().get(0).steps().size());
+        assertEquals(2, suite.tests().get(1).steps().get(0).arguments().get("ticks"));
+    }
+
+    @Test
+    void compilesBundledCreativeWorldSuite() throws Exception {
+        Path scenarioRoot = Path.of(getClass().getResource("/tests").toURI());
+
+        SuitePlan suite = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot)).compileSuite("creativeWorldSuite");
+
+        assertEquals("Creative World Suite", suite.name());
+        assertFalse(suite.beforeAll().isEmpty());
+        assertEquals("launchGame", suite.beforeAll().getFirst().name());
+        assertEquals(2, suite.tests().size());
+        assertEquals("suitePlaceDirt", suite.tests().get(0).id());
+        assertEquals("suiteCaptureInventory", suite.tests().get(1).id());
+        assertEquals("closeScreen", suite.afterEach().getFirst().name());
+        assertEquals("suite-end.png", suite.afterAll().getFirst().arguments().get("name"));
+    }
+
+    @Test
+    void rejectsSuiteWithStepsBody(@TempDir Path root) throws Exception {
+        write(root.resolve("invalid.yaml"), """
+                ---
+                name: Invalid
+                type: suite
+                ---
+                steps:
+                  - launchGame
+                tests:
+                  - member
+                """);
+
+        ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
+
+        assertTrue(exception.getMessage().contains("may not declare steps"));
+    }
+
+    @Test
+    void rejectsSuiteSetupAlias(@TempDir Path root) throws Exception {
+        write(root.resolve("invalid.yaml"), """
+                ---
+                name: Invalid
+                type: suite
+                ---
+                setup:
+                  - launchGame
+                tests:
+                  - member
+                """);
+
+        ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
+
+        assertTrue(exception.getMessage().contains("unsupported suite body key 'setup'"));
+    }
+
+    @Test
+    void rejectsUnknownSuiteMember(@TempDir Path root) throws Exception {
+        write(root.resolve("member.yaml"), """
+                ---
+                name: Member
+                type: test
+                ---
+                steps:
+                  - launchGame
+                """);
+        write(root.resolve("worldSuite.yaml"), """
+                ---
+                name: World Suite
+                type: suite
+                ---
+                tests:
+                  - missingMember
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compileSuite("worldSuite")
+        );
+
+        assertTrue(exception.getMessage().contains("unknown suite test 'missingMember'"));
+    }
+
+    @Test
+    void rejectsSuiteMemberThatIsCommand(@TempDir Path root) throws Exception {
+        write(root.resolve("shared.yaml"), """
+                ---
+                name: Shared
+                type: command
+                ---
+                steps:
+                  - launchGame
+                """);
+        write(root.resolve("worldSuite.yaml"), """
+                ---
+                name: World Suite
+                type: suite
+                ---
+                tests:
+                  - shared
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        ScenarioException exception = assertThrows(
+                ScenarioException.class,
+                () -> new ScenarioCompiler(catalog).compileSuite("worldSuite")
+        );
+
+        assertTrue(exception.getMessage().contains("must be a test, not a command"));
+    }
+
+    @Test
+    void rejectsHookKeysOnTestDocuments(@TempDir Path root) throws Exception {
+        write(root.resolve("test.yaml"), """
+                ---
+                name: Test
+                type: test
+                ---
+                before-all:
+                  - launchGame
+                steps:
+                  - waitTicks: 1
+                """);
+
+        ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
+
+        assertTrue(exception.getMessage().contains("only suite documents may declare 'before-all'"));
     }
 
     @Test

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioReportWriterTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioReportWriterTest.java
@@ -67,6 +67,59 @@ class ScenarioReportWriterTest {
     }
 
     @Test
+    void writeSuite_emitsMultiCaseXmlAndSuiteMetrics() throws Exception {
+        Path reportFile = tempDir.resolve("report.xml");
+        ScenarioReportWriter writer = new ScenarioReportWriter(reportFile);
+        SuitePlan suite = new SuitePlan(
+                "worldSuite",
+                "World Suite",
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(new ScenarioPlan("memberA", "Member A", List.of()))
+        );
+        List<ScenarioReportWriter.CaseResult> cases = List.of(
+                new ScenarioReportWriter.CaseResult(
+                        "before-all",
+                        "before-all",
+                        List.of(new ScenarioReportWriter.StepResult("launchGame", 10_000_000L, true)),
+                        null
+                ),
+                new ScenarioReportWriter.CaseResult(
+                        "memberA",
+                        "Member A",
+                        List.of(new ScenarioReportWriter.StepResult("waitTicks \"1\"", 5_000_000L, false)),
+                        "before-each: boom"
+                ),
+                new ScenarioReportWriter.CaseResult(
+                        "after-all",
+                        "after-all",
+                        List.of(),
+                        null
+                )
+        );
+
+        writer.writeSuite(suite, cases, "suite: worldSuite\n");
+
+        String xml = Files.readString(reportFile);
+        assertTrue(xml.contains("tests=\"3\""));
+        assertTrue(xml.contains("failures=\"1\""));
+        assertTrue(xml.contains("name=\"before-all\""));
+        assertTrue(xml.contains("name=\"memberA\""));
+        assertTrue(xml.contains("before-each: boom"));
+
+        JSONObject metrics = new JSONObject(Files.readString(writer.metricsFile()));
+        assertTrue(metrics.getBoolean("suite"));
+        assertEquals("worldSuite", metrics.getString("scenarioId"));
+        assertFalse(metrics.getBoolean("passed"));
+        assertEquals(3, metrics.getJSONArray("cases").length());
+        assertEquals("memberA", metrics.getJSONArray("cases").getJSONObject(1).getString("id"));
+        assertFalse(metrics.getJSONArray("cases").getJSONObject(1).getBoolean("passed"));
+        assertEquals(2, metrics.getJSONArray("steps").length());
+    }
+
+    @Test
     void write_emitsMetricsBesideReport() throws Exception {
         Path reportFile = tempDir.resolve("report.xml");
         ScenarioReportWriter writer = new ScenarioReportWriter(reportFile);

--- a/screenplay/docs/docs/reference/gradle-plugin.md
+++ b/screenplay/docs/docs/reference/gradle-plugin.md
@@ -29,8 +29,11 @@ screenplay {
 
 | Task | Purpose |
 | --- | --- |
-| `runScreenplay` | Run one scenario (`-Pscreenplay=<id>` required) |
-| `runScreenplayTests` | Discover and run every `type: test` YAML |
+| `runScreenplay` | Run one scenario or suite (`-Pscreenplay=<id>` required) |
+| `runScreenplayTests` | Discover and run every suite plus standalone `type: test` YAML |
+
+Suite member tests listed under a discovered suite's `tests:` key are not also
+run standalone.
 
 ## Gradle properties
 

--- a/screenplay/docs/docs/running-tests.md
+++ b/screenplay/docs/docs/running-tests.md
@@ -1,25 +1,29 @@
 # Running tests
 
-## Single scenario
+## Single scenario or suite
 
-Run a test by its YAML filename without the extension:
+Run a test or suite by its YAML filename without the extension:
 
 ```bash
 ./screenplay/gradlew runScreenplay -Pscreenplay=createWorld
+./screenplay/gradlew runScreenplay -Pscreenplay=creativeWorldSuite
 ```
 
 ## All scenarios
 
-Discover every `type: test` YAML under configured tests roots and run each one
-(fresh client per scenario):
+Discover every `type: suite` and standalone `type: test` YAML under configured
+tests roots. Suites run in one client session; standalone tests still get a
+fresh client each:
 
 ```bash
 ./screenplay/gradlew runScreenplayTests
 ./screenplay/gradlew runScreenplayTests -PscreenplayDisplay=xvfb -PscreenplayTimeout=120
 ```
 
-`runScreenplayTests` skips `type: command` documents, continues after individual
-failures, and fails the aggregate with the list of failed scenario IDs.
+`runScreenplayTests` skips `type: command` documents and skips `type: test`
+IDs that are listed as members of a discovered suite (those run only via the
+suite). It continues after individual failures and fails the aggregate with
+the list of failed IDs.
 
 ## Isolated run directory
 

--- a/screenplay/docs/docs/writing-scenarios.md
+++ b/screenplay/docs/docs/writing-scenarios.md
@@ -19,10 +19,64 @@ steps:
 | --- | --- |
 | `test` | Executable scenario selected with `-Pscreenplay=<id>` |
 | `command` | Reusable composite command invoked by filename stem |
+| `suite` | One-client group of tests with shared hooks |
 
 The **filename stem** is the stable ID. For example,
-`subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test or
-command IDs are rejected even when files live in different directories.
+`subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test,
+command, or suite IDs are rejected even when files live in different
+directories.
+
+## Suites
+
+A `type: suite` document runs member tests in **one** Minecraft client session
+with xUnit-style hooks:
+
+```yaml
+---
+name: Creative World Suite
+type: suite
+---
+before-all:
+  - launchGame
+  - createWorld:
+      worldType: superflat
+      gameMode: creative
+  - closeScreen
+before-each:
+  - runCommand: "/time set day"
+after-each:
+  - closeScreen
+after-all:
+  - captureScreenshot:
+      name: suite-end
+tests:
+  - suitePlaceDirt
+  - suiteCaptureInventory
+```
+
+| Key | Required | Role |
+| --- | --- | --- |
+| `tests` | yes | Non-empty list of `type: test` filename stems |
+| `before-all` | no | Once before the first member |
+| `before-each` | no | Before every member body |
+| `after-each` | no | After every member body (still runs if that member failed) |
+| `after-all` | no | Once after the last member (still runs after failures) |
+
+Execution order:
+
+```
+before-all
+  for each member:
+    before-each
+    test body
+    after-each
+after-all
+```
+
+Suites may not declare `steps` or `parameters`. Member tests are normal
+`type: test` documents (often body-only when the suite owns world setup).
+On failure, remaining members are skipped, `after-all` still runs, and the
+process exits non-zero.
 
 ## Steps
 

--- a/screenplay/gradle-plugin/src/main/groovy/com/adamkali/screenplay/gradle/ScreenplayPlugin.groovy
+++ b/screenplay/gradle-plugin/src/main/groovy/com/adamkali/screenplay/gradle/ScreenplayPlugin.groovy
@@ -248,18 +248,23 @@ guiScale:1
 
         project.tasks.register('runScreenplayTests') {
             group = 'verification'
-            description = 'Discover all type:test YAML scenarios and run each via runScreenplay'
+            description = 'Discover Screenplay suites and standalone type:test scenarios, then run each via runScreenplay'
 
             doLast {
                 def missing = testsDirs.findAll { !it.isDirectory() }
                 if (missing) {
                     throw new GradleException("Screenplay tests directory not found: ${missing}")
                 }
-                def scenarioIds = discoverScenarioTestIds(testsDirs)
+                def discovery = discoverScreenplayRunIds(testsDirs)
+                def scenarioIds = discovery.runIds as List
                 if (scenarioIds.isEmpty()) {
-                    throw new GradleException("No scenario tests (type: test) found under ${testsDirs}")
+                    throw new GradleException(
+                            "No scenario suites or standalone tests found under ${testsDirs}")
                 }
-                logger.lifecycle("Discovered ${scenarioIds.size()} Screenplay test(s): ${scenarioIds.join(', ')}")
+                logger.lifecycle(
+                        "Discovered ${scenarioIds.size()} Screenplay run(s): ${scenarioIds.join(', ')}"
+                                + " (${discovery.suiteIds.size()} suite(s), "
+                                + "${discovery.standaloneTestIds.size()} standalone test(s))")
 
                 def gradleWrapper = new File(projectDirFile, 'gradlew')
                 def gradleCommand = gradleWrapper.exists() ? gradleWrapper.absolutePath : 'gradle'
@@ -269,7 +274,7 @@ guiScale:1
                 resultsDir.mkdirs()
 
                 scenarioIds.each { String scenarioId ->
-                    logger.lifecycle("Running Screenplay test '${scenarioId}'")
+                    logger.lifecycle("Running Screenplay '${scenarioId}'")
                     def args = [gradleCommand, 'runScreenplay', "-Pscreenplay=${scenarioId}"]
                     args << "-PscreenplayDisplay=${displayMode.get()}"
                     if (timeoutProperty.isPresent()) {
@@ -305,38 +310,60 @@ guiScale:1
 
                     if (result.exitValue != 0) {
                         failed << scenarioId
-                        logger.error("Screenplay test '${scenarioId}' failed (exit ${result.exitValue})")
+                        logger.error("Screenplay '${scenarioId}' failed (exit ${result.exitValue})")
                     } else {
-                        logger.lifecycle("Screenplay test '${scenarioId}' passed")
+                        logger.lifecycle("Screenplay '${scenarioId}' passed")
                     }
                 }
 
                 if (!failed.isEmpty()) {
                     throw new GradleException(
-                            "Failed Screenplay test(s): ${failed.join(', ')} "
+                            "Failed Screenplay run(s): ${failed.join(', ')} "
                                     + "(${failed.size()} of ${scenarioIds.size()})")
                 }
-                logger.lifecycle("All ${scenarioIds.size()} Screenplay test(s) passed")
+                logger.lifecycle("All ${scenarioIds.size()} Screenplay run(s) passed")
             }
         }
     }
 
-    private static List discoverScenarioTestIds(List<File> scenarioTestsRoots) {
-        def ids = [] as TreeSet
+    private static Map discoverScreenplayRunIds(List<File> scenarioTestsRoots) {
+        def suiteIds = [] as TreeSet
+        def testIds = [] as TreeSet
+        def suiteMemberIds = [] as HashSet
         scenarioTestsRoots.each { File scenarioTestsRoot ->
             projectFileTree(scenarioTestsRoot).each { File yamlFile ->
-                if (!isScenarioTestYaml(yamlFile)) {
+                def frontmatterType = readFrontmatterType(yamlFile)
+                if (frontmatterType == null) {
                     return
                 }
-                def name = yamlFile.name
-                def extension = name.lastIndexOf('.')
-                def id = extension < 0 ? name : name.substring(0, extension)
-                if (!ids.add(id)) {
-                    throw new GradleException("Duplicate scenario test id '${id}' under ${scenarioTestsRoots}")
+                def id = filenameStem(yamlFile)
+                if (frontmatterType == 'suite') {
+                    if (!suiteIds.add(id)) {
+                        throw new GradleException("Duplicate scenario suite id '${id}' under ${scenarioTestsRoots}")
+                    }
+                    suiteMemberIds.addAll(readSuiteTestIds(yamlFile))
+                } else if (frontmatterType == 'test') {
+                    if (!testIds.add(id)) {
+                        throw new GradleException("Duplicate scenario test id '${id}' under ${scenarioTestsRoots}")
+                    }
                 }
             }
         }
-        return ids as List
+        def standaloneTestIds = testIds.findAll { !suiteMemberIds.contains(it) } as TreeSet
+        def runIds = [] as TreeSet
+        runIds.addAll(suiteIds)
+        runIds.addAll(standaloneTestIds)
+        return [
+                suiteIds         : suiteIds,
+                standaloneTestIds: standaloneTestIds,
+                runIds           : runIds
+        ]
+    }
+
+    private static String filenameStem(File yamlFile) {
+        def name = yamlFile.name
+        def extension = name.lastIndexOf('.')
+        return extension < 0 ? name : name.substring(0, extension)
     }
 
     private static Collection<File> projectFileTree(File root) {
@@ -349,18 +376,58 @@ guiScale:1
         return files
     }
 
-    private static boolean isScenarioTestYaml(File yamlFile) {
+    private static String readFrontmatterType(File yamlFile) {
         def text = yamlFile.getText('UTF-8').replace('\r\n', '\n')
         if (!text.startsWith('---\n')) {
-            return false
+            return null
         }
         def closing = text.indexOf('\n---\n', 4)
         if (closing < 0) {
-            return false
+            return null
         }
-        return text.substring(4, closing).readLines().any { line ->
-            line.trim() == 'type: test'
+        def typeLine = text.substring(4, closing).readLines().find { line ->
+            line.trim().startsWith('type:')
         }
+        if (typeLine == null) {
+            return null
+        }
+        return typeLine.substring(typeLine.indexOf(':') + 1).trim()
+    }
+
+    private static List readSuiteTestIds(File yamlFile) {
+        def text = yamlFile.getText('UTF-8').replace('\r\n', '\n')
+        def closing = text.indexOf('\n---\n', 4)
+        if (closing < 0) {
+            return []
+        }
+        def body = text.substring(closing + 5)
+        def ids = []
+        def inTests = false
+        body.readLines().each { String rawLine ->
+            def line = rawLine.replaceAll(/\s+$/, '')
+            if (!inTests) {
+                if (line.trim() == 'tests:') {
+                    inTests = true
+                }
+                return
+            }
+            if (line ==~ /^[A-Za-z0-9_-]+:.*/) {
+                inTests = false
+                return
+            }
+            def matcher = (line =~ /^\s*-\s+(.+?)\s*$/)
+            if (matcher.matches()) {
+                def value = matcher.group(1).trim()
+                if ((value.startsWith('"') && value.endsWith('"'))
+                        || (value.startsWith("'") && value.endsWith("'"))) {
+                    value = value.substring(1, value.length() - 1)
+                }
+                if (!value.isBlank()) {
+                    ids << value
+                }
+            }
+        }
+        return ids
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

Screenplay scenarios currently duplicate shared setup (launch game, create world) in every YAML test. Suites let multiple tests share one client session with xUnit-style hooks, cutting duplication and runtime while keeping teardown reliable on failure.

## Proposed Implementation

- Add `type: suite` documents with `before-all` / `before-each` / `after-each` / `after-all` hooks and a `tests:` member list
- Compile suites into `SuitePlan` and run them in one Minecraft client session (abort remaining members on failure; always attempt `after-all`)
- Extend JUnit XML / metrics reporting for multi-case suite results
- Update `runScreenplayTests` to discover suites and skip standalone runs for suite member tests
- Add `creativeWorldSuite` demo + docs/AGENTS updates
- Verified with `./screenplay/gradlew :common:test` and `./screenplay/gradlew build`

## Problems Encountered / Decisions Made

- Repo layout after main pull uses `screenplay/` sibling build (not legacy `screenplay-common/` paths)
- Failure policy: skip remaining members, still run current `after-each` when entered, always attempt `after-all`, exit non-zero
- No legacy `setup`/`teardown` aliases — only the four kebab-case hook keys
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03d5f-08f9-7e0f-b83e-ed6648da0b9c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03d5f-08f9-7e0f-b83e-ed6648da0b9c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

