### PR TITLE
refactor(dwm): lay out the Field Guide with Stack and Columns

### DIFF
--- a/dwm/src/client/java/com/adamkali/dwm/gui/FieldGuideScreen.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/FieldGuideScreen.java
@@ -196,7 +196,7 @@ public class FieldGuideScreen extends Screen {
         ));
         content.add(new MultiLineTextWidget(
                 Component.translatable(page.bodyKey()).copy().withStyle(
-                        Style.EMPTY.withColor(FieldGuideBookLayout.TEXT_COLOR)
+                        Style.EMPTY.withColor(FieldGuideBookLayout.TEXT_COLOR).withoutShadow()
                 ),
                 font
         ).setMaxWidth(FieldGuideBookLayout.RIGHT_PAGE_WIDTH).setMaxRows(bodyMaxRows(page)));
@@ -212,7 +212,7 @@ public class FieldGuideScreen extends Screen {
         if (page.patternPage()) {
             content.add(new MultiLineTextWidget(
                     Component.translatable("dwm.guide.pattern.all_colours").copy().withStyle(
-                            Style.EMPTY.withColor(FieldGuideBookLayout.TEXT_COLOR)
+                            Style.EMPTY.withColor(FieldGuideBookLayout.TEXT_COLOR).withoutShadow()
                     ),
                     font
             ).setMaxWidth(FieldGuideBookLayout.RIGHT_PAGE_WIDTH).setMaxRows(FieldGuideBookLayout.PATTERN_MAX_LINES));

--- a/dwm/src/client/java/com/adamkali/dwm/gui/FieldGuideScreen.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/FieldGuideScreen.java
@@ -1,22 +1,32 @@
 package com.adamkali.dwm.gui;
 
+import com.adamkali.dwm.gui.layout.Columns;
+import com.adamkali.dwm.gui.layout.FillWidget;
+import com.adamkali.dwm.gui.layout.Layouts;
+import com.adamkali.dwm.gui.layout.Stack;
 import com.adamkali.dwm.guide.FieldGuideBookLayout;
 import com.adamkali.dwm.guide.FieldGuideCatalog;
 import com.adamkali.dwm.guide.FieldGuideChapter;
 import com.adamkali.dwm.guide.FieldGuidePage;
 import com.adamkali.dwm.guide.FieldGuideRecipePanel;
+import com.adamkali.dwm.guide.FieldGuideRecipeWidget;
+import com.adamkali.dwm.guide.FieldGuideVariantWidget;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
 import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.MultiLineTextWidget;
 import net.minecraft.client.gui.components.PlainTextButton;
+import net.minecraft.client.gui.components.StringWidget;
+import net.minecraft.client.gui.layouts.FrameLayout;
 import net.minecraft.client.gui.screens.inventory.PageButton;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.input.KeyEvent;
-import net.minecraft.client.input.MouseButtonEvent;
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.Style;
+import net.minecraft.resources.Identifier;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -24,12 +34,7 @@ import java.util.List;
 
 @Environment(EnvType.CLIENT)
 public class FieldGuideScreen extends Screen {
-    private static final int BODY_TEXT_MAX_LINES_WITH_RECIPE = 4;
-    private static final int BODY_TEXT_MAX_LINES_WITHOUT_RECIPE = 10;
-
-    private final List<PlainTextButton> chapterButtons = new ArrayList<>();
-    private final List<PlainTextButton> pageButtons = new ArrayList<>();
-    private final List<PlainTextButton> stationTabButtons = new ArrayList<>();
+    private final List<AbstractWidget> contentWidgets = new ArrayList<>();
     private @Nullable PageButton backPageButton;
     private @Nullable PageButton forwardPageButton;
 
@@ -56,6 +61,7 @@ public class FieldGuideScreen extends Screen {
     protected void init() {
         bookLeft = FieldGuideBookLayout.bookLeft(width);
         bookTop = FieldGuideBookLayout.bookTop(height);
+        contentWidgets.clear();
 
         if (selectedPage == null) {
             selectedChapter = FieldGuideCatalog.chapters().getFirst();
@@ -63,9 +69,6 @@ public class FieldGuideScreen extends Screen {
         } else if (selectedChapter == null) {
             selectedChapter = FieldGuideCatalog.chapterForPage(selectedPage);
         }
-
-        clearIndexWidgets();
-        rebuildIndexWidgets();
 
         backPageButton = addRenderableWidget(new PageButton(
                 bookLeft + FieldGuideBookLayout.PAGE_BACK_X,
@@ -92,61 +95,226 @@ public class FieldGuideScreen extends Screen {
                 .build());
 
         updateNavigationState();
-        rebuildStationTabs();
+        rebuildContent();
     }
 
-    private void clearIndexWidgets() {
-        chapterButtons.forEach(this::removeWidget);
-        chapterButtons.clear();
-        pageButtons.forEach(this::removeWidget);
-        pageButtons.clear();
-        stationTabButtons.forEach(this::removeWidget);
-        stationTabButtons.clear();
+    private void rebuildContent() {
+        contentWidgets.forEach(this::removeWidget);
+        contentWidgets.clear();
+        if (selectedChapter == null || selectedPage == null) {
+            return;
+        }
+
+        contentWidgets.addAll(Layouts.mount(
+                buildLeftPage(),
+                bookLeft + FieldGuideBookLayout.LEFT_PAGE_X,
+                bookTop + FieldGuideBookLayout.INDEX_HEADER_Y,
+                this::addRenderableWidget
+        ));
+        contentWidgets.addAll(Layouts.mount(
+                buildRightPage(),
+                bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X,
+                bookTop + FieldGuideBookLayout.RIGHT_PAGE_TOP,
+                this::addRenderableWidget
+        ));
+
+        StringWidget indicator = coloured(pageIndicator(), FieldGuideBookLayout.MUTED_TEXT_COLOR);
+        indicator.setPosition(
+                bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X + 28,
+                bookTop + FieldGuideBookLayout.RIGHT_INDICATOR_Y
+        );
+        addRenderableWidget(indicator);
+        contentWidgets.add(indicator);
     }
 
-    private void rebuildIndexWidgets() {
-        chapterButtons.forEach(this::removeWidget);
-        chapterButtons.clear();
-        pageButtons.forEach(this::removeWidget);
-        pageButtons.clear();
-
-        int chapterY = bookTop + FieldGuideBookLayout.INDEX_CONTENT_Y;
+    private Stack buildLeftPage() {
+        Stack chapters = Stack.vertical(FieldGuideBookLayout.CHAPTER_BUTTON_GAP);
         for (FieldGuideChapter chapter : FieldGuideCatalog.chapters()) {
             FieldGuideChapter targetChapter = chapter;
             boolean selected = chapter.equals(selectedChapter);
-            PlainTextButton chapterButton = new PlainTextButton(
-                    bookLeft + FieldGuideBookLayout.LEFT_PAGE_X,
-                    chapterY,
+            chapters.add(new PlainTextButton(
+                    0,
+                    0,
                     FieldGuideBookLayout.LEFT_PAGE_WIDTH,
                     FieldGuideBookLayout.CHAPTER_ENTRY_HEIGHT,
                     styledChapterLabel(chapter.titleKey(), selected),
                     button -> selectChapter(targetChapter),
                     font
-            );
-            addRenderableWidget(chapterButton);
-            chapterButtons.add(chapterButton);
-            chapterY += FieldGuideBookLayout.CHAPTER_ENTRY_HEIGHT + 1;
+            ));
         }
 
+        Stack pages = Stack.vertical(0);
         if (selectedChapter != null) {
-            int pageY = bookTop + FieldGuideBookLayout.PAGE_CONTENT_Y;
             for (FieldGuidePage page : selectedChapter.pages()) {
                 FieldGuidePage targetPage = page;
                 boolean selected = page.equals(selectedPage);
-                PlainTextButton pageButton = new PlainTextButton(
-                        bookLeft + FieldGuideBookLayout.LEFT_PAGE_X + FieldGuideBookLayout.PAGE_ENTRY_INDENT,
-                        pageY,
+                pages.add(new PlainTextButton(
+                        0,
+                        0,
                         FieldGuideBookLayout.LEFT_PAGE_WIDTH - FieldGuideBookLayout.PAGE_ENTRY_INDENT,
                         FieldGuideBookLayout.PAGE_ENTRY_HEIGHT,
                         styledPageLabel(page.titleKey(), selected),
                         button -> selectPage(targetPage),
                         font
-                );
-                addRenderableWidget(pageButton);
-                pageButtons.add(pageButton);
-                pageY += FieldGuideBookLayout.PAGE_ENTRY_HEIGHT;
+                ), settings -> settings.paddingLeft(FieldGuideBookLayout.PAGE_ENTRY_INDENT));
             }
         }
+
+        Stack pagesSection = Stack.vertical(FieldGuideBookLayout.STACK_GAP);
+        pagesSection.add(coloured(Component.literal("PAGES"), FieldGuideBookLayout.INDEX_HEADER_COLOR));
+        pagesSection.add(new FillWidget(
+                FieldGuideBookLayout.LEFT_PAGE_WIDTH - 6,
+                FieldGuideBookLayout.HAIRLINE_HEIGHT,
+                FieldGuideBookLayout.LEFT_HAIRLINE_COLOR
+        ));
+        pagesSection.add(pages);
+
+        Stack left = Stack.vertical(FieldGuideBookLayout.SECTION_GAP);
+        left.add(coloured(Component.translatable("dwm.guide.index.header"), FieldGuideBookLayout.INDEX_HEADER_COLOR));
+        left.add(chapters);
+        left.add(pagesSection);
+        return left;
+    }
+
+    private Stack buildRightPage() {
+        FieldGuidePage page = selectedPage;
+        Stack content = Stack.vertical(FieldGuideBookLayout.STACK_GAP);
+        content.add(coloured(
+                Component.translatable(selectedChapter.titleKey()),
+                FieldGuideBookLayout.MUTED_TEXT_COLOR
+        ));
+        content.add(new StringWidget(
+                Component.translatable(page.titleKey()).copy().withStyle(
+                        Style.EMPTY.withBold(true).withColor(FieldGuideBookLayout.TITLE_COLOR)
+                ),
+                font
+        ));
+        content.add(new FillWidget(
+                FieldGuideBookLayout.RIGHT_PAGE_WIDTH,
+                FieldGuideBookLayout.HAIRLINE_HEIGHT,
+                FieldGuideBookLayout.ACCENT_COLOR
+        ));
+        content.add(new MultiLineTextWidget(
+                Component.translatable(page.bodyKey()).copy().withStyle(
+                        Style.EMPTY.withColor(FieldGuideBookLayout.TEXT_COLOR)
+                ),
+                font
+        ).setMaxWidth(FieldGuideBookLayout.RIGHT_PAGE_WIDTH).setMaxRows(bodyMaxRows(page)));
+
+        List<FieldGuideRecipePanel.Station> stations = FieldGuideRecipePanel.availableStations(page);
+        if (!stations.isEmpty()) {
+            content.add(buildRecipeHeader(page, stations));
+            content.add(
+                    new FieldGuideRecipeWidget(minecraft, page, selectedStation, selectedCraftingVariantIndex),
+                    settings -> settings.alignHorizontallyCenter()
+            );
+        }
+        if (page.patternPage()) {
+            content.add(new MultiLineTextWidget(
+                    Component.translatable("dwm.guide.pattern.all_colours").copy().withStyle(
+                            Style.EMPTY.withColor(FieldGuideBookLayout.TEXT_COLOR)
+                    ),
+                    font
+            ).setMaxWidth(FieldGuideBookLayout.RIGHT_PAGE_WIDTH).setMaxRows(FieldGuideBookLayout.PATTERN_MAX_LINES));
+        }
+        return content;
+    }
+
+    private FrameLayout buildRecipeHeader(FieldGuidePage page, List<FieldGuideRecipePanel.Station> stations) {
+        boolean showVariants = selectedStation == FieldGuideRecipePanel.Station.CRAFTING
+                && page.craftingRecipes().size() > 1;
+        int headerHeight = showVariants
+                ? FieldGuideBookLayout.VARIANT_SLOT_SIZE
+                : FieldGuideBookLayout.LINE_HEIGHT;
+        FrameLayout header = new FrameLayout(FieldGuideBookLayout.RIGHT_PAGE_WIDTH, headerHeight);
+
+        if (stations.size() > 1) {
+            Stack tabs = Columns.of(FieldGuideBookLayout.STATION_TAB_GAP);
+            for (FieldGuideRecipePanel.Station station : stations) {
+                FieldGuideRecipePanel.Station target = station;
+                boolean selected = station == selectedStation;
+                tabs.add(new PlainTextButton(
+                        0,
+                        0,
+                        FieldGuideBookLayout.STATION_TAB_WIDTH,
+                        FieldGuideBookLayout.STATION_TAB_HEIGHT,
+                        station.label().copy().withStyle(selected
+                                ? Style.EMPTY.withBold(true).withColor(FieldGuideBookLayout.PAGE_SELECTED_COLOR)
+                                : Style.EMPTY.withColor(FieldGuideBookLayout.PAGE_UNSELECTED_COLOR)),
+                        button -> {
+                            selectedStation = target;
+                            rebuildContent();
+                        },
+                        font
+                ));
+            }
+            header.addChild(tabs, settings -> settings.alignHorizontallyLeft().alignVerticallyMiddle());
+        } else {
+            header.addChild(
+                    new StringWidget(
+                            selectedStation.label().copy().append(" RECIPE").withStyle(
+                                    Style.EMPTY.withBold(true).withColor(FieldGuideBookLayout.INDEX_HEADER_COLOR)
+                            ),
+                            font
+                    ),
+                    settings -> settings.alignHorizontallyLeft().alignVerticallyMiddle()
+            );
+        }
+
+        if (showVariants) {
+            Stack variants = Columns.of(FieldGuideBookLayout.VARIANT_ICON_GAP);
+            List<Identifier> recipes = page.craftingRecipes();
+            for (int index = 0; index < recipes.size(); index++) {
+                int variantIndex = index;
+                variants.add(new FieldGuideVariantWidget(
+                        minecraft,
+                        recipes.get(index),
+                        index == selectedCraftingVariantIndex,
+                        () -> {
+                            selectedCraftingVariantIndex = variantIndex;
+                            rebuildContent();
+                        }
+                ));
+            }
+            header.addChild(variants, settings -> settings.alignHorizontallyRight().alignVerticallyMiddle());
+        }
+        return header;
+    }
+
+    private int bodyMaxRows(FieldGuidePage page) {
+        int children = 4;
+        int intrinsic = FieldGuideBookLayout.LINE_HEIGHT * 2 + FieldGuideBookLayout.HAIRLINE_HEIGHT;
+        List<FieldGuideRecipePanel.Station> stations = FieldGuideRecipePanel.availableStations(page);
+        if (!stations.isEmpty()) {
+            children += 2;
+            boolean variants = selectedStation == FieldGuideRecipePanel.Station.CRAFTING
+                    && page.craftingRecipes().size() > 1;
+            intrinsic += variants
+                    ? FieldGuideBookLayout.VARIANT_SLOT_SIZE
+                    : FieldGuideBookLayout.LINE_HEIGHT;
+            intrinsic += FieldGuideRecipePanel.PANEL_HEIGHT;
+        }
+        if (page.patternPage()) {
+            children += 1;
+            intrinsic += FieldGuideBookLayout.PATTERN_MAX_LINES * FieldGuideBookLayout.LINE_HEIGHT;
+        }
+        int reserved = intrinsic + (children - 1) * FieldGuideBookLayout.STACK_GAP;
+        int budget = FieldGuideBookLayout.rightPageContentHeight();
+        return Math.max(1, (budget - reserved) / FieldGuideBookLayout.LINE_HEIGHT);
+    }
+
+    private StringWidget coloured(Component text, int color) {
+        return new StringWidget(text.copy().withStyle(Style.EMPTY.withColor(color)), font);
+    }
+
+    private Component pageIndicator() {
+        int pageIndex = FieldGuideCatalog.pageIndexInChapter(selectedChapter, selectedPage) + 1;
+        return Component.translatable(
+                "dwm.guide.page.indicator",
+                Component.translatable(selectedChapter.titleKey()),
+                pageIndex,
+                selectedChapter.pages().size()
+        );
     }
 
     private static Component styledChapterLabel(String titleKey, boolean selected) {
@@ -164,7 +332,6 @@ public class FieldGuideScreen extends Screen {
     private void selectChapter(FieldGuideChapter chapter) {
         selectedChapter = chapter;
         selectPage(chapter.pages().getFirst());
-        init();
     }
 
     private void selectPage(FieldGuidePage page) {
@@ -175,9 +342,8 @@ public class FieldGuideScreen extends Screen {
         if (!stations.isEmpty() && !stations.contains(selectedStation)) {
             selectedStation = stations.getFirst();
         }
-        rebuildIndexWidgets();
+        rebuildContent();
         updateNavigationState();
-        rebuildStationTabs();
     }
 
     private void turnPage(int delta) {
@@ -198,41 +364,6 @@ public class FieldGuideScreen extends Screen {
         int index = FieldGuideCatalog.pageIndexInChapter(selectedChapter, selectedPage);
         backPageButton.active = index > 0;
         forwardPageButton.active = index < selectedChapter.pages().size() - 1;
-    }
-
-    private void rebuildStationTabs() {
-        stationTabButtons.forEach(this::removeWidget);
-        stationTabButtons.clear();
-        if (selectedPage == null) {
-            return;
-        }
-        List<FieldGuideRecipePanel.Station> stations = FieldGuideRecipePanel.availableStations(selectedPage);
-        if (stations.size() <= 1) {
-            return;
-        }
-        int tabX = bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X;
-        int tabY = bookTop + FieldGuideBookLayout.RIGHT_RECIPE_Y - 11;
-        for (FieldGuideRecipePanel.Station station : stations) {
-            FieldGuideRecipePanel.Station target = station;
-            boolean selected = station == selectedStation;
-            PlainTextButton tab = new PlainTextButton(
-                    tabX,
-                    tabY,
-                    42,
-                    9,
-                    station.label().copy().withStyle(selected
-                            ? Style.EMPTY.withBold(true).withColor(FieldGuideBookLayout.PAGE_SELECTED_COLOR)
-                            : Style.EMPTY.withColor(FieldGuideBookLayout.PAGE_UNSELECTED_COLOR)),
-                    button -> {
-                        selectedStation = target;
-                        rebuildStationTabs();
-                    },
-                    font
-            );
-            addRenderableWidget(tab);
-            stationTabButtons.add(tab);
-            tabX += 44;
-        }
     }
 
     @Override
@@ -278,172 +409,14 @@ public class FieldGuideScreen extends Screen {
     @Override
     public void extractRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
         super.extractRenderState(graphics, mouseX, mouseY, delta);
-
-        if (selectedChapter == null || selectedPage == null) {
-            return;
-        }
-
-        int leftX = bookLeft + FieldGuideBookLayout.LEFT_PAGE_X;
-        int rightX = bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X;
-
         graphics.text(
                 font,
                 Component.translatable("dwm.guide.title"),
-                leftX + 5,
+                bookLeft + FieldGuideBookLayout.LEFT_PAGE_X + 5,
                 bookTop + FieldGuideBookLayout.HEADER_Y + 7,
                 0xFFFFFFFF,
                 false
         );
-        graphics.text(
-                font,
-                Component.translatable("dwm.guide.index.header"),
-                leftX,
-                bookTop + FieldGuideBookLayout.INDEX_HEADER_Y,
-                FieldGuideBookLayout.INDEX_HEADER_COLOR,
-                false
-        );
-        graphics.text(
-                font,
-                Component.literal("PAGES"),
-                leftX,
-                bookTop + FieldGuideBookLayout.PAGE_HEADER_Y,
-                FieldGuideBookLayout.INDEX_HEADER_COLOR,
-                false
-        );
-        graphics.fill(
-                leftX,
-                bookTop + FieldGuideBookLayout.PAGE_HEADER_Y + 10,
-                leftX + FieldGuideBookLayout.LEFT_PAGE_WIDTH - 6,
-                bookTop + FieldGuideBookLayout.PAGE_HEADER_Y + 11,
-                0xFFBCA477
-        );
-
-        graphics.text(
-                font,
-                Component.translatable(selectedChapter.titleKey()).copy().withStyle(Style.EMPTY.withColor(FieldGuideBookLayout.MUTED_TEXT_COLOR)),
-                rightX,
-                bookTop + FieldGuideBookLayout.RIGHT_CHAPTER_Y,
-                FieldGuideBookLayout.MUTED_TEXT_COLOR,
-                false
-        );
-        graphics.text(
-                font,
-                Component.translatable(selectedPage.titleKey()).copy().withStyle(Style.EMPTY.withBold(true)),
-                rightX,
-                bookTop + FieldGuideBookLayout.RIGHT_TITLE_Y,
-                FieldGuideBookLayout.TITLE_COLOR,
-                false
-        );
-        graphics.fill(
-                rightX,
-                bookTop + FieldGuideBookLayout.RIGHT_TITLE_Y + 12,
-                rightX + FieldGuideBookLayout.RIGHT_PAGE_WIDTH,
-                bookTop + FieldGuideBookLayout.RIGHT_TITLE_Y + 13,
-                FieldGuideBookLayout.ACCENT_COLOR
-        );
-        renderWrappedBody(
-                graphics,
-                Component.translatable(selectedPage.bodyKey()),
-                rightX,
-                bookTop + FieldGuideBookLayout.RIGHT_BODY_Y,
-                FieldGuideBookLayout.RIGHT_PAGE_WIDTH,
-                FieldGuideRecipePanel.availableStations(selectedPage).isEmpty()
-                        ? BODY_TEXT_MAX_LINES_WITHOUT_RECIPE
-                        : BODY_TEXT_MAX_LINES_WITH_RECIPE
-        );
-
-        int pageIndex = FieldGuideCatalog.pageIndexInChapter(selectedChapter, selectedPage) + 1;
-        Component indicator = Component.translatable(
-                "dwm.guide.page.indicator",
-                Component.translatable(selectedChapter.titleKey()),
-                pageIndex,
-                selectedChapter.pages().size()
-        );
-        graphics.text(
-                font,
-                indicator,
-                rightX + 28,
-                bookTop + FieldGuideBookLayout.RIGHT_INDICATOR_Y,
-                FieldGuideBookLayout.MUTED_TEXT_COLOR,
-                false
-        );
-
-        if (!FieldGuideRecipePanel.availableStations(selectedPage).isEmpty()) {
-            graphics.text(
-                    font,
-                    selectedStation.label().copy().append(" RECIPE").withStyle(Style.EMPTY.withBold(true)),
-                    rightX,
-                    bookTop + FieldGuideBookLayout.RIGHT_RECIPE_LABEL_Y,
-                    FieldGuideBookLayout.INDEX_HEADER_COLOR,
-                    false
-            );
-        }
-
-        if (selectedStation == FieldGuideRecipePanel.Station.CRAFTING) {
-            FieldGuideRecipePanel.renderCraftingVariants(
-                    graphics,
-                    minecraft,
-                    bookLeft,
-                    bookTop,
-                    selectedPage,
-                    selectedCraftingVariantIndex,
-                    mouseX,
-                    mouseY
-            );
-        }
-
-        FieldGuideRecipePanel.render(
-                graphics,
-                minecraft,
-                bookLeft,
-                bookTop,
-                selectedPage,
-                selectedStation,
-                selectedCraftingVariantIndex,
-                mouseX,
-                mouseY
-        );
-
-        if (selectedPage.patternPage()) {
-            renderWrappedBody(
-                    graphics,
-                    Component.translatable("dwm.guide.pattern.all_colours"),
-                    rightX,
-                    bookTop + FieldGuideBookLayout.RIGHT_PATTERN_Y,
-                    FieldGuideBookLayout.RIGHT_PAGE_WIDTH,
-                    2
-            );
-        }
-    }
-
-    private void renderWrappedBody(GuiGraphicsExtractor graphics, Component text, int x, int y, int maxWidth, int maxLines) {
-        int lineCount = 0;
-        for (var line : font.split(text, maxWidth)) {
-            graphics.text(font, line, x, y, FieldGuideBookLayout.TEXT_COLOR, false);
-            y += 9;
-            lineCount++;
-            if (lineCount >= maxLines) {
-                break;
-            }
-        }
-    }
-
-    @Override
-    public boolean mouseClicked(MouseButtonEvent event, boolean doubleClick) {
-        if (selectedPage != null && selectedStation == FieldGuideRecipePanel.Station.CRAFTING) {
-            int variantIndex = FieldGuideRecipePanel.craftingVariantIndexAt(
-                    selectedPage,
-                    bookLeft,
-                    bookTop,
-                    event.x(),
-                    event.y()
-            );
-            if (variantIndex >= 0) {
-                selectedCraftingVariantIndex = variantIndex;
-                return true;
-            }
-        }
-        return super.mouseClicked(event, doubleClick);
     }
 
     @Override

--- a/dwm/src/client/java/com/adamkali/dwm/gui/layout/Columns.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/layout/Columns.java
@@ -1,0 +1,26 @@
+package com.adamkali.dwm.gui.layout;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.layouts.LayoutElement;
+
+/**
+ * Horizontal {@link Stack} factory for side-by-side children.
+ */
+@Environment(EnvType.CLIENT)
+public final class Columns {
+    private Columns() {
+    }
+
+    public static Stack of(int gap) {
+        return Stack.horizontal(gap);
+    }
+
+    public static Stack of(int gap, LayoutElement... children) {
+        Stack columns = Stack.horizontal(gap);
+        for (LayoutElement child : children) {
+            columns.add(child);
+        }
+        return columns;
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/gui/layout/FillWidget.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/layout/FillWidget.java
@@ -1,0 +1,37 @@
+package com.adamkali.dwm.gui.layout;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.CommonComponents;
+
+/**
+ * Inactive rectangle that participates in layout. Used for hairlines and solid bars.
+ */
+@Environment(EnvType.CLIENT)
+public final class FillWidget extends AbstractWidget {
+    private final int color;
+
+    public FillWidget(int width, int height, int color) {
+        super(0, 0, width, height, CommonComponents.EMPTY);
+        this.color = color;
+        this.active = false;
+    }
+
+    @Override
+    protected void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        graphics.fill(getX(), getY(), getX() + width, getY() + height, color);
+    }
+
+    @Override
+    protected void updateWidgetNarration(NarrationElementOutput output) {
+    }
+
+    @Override
+    public NarratableEntry.NarrationPriority narrationPriority() {
+        return NarratableEntry.NarrationPriority.NONE;
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/gui/layout/Layouts.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/layout/Layouts.java
@@ -1,0 +1,30 @@
+package com.adamkali.dwm.gui.layout;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.layouts.Layout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Positions a layout tree and registers its interactive/paint widgets on a screen.
+ */
+@Environment(EnvType.CLIENT)
+public final class Layouts {
+    private Layouts() {
+    }
+
+    public static List<AbstractWidget> mount(Layout layout, int x, int y, Consumer<AbstractWidget> addWidget) {
+        layout.setPosition(x, y);
+        layout.arrangeElements();
+        List<AbstractWidget> widgets = new ArrayList<>();
+        layout.visitWidgets(widget -> {
+            addWidget.accept(widget);
+            widgets.add(widget);
+        });
+        return widgets;
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/gui/layout/Stack.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/layout/Stack.java
@@ -1,0 +1,83 @@
+package com.adamkali.dwm.gui.layout;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.layouts.Layout;
+import net.minecraft.client.gui.layouts.LayoutElement;
+import net.minecraft.client.gui.layouts.LayoutSettings;
+import net.minecraft.client.gui.layouts.LinearLayout;
+
+import java.util.function.Consumer;
+
+/**
+ * Vertical or horizontal sequence of {@link LayoutElement}s with a uniform gap.
+ */
+@Environment(EnvType.CLIENT)
+public final class Stack implements Layout {
+    private final LinearLayout inner;
+
+    private Stack(LinearLayout inner) {
+        this.inner = inner;
+    }
+
+    public static Stack vertical(int gap) {
+        return new Stack(LinearLayout.vertical().spacing(gap));
+    }
+
+    public static Stack horizontal(int gap) {
+        return new Stack(LinearLayout.horizontal().spacing(gap));
+    }
+
+    public <T extends LayoutElement> T add(T child) {
+        return inner.addChild(child);
+    }
+
+    public <T extends LayoutElement> T add(T child, Consumer<LayoutSettings> settings) {
+        return inner.addChild(child, settings);
+    }
+
+    @Override
+    public void visitChildren(Consumer<LayoutElement> visitor) {
+        inner.visitChildren(visitor);
+    }
+
+    @Override
+    public void removeChildren() {
+        inner.removeChildren();
+    }
+
+    @Override
+    public void arrangeElements() {
+        inner.arrangeElements();
+    }
+
+    @Override
+    public int getWidth() {
+        return inner.getWidth();
+    }
+
+    @Override
+    public int getHeight() {
+        return inner.getHeight();
+    }
+
+    @Override
+    public void setX(int x) {
+        inner.setX(x);
+    }
+
+    @Override
+    public void setY(int y) {
+        inner.setY(y);
+    }
+
+    @Override
+    public int getX() {
+        return inner.getX();
+    }
+
+    @Override
+    public int getY() {
+        return inner.getY();
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideBookLayout.java
+++ b/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideBookLayout.java
@@ -4,7 +4,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
 /**
- * Layout constants for the Field Guide's two-page catalog.
+ * Book chrome metrics, page insets, colours, and stack gaps for the Field Guide.
  */
 @Environment(EnvType.CLIENT)
 public final class FieldGuideBookLayout {
@@ -21,23 +21,27 @@ public final class FieldGuideBookLayout {
     public static final int HEADER_Y = 14;
     public static final int HEADER_HEIGHT = 22;
     public static final int INDEX_HEADER_Y = 44;
-    public static final int INDEX_CONTENT_Y = 59;
+    public static final int RIGHT_PAGE_TOP = 20;
+    public static final int RIGHT_INDICATOR_Y = 203;
+
+    public static final int STACK_GAP = 4;
+    public static final int CHAPTER_BUTTON_GAP = 1;
+    public static final int SECTION_GAP = 8;
+    public static final int HAIRLINE_HEIGHT = 1;
+    public static final int LINE_HEIGHT = 9;
+    public static final int PATTERN_MAX_LINES = 2;
+
     public static final int CHAPTER_ENTRY_HEIGHT = 14;
-    public static final int PAGE_HEADER_Y = 108;
-    public static final int PAGE_CONTENT_Y = 122;
     public static final int PAGE_ENTRY_HEIGHT = 11;
     public static final int PAGE_ENTRY_INDENT = 8;
 
-    public static final int RIGHT_CHAPTER_Y = 20;
-    public static final int RIGHT_TITLE_Y = 37;
-    public static final int RIGHT_BODY_Y = 56;
-    public static final int RIGHT_RECIPE_LABEL_Y = 94;
-    public static final int RIGHT_RECIPE_Y = 108;
+    public static final int STATION_TAB_WIDTH = 42;
+    public static final int STATION_TAB_HEIGHT = 9;
+    public static final int STATION_TAB_GAP = 2;
+
     public static final int VARIANT_SLOT_SIZE = 18;
     public static final int VARIANT_ICON_PAD = 1;
     public static final int VARIANT_ICON_GAP = 3;
-    public static final int RIGHT_PATTERN_Y = 177;
-    public static final int RIGHT_INDICATOR_Y = 203;
 
     public static final int PAGE_BACK_X = RIGHT_PAGE_X + 3;
     public static final int PAGE_FORWARD_X = RIGHT_PAGE_X + RIGHT_PAGE_WIDTH - 26;
@@ -61,6 +65,7 @@ public final class FieldGuideBookLayout {
     public static final int CHAPTER_UNSELECTED_COLOR = 0xFF6F6556;
     public static final int PAGE_SELECTED_COLOR = 0xFF213B61;
     public static final int PAGE_UNSELECTED_COLOR = 0xFF51493E;
+    public static final int LEFT_HAIRLINE_COLOR = 0xFFBCA477;
 
     private FieldGuideBookLayout() {
     }
@@ -75,5 +80,9 @@ public final class FieldGuideBookLayout {
 
     public static int doneButtonTop(int bookTop) {
         return bookTop + DONE_BUTTON_Y_OFFSET;
+    }
+
+    public static int rightPageContentHeight() {
+        return PAGE_BUTTON_Y - RIGHT_PAGE_TOP;
     }
 }

--- a/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideRecipePanel.java
+++ b/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideRecipePanel.java
@@ -25,13 +25,13 @@ import java.util.Optional;
 
 @Environment(EnvType.CLIENT)
 public final class FieldGuideRecipePanel {
-    private static final int PANEL_WIDTH = 138;
-    private static final int PANEL_HEIGHT = 70;
+    public static final int PANEL_WIDTH = 138;
+    public static final int PANEL_HEIGHT = 70;
     private static final int SLOT_SIZE = 20;
     private static final int SLOT_BORDER_COLOR = 0xFF6F6251;
     private static final int SLOT_COLOR = 0xFFD8CDB9;
     private static final int PANEL_BORDER_COLOR = 0xFF9D845A;
-    private static final int PANEL_COLOR = 0xFFE2D2AD;
+    static final int PANEL_COLOR = 0xFFE2D2AD;
 
     private FieldGuideRecipePanel() {
     }
@@ -69,8 +69,8 @@ public final class FieldGuideRecipePanel {
     public static void render(
             GuiGraphicsExtractor graphics,
             Minecraft client,
-            int bookLeft,
-            int bookTop,
+            int x,
+            int y,
             FieldGuidePage page,
             Station station,
             int craftingVariantIndex,
@@ -84,7 +84,7 @@ public final class FieldGuideRecipePanel {
 
         Optional<RecipeHolder<?>> holder = recipeHolder(client, recipeId);
         if (holder.isEmpty()) {
-            renderUnavailable(client, graphics, bookLeft, bookTop);
+            renderUnavailable(client, graphics, x, y);
             return;
         }
 
@@ -94,33 +94,67 @@ public final class FieldGuideRecipePanel {
                 .filter(candidate -> matchesStation(candidate, station))
                 .findFirst();
         if (display.isEmpty()) {
-            renderUnavailable(client, graphics, bookLeft, bookTop);
+            renderUnavailable(client, graphics, x, y);
             return;
         }
 
-        int baseY = bookTop + FieldGuideBookLayout.RIGHT_RECIPE_Y;
         switch (station) {
-            case CRAFTING -> renderCraftingPreview(graphics, client, bookLeft, baseY, display.get(), context, mouseX, mouseY);
-            case SMELTING -> renderFurnacePreview(graphics, client, bookLeft, baseY, display.get(), context, mouseX, mouseY);
-            case STONECUTTING -> renderStonecutterPreview(graphics, client, bookLeft, baseY, display.get(), context, mouseX, mouseY);
+            case CRAFTING -> renderCraftingPreview(graphics, client, x, y, display.get(), context, mouseX, mouseY);
+            case SMELTING -> renderFurnacePreview(graphics, client, x, y, display.get(), context, mouseX, mouseY);
+            case STONECUTTING -> renderStonecutterPreview(graphics, client, x, y, display.get(), context, mouseX, mouseY);
         }
     }
 
-    private static void renderUnavailable(Minecraft client, GuiGraphicsExtractor graphics, int bookLeft, int bookTop) {
+    public static void renderVariant(
+            GuiGraphicsExtractor graphics,
+            Minecraft client,
+            int x,
+            int y,
+            Identifier recipeId,
+            boolean selected,
+            int mouseX,
+            int mouseY
+    ) {
+        graphics.fill(
+                x,
+                y,
+                x + FieldGuideBookLayout.VARIANT_SLOT_SIZE,
+                y + FieldGuideBookLayout.VARIANT_SLOT_SIZE,
+                selected ? FieldGuideBookLayout.ACCENT_COLOR : SLOT_BORDER_COLOR
+        );
+        graphics.fill(
+                x + 1,
+                y + 1,
+                x + FieldGuideBookLayout.VARIANT_SLOT_SIZE - 1,
+                y + FieldGuideBookLayout.VARIANT_SLOT_SIZE - 1,
+                PANEL_COLOR
+        );
+        drawItem(
+                graphics,
+                client.font,
+                craftingResultStack(client, recipeId),
+                x + FieldGuideBookLayout.VARIANT_ICON_PAD,
+                y + FieldGuideBookLayout.VARIANT_ICON_PAD,
+                mouseX,
+                mouseY
+        );
+    }
+
+    private static void renderUnavailable(Minecraft client, GuiGraphicsExtractor graphics, int x, int y) {
         graphics.text(
                 client.font,
                 Component.translatable("dwm.guide.recipe.unavailable"),
-                bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X,
-                bookTop + FieldGuideBookLayout.RIGHT_RECIPE_Y,
+                x,
+                y,
                 0xFF888888,
                 false
         );
     }
 
-    private static int renderCraftingPreview(
+    private static void renderCraftingPreview(
             GuiGraphicsExtractor graphics,
             Minecraft client,
-            int bookLeft,
+            int x,
             int y,
             RecipeDisplay display,
             ContextMap context,
@@ -130,10 +164,9 @@ public final class FieldGuideRecipePanel {
         Optional<FieldGuideRecipeGridBuilder.CraftingPreview> preview =
                 FieldGuideRecipeGridBuilder.craftingPreview(display, context);
         if (preview.isEmpty()) {
-            return y;
+            return;
         }
 
-        int x = centeredX(bookLeft);
         renderPanel(graphics, x, y);
         int gridX = x + 7;
         int gridY = y + 5;
@@ -162,13 +195,12 @@ public final class FieldGuideRecipePanel {
                 mouseX,
                 mouseY
         );
-        return y + PANEL_HEIGHT;
     }
 
-    private static int renderFurnacePreview(
+    private static void renderFurnacePreview(
             GuiGraphicsExtractor graphics,
             Minecraft client,
-            int bookLeft,
+            int x,
             int y,
             RecipeDisplay display,
             ContextMap context,
@@ -176,10 +208,9 @@ public final class FieldGuideRecipePanel {
             int mouseY
     ) {
         if (!(display instanceof FurnaceRecipeDisplay furnace)) {
-            return y;
+            return;
         }
 
-        int x = centeredX(bookLeft);
         renderPanel(graphics, x, y);
         int inputX = x + 20;
         int outputX = x + 98;
@@ -194,13 +225,12 @@ public final class FieldGuideRecipePanel {
         ItemStack result = furnace.result().resolveForFirstStack(context);
         drawItemInSlot(graphics, client.font, input, inputX, slotY, mouseX, mouseY);
         drawItemInSlot(graphics, client.font, result, outputX, slotY, mouseX, mouseY);
-        return y + PANEL_HEIGHT;
     }
 
-    private static int renderStonecutterPreview(
+    private static void renderStonecutterPreview(
             GuiGraphicsExtractor graphics,
             Minecraft client,
-            int bookLeft,
+            int x,
             int y,
             RecipeDisplay display,
             ContextMap context,
@@ -208,10 +238,9 @@ public final class FieldGuideRecipePanel {
             int mouseY
     ) {
         if (!(display instanceof StonecutterRecipeDisplay stonecutter)) {
-            return y;
+            return;
         }
 
-        int x = centeredX(bookLeft);
         renderPanel(graphics, x, y);
         int inputX = x + 20;
         int outputX = x + 98;
@@ -225,12 +254,6 @@ public final class FieldGuideRecipePanel {
         ItemStack result = stonecutter.result().resolveForFirstStack(context);
         drawItemInSlot(graphics, client.font, input, inputX, slotY, mouseX, mouseY);
         drawItemInSlot(graphics, client.font, result, outputX, slotY, mouseX, mouseY);
-        return y + PANEL_HEIGHT;
-    }
-
-    private static int centeredX(int bookLeft) {
-        int pageCenter = bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X + FieldGuideBookLayout.RIGHT_PAGE_WIDTH / 2;
-        return pageCenter - PANEL_WIDTH / 2;
     }
 
     private static void renderPanel(GuiGraphicsExtractor graphics, int x, int y) {
@@ -304,69 +327,6 @@ public final class FieldGuideRecipePanel {
         return recipes.byKey(ResourceKey.create(Registries.RECIPE, recipeId));
     }
 
-    public static void renderCraftingVariants(
-            GuiGraphicsExtractor graphics,
-            Minecraft client,
-            int bookLeft,
-            int bookTop,
-            FieldGuidePage page,
-            int selectedIndex,
-            int mouseX,
-            int mouseY
-    ) {
-        List<Identifier> recipes = page.craftingRecipes();
-        if (recipes.size() <= 1) {
-            return;
-        }
-
-        for (int index = 0; index < recipes.size(); index++) {
-            int slotX = variantSlotX(bookLeft, recipes.size(), index);
-            int slotY = variantRowY(bookTop);
-            boolean selected = index == selectedIndex;
-            graphics.fill(
-                    slotX,
-                    slotY,
-                    slotX + FieldGuideBookLayout.VARIANT_SLOT_SIZE,
-                    slotY + FieldGuideBookLayout.VARIANT_SLOT_SIZE,
-                    selected ? FieldGuideBookLayout.ACCENT_COLOR : SLOT_BORDER_COLOR
-            );
-            graphics.fill(
-                    slotX + 1,
-                    slotY + 1,
-                    slotX + FieldGuideBookLayout.VARIANT_SLOT_SIZE - 1,
-                    slotY + FieldGuideBookLayout.VARIANT_SLOT_SIZE - 1,
-                    PANEL_COLOR
-            );
-            drawItem(
-                    graphics,
-                    client.font,
-                    craftingResultStack(client, recipes.get(index)),
-                    slotX + FieldGuideBookLayout.VARIANT_ICON_PAD,
-                    slotY + FieldGuideBookLayout.VARIANT_ICON_PAD,
-                    mouseX,
-                    mouseY
-            );
-        }
-    }
-
-    public static int craftingVariantIndexAt(FieldGuidePage page, int bookLeft, int bookTop, double mouseX, double mouseY) {
-        List<Identifier> recipes = page.craftingRecipes();
-        if (recipes.size() <= 1) {
-            return -1;
-        }
-        int slotY = variantRowY(bookTop);
-        if (mouseY < slotY || mouseY >= slotY + FieldGuideBookLayout.VARIANT_SLOT_SIZE) {
-            return -1;
-        }
-        for (int index = 0; index < recipes.size(); index++) {
-            int slotX = variantSlotX(bookLeft, recipes.size(), index);
-            if (mouseX >= slotX && mouseX < slotX + FieldGuideBookLayout.VARIANT_SLOT_SIZE) {
-                return index;
-            }
-        }
-        return -1;
-    }
-
     private static ItemStack craftingResultStack(Minecraft client, Identifier recipeId) {
         Optional<RecipeHolder<?>> holder = recipeHolder(client, recipeId);
         if (holder.isEmpty()) {
@@ -379,18 +339,6 @@ public final class FieldGuideRecipePanel {
                 .flatMap(display -> FieldGuideRecipeGridBuilder.craftingPreview(display, context))
                 .map(FieldGuideRecipeGridBuilder.CraftingPreview::result)
                 .orElse(ItemStack.EMPTY);
-    }
-
-    private static int variantRowY(int bookTop) {
-        return bookTop + FieldGuideBookLayout.RIGHT_RECIPE_LABEL_Y - 2;
-    }
-
-    private static int variantSlotX(int bookLeft, int variantCount, int index) {
-        int rightEdge = bookLeft + FieldGuideBookLayout.RIGHT_PAGE_X + FieldGuideBookLayout.RIGHT_PAGE_WIDTH;
-        int totalWidth = variantCount * FieldGuideBookLayout.VARIANT_SLOT_SIZE
-                + (variantCount - 1) * FieldGuideBookLayout.VARIANT_ICON_GAP;
-        int startX = rightEdge - totalWidth;
-        return startX + index * (FieldGuideBookLayout.VARIANT_SLOT_SIZE + FieldGuideBookLayout.VARIANT_ICON_GAP);
     }
 
     private static @Nullable Identifier recipeIdFor(FieldGuidePage page, Station station, int craftingVariantIndex) {

--- a/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideRecipeWidget.java
+++ b/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideRecipeWidget.java
@@ -1,0 +1,56 @@
+package com.adamkali.dwm.guide;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.network.chat.CommonComponents;
+
+@Environment(EnvType.CLIENT)
+public final class FieldGuideRecipeWidget extends AbstractWidget {
+    private final Minecraft client;
+    private final FieldGuidePage page;
+    private final FieldGuideRecipePanel.Station station;
+    private final int craftingVariantIndex;
+
+    public FieldGuideRecipeWidget(
+            Minecraft client,
+            FieldGuidePage page,
+            FieldGuideRecipePanel.Station station,
+            int craftingVariantIndex
+    ) {
+        super(0, 0, FieldGuideRecipePanel.PANEL_WIDTH, FieldGuideRecipePanel.PANEL_HEIGHT, CommonComponents.EMPTY);
+        this.client = client;
+        this.page = page;
+        this.station = station;
+        this.craftingVariantIndex = craftingVariantIndex;
+        this.active = false;
+    }
+
+    @Override
+    protected void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        FieldGuideRecipePanel.render(
+                graphics,
+                client,
+                getX(),
+                getY(),
+                page,
+                station,
+                craftingVariantIndex,
+                mouseX,
+                mouseY
+        );
+    }
+
+    @Override
+    protected void updateWidgetNarration(NarrationElementOutput output) {
+    }
+
+    @Override
+    public NarratableEntry.NarrationPriority narrationPriority() {
+        return NarratableEntry.NarrationPriority.NONE;
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideVariantWidget.java
+++ b/dwm/src/client/java/com/adamkali/dwm/guide/FieldGuideVariantWidget.java
@@ -1,0 +1,66 @@
+package com.adamkali.dwm.guide;
+
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.narration.NarrationElementOutput;
+import net.minecraft.client.input.MouseButtonEvent;
+import net.minecraft.client.sounds.SoundManager;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.resources.Identifier;
+
+@Environment(EnvType.CLIENT)
+public final class FieldGuideVariantWidget extends AbstractWidget {
+    private final Minecraft client;
+    private final Identifier recipeId;
+    private final boolean selected;
+    private final Runnable onSelect;
+
+    public FieldGuideVariantWidget(
+            Minecraft client,
+            Identifier recipeId,
+            boolean selected,
+            Runnable onSelect
+    ) {
+        super(
+                0,
+                0,
+                FieldGuideBookLayout.VARIANT_SLOT_SIZE,
+                FieldGuideBookLayout.VARIANT_SLOT_SIZE,
+                CommonComponents.EMPTY
+        );
+        this.client = client;
+        this.recipeId = recipeId;
+        this.selected = selected;
+        this.onSelect = onSelect;
+    }
+
+    @Override
+    protected void extractWidgetRenderState(GuiGraphicsExtractor graphics, int mouseX, int mouseY, float delta) {
+        FieldGuideRecipePanel.renderVariant(
+                graphics,
+                client,
+                getX(),
+                getY(),
+                recipeId,
+                selected,
+                mouseX,
+                mouseY
+        );
+    }
+
+    @Override
+    public void onClick(MouseButtonEvent event, boolean doubleClick) {
+        onSelect.run();
+    }
+
+    @Override
+    public void playDownSound(SoundManager soundManager) {
+    }
+
+    @Override
+    protected void updateWidgetNarration(NarrationElementOutput output) {
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/gui/layout/StackTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/gui/layout/StackTest.java
@@ -1,0 +1,73 @@
+package com.adamkali.dwm.gui.layout;
+
+import net.minecraft.client.gui.components.AbstractWidget;
+import net.minecraft.client.gui.layouts.SpacerElement;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StackTest {
+    @Test
+    void verticalStackPlacesChildrenWithGap() {
+        SpacerElement first = new SpacerElement(10, 8);
+        SpacerElement second = new SpacerElement(10, 8);
+        SpacerElement third = new SpacerElement(10, 8);
+        Stack stack = Stack.vertical(4);
+        stack.add(first);
+        stack.add(second);
+        stack.add(third);
+        stack.setPosition(20, 30);
+        stack.arrangeElements();
+
+        assertEquals(30, first.getY());
+        assertEquals(42, second.getY());
+        assertEquals(54, third.getY());
+        assertEquals(20, first.getX());
+        assertEquals(8 + 4 + 8 + 4 + 8, stack.getHeight());
+    }
+
+    @Test
+    void columnsPlaceChildrenHorizontallyWithGap() {
+        SpacerElement first = new SpacerElement(12, 6);
+        SpacerElement second = new SpacerElement(12, 6);
+        Stack columns = Columns.of(3, first, second);
+        columns.setPosition(5, 9);
+        columns.arrangeElements();
+
+        assertEquals(5, first.getX());
+        assertEquals(20, second.getX());
+        assertEquals(9, first.getY());
+        assertEquals(9, second.getY());
+        assertEquals(12 + 3 + 12, columns.getWidth());
+    }
+
+    @Test
+    void fillWidgetReportsConstructedSize() {
+        FillWidget fill = new FillWidget(166, 1, 0xFFC79A45);
+        assertEquals(166, fill.getWidth());
+        assertEquals(1, fill.getHeight());
+    }
+
+    @Test
+    void mountArrangesAndCollectsWidgets() {
+        FillWidget hairline = new FillWidget(20, 1, 0xFFFFFFFF);
+        SpacerElement spacer = new SpacerElement(20, 8);
+        Stack stack = Stack.vertical(2);
+        stack.add(hairline);
+        stack.add(spacer);
+
+        List<AbstractWidget> captured = new ArrayList<>();
+        List<AbstractWidget> widgets = Layouts.mount(stack, 10, 15, captured::add);
+
+        assertEquals(1, widgets.size());
+        assertEquals(hairline, widgets.getFirst());
+        assertEquals(captured, widgets);
+        assertEquals(10, hairline.getX());
+        assertEquals(15, hairline.getY());
+        assertEquals(10, spacer.getX());
+        assertEquals(18, spacer.getY());
+    }
+}


### PR DESCRIPTION
## Why this matters

- Field Guide pages were positioned with a table of magic Y coordinates, so adding body text, a recipe, or variants meant restitching every later offset by hand.

## Proposed Implementation

- Add a small client layout toolkit (`Stack`, `Columns`, `FillWidget`, `Layouts.mount`) on top of vanilla `LinearLayout`.
- Rebuild Field Guide page content as nested layout trees; book chrome, page-turn buttons, and Done stay absolutely placed.
- Recipe previews and crafting-variant icons become widgets, so body text can push the diagram down instead of truncating to protect a fixed `RIGHT_RECIPE_Y`.
- Unit-test stack/column spacing and FillWidget sizing (`StackTest`).

## Problems Encountered / Decisions Made

- Stacked on #219 because this screen already uses the roundel variant selector.
- `Layouts.mount` takes an add-widget callback rather than `Screen` directly: `addRenderableWidget` is protected.
- Page indicator stays pinned to the book footer with the page-turn buttons, not in the flowing right-page stack, so it stays aligned with the chrome.


Made with [Cursor](https://cursor.com)