### PR TITLE
feat(guide): load Field Guide catalog from datapacks

### DIFF
--- a/dwm/docs/feature-field-guide.md
+++ b/dwm/docs/feature-field-guide.md
@@ -41,13 +41,13 @@ Future phases may add Gallifrey building, Azbantium, dimension reference, and ch
 
 ## Datapack layout
 
-The catalog is three synced dynamic registries. File path is the entry id (`data/dwm/guide/page/find_tardis.json` → `dwm:find_tardis`). Nested `id` fields must match the file id.
+The catalog is three synced dynamic registries. Registry keys use the vanilla `minecraft` namespace so Fabric does not insert an extra registry-namespace folder. File path is the entry id (`data/dwm/guide/page/find_tardis.json` → `dwm:find_tardis`). Nested `id` fields must match the file id.
 
 | Registry | Folder | Built-in entry |
 | --- | --- | --- |
-| `dwm:guide/book` | `data/<ns>/guide/book/` | `dwm:field_guide` |
-| `dwm:guide/chapter` | `data/<ns>/guide/chapter/` | `dwm:quick_start`, `dwm:sonic`, `dwm:console_room` |
-| `dwm:guide/page` | `data/<ns>/guide/page/` | one JSON per page |
+| `minecraft:guide/book` | `data/<ns>/guide/book/` | `dwm:field_guide` |
+| `minecraft:guide/chapter` | `data/<ns>/guide/chapter/` | `dwm:quick_start`, `dwm:sonic`, `dwm:console_room` |
+| `minecraft:guide/page` | `data/<ns>/guide/page/` | one JSON per page |
 
 **Book**
 

--- a/dwm/docs/feature-field-guide.md
+++ b/dwm/docs/feature-field-guide.md
@@ -20,7 +20,7 @@ Give players an always-available in-mod playbook for DWM crafting chains and cor
 | Keybind | **G** (`Controls → Doctor Who Mod → Open Field Guide`) |
 | Pause menu | **Field Guide** button on the in-game pause screen |
 
-There is no physical guide item and no server packet — the screen is client-only.
+There is no physical guide item. The screen is client-only; catalog content is loaded from datapacks and synced with the world.
 
 ## Presentation
 
@@ -38,6 +38,64 @@ There is no physical guide item and no server packet — the screen is client-on
 | **Console Room Builder** | Chronoplasm, wall, roundels (A/B/Big on one page), interior props (white canonical recipes; pattern note for colours) |
 
 Future phases may add Gallifrey building, Azbantium, dimension reference, and chameleon notes.
+
+## Datapack layout
+
+The catalog is three synced dynamic registries. File path is the entry id (`data/dwm/guide/page/find_tardis.json` → `dwm:find_tardis`). Nested `id` fields must match the file id.
+
+| Registry | Folder | Built-in entry |
+| --- | --- | --- |
+| `dwm:guide/book` | `data/<ns>/guide/book/` | `dwm:field_guide` |
+| `dwm:guide/chapter` | `data/<ns>/guide/chapter/` | `dwm:quick_start`, `dwm:sonic`, `dwm:console_room` |
+| `dwm:guide/page` | `data/<ns>/guide/page/` | one JSON per page |
+
+**Book**
+
+```json
+{
+  "guide": { "id": "dwm:field_guide" },
+  "chapters": [
+    { "id": "dwm:quick_start" },
+    { "id": "dwm:sonic" },
+    { "id": "dwm:console_room" }
+  ]
+}
+```
+
+**Chapter**
+
+```json
+{
+  "chapter": { "id": "dwm:quick_start" },
+  "titleKey": "dwm.guide.chapter.quick_start",
+  "pages": [
+    { "id": "dwm:find_tardis" },
+    { "id": "dwm:claim_tardis" }
+  ]
+}
+```
+
+**Page** — exactly one `text` block, plus optional recipe blocks (`crafting`, `smelting`, `stonecutting`). `pattern: true` shows the colour-swap footnote.
+
+```json
+{
+  "page": { "id": "dwm:chronoplasm" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.chronoplasm.title",
+      "bodyKey": "dwm.guide.page.chronoplasm.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": ["dwm:white_chronoplasm_powder"],
+      "pattern": true
+    }
+  ]
+}
+```
+
+`/reload` rebuilds the registries. Other datapacks replace entries by id (replacing `dwm:field_guide` replaces the chapter list). Lang strings remain in the language provider / `en_us.json`.
 
 ## Known Constraints
 

--- a/dwm/src/client/java/com/adamkali/dwm/gui/FieldGuideScreen.java
+++ b/dwm/src/client/java/com/adamkali/dwm/gui/FieldGuideScreen.java
@@ -51,10 +51,7 @@ public class FieldGuideScreen extends Screen {
 
     public FieldGuideScreen(@Nullable FieldGuidePage initialPage) {
         super(Component.translatable("dwm.guide.title"));
-        if (initialPage != null) {
-            selectedChapter = FieldGuideCatalog.chapterForPage(initialPage);
-            selectedPage = initialPage;
-        }
+        selectedPage = initialPage;
     }
 
     @Override
@@ -63,11 +60,22 @@ public class FieldGuideScreen extends Screen {
         bookTop = FieldGuideBookLayout.bookTop(height);
         contentWidgets.clear();
 
+        List<FieldGuideChapter> chapters = chapters();
         if (selectedPage == null) {
-            selectedChapter = FieldGuideCatalog.chapters().getFirst();
-            selectedPage = selectedChapter.pages().getFirst();
+            if (!chapters.isEmpty() && !chapters.getFirst().pages().isEmpty()) {
+                selectedChapter = chapters.getFirst();
+                selectedPage = selectedChapter.pages().getFirst();
+            }
         } else if (selectedChapter == null) {
-            selectedChapter = FieldGuideCatalog.chapterForPage(selectedPage);
+            for (FieldGuideChapter chapter : chapters) {
+                if (chapter.pages().contains(selectedPage)) {
+                    selectedChapter = chapter;
+                    break;
+                }
+            }
+            if (selectedChapter == null) {
+                selectedPage = null;
+            }
         }
 
         backPageButton = addRenderableWidget(new PageButton(
@@ -129,7 +137,7 @@ public class FieldGuideScreen extends Screen {
 
     private Stack buildLeftPage() {
         Stack chapters = Stack.vertical(FieldGuideBookLayout.CHAPTER_BUTTON_GAP);
-        for (FieldGuideChapter chapter : FieldGuideCatalog.chapters()) {
+        for (FieldGuideChapter chapter : chapters()) {
             FieldGuideChapter targetChapter = chapter;
             boolean selected = chapter.equals(selectedChapter);
             chapters.add(new PlainTextButton(
@@ -317,6 +325,13 @@ public class FieldGuideScreen extends Screen {
         );
     }
 
+    private List<FieldGuideChapter> chapters() {
+        if (minecraft == null || minecraft.level == null) {
+            return List.of();
+        }
+        return FieldGuideCatalog.chapters(minecraft.level.registryAccess());
+    }
+
     private static Component styledChapterLabel(String titleKey, boolean selected) {
         return Component.translatable(titleKey).withStyle(selected
                 ? Style.EMPTY.withBold(true).withColor(FieldGuideBookLayout.CHAPTER_SELECTED_COLOR)
@@ -336,7 +351,7 @@ public class FieldGuideScreen extends Screen {
 
     private void selectPage(FieldGuidePage page) {
         selectedPage = page;
-        selectedChapter = FieldGuideCatalog.chapterForPage(page);
+        selectedChapter = FieldGuideCatalog.chapterForPage(chapters(), page);
         selectedCraftingVariantIndex = 0;
         List<FieldGuideRecipePanel.Station> stations = FieldGuideRecipePanel.availableStations(page);
         if (!stations.isEmpty() && !stations.contains(selectedStation)) {

--- a/dwm/src/main/java/com/adamkali/dwm/DWMMain.java
+++ b/dwm/src/main/java/com/adamkali/dwm/DWMMain.java
@@ -8,6 +8,7 @@ import com.adamkali.dwm.block.entities.DWMBlockEntities;
 import com.adamkali.dwm.command.TardisCommands;
 import com.adamkali.dwm.config.DWMConfig;
 import com.adamkali.dwm.entity.DWMEntityTypes;
+import com.adamkali.dwm.guide.FieldGuideRegistries;
 import com.adamkali.dwm.item.DWMDataComponents;
 import com.adamkali.dwm.item.DWMItems;
 import com.adamkali.dwm.network.ServerPayloadTypeRegistry;
@@ -39,6 +40,7 @@ public class DWMMain implements ModInitializer {
         DWMBlockEntities.initialize();
         DWMSounds.initialize();
         DWMStructureProcessors.initialize();
+        FieldGuideRegistries.initialize();
         ServerPayloadTypeRegistry.initialize();
         PortalStreamSyncService.initialize();
         TardisTravelService.initialize();

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideBookData.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideBookData.java
@@ -1,0 +1,20 @@
+package com.adamkali.dwm.guide;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.List;
+
+/**
+ * Datapack book entry under {@code data/<ns>/guide/book/}.
+ */
+public record FieldGuideBookData(FieldGuideIdRef guide, List<FieldGuideIdRef> chapters) {
+    public static final Codec<FieldGuideBookData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            FieldGuideIdRef.CODEC.fieldOf("guide").forGetter(FieldGuideBookData::guide),
+            FieldGuideIdRef.CODEC.listOf().fieldOf("chapters").forGetter(FieldGuideBookData::chapters)
+    ).apply(instance, FieldGuideBookData::new));
+
+    public FieldGuideBookData {
+        chapters = List.copyOf(chapters);
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideCatalog.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideCatalog.java
@@ -1,72 +1,45 @@
 package com.adamkali.dwm.guide;
 
-import com.adamkali.dwm.DWMReference;
+import com.mojang.logging.LogUtils;
+import net.minecraft.core.Registry;
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import org.slf4j.Logger;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Curated Field Guide chapters and pages. Recipe ids reference merged data/recipe resources.
+ * Resolves the Field Guide catalog from datapack book/chapter/page registries.
  */
 public final class FieldGuideCatalog {
-    private static final Identifier SONIC_THIRD_DOCTOR =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sonic_third_doctor");
-    private static final Identifier SONIC_SECOND_DOCTOR_CASING =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "sonic_second_doctor_casing");
-    private static final Identifier TARDIS_KEY =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "tardis_key");
-    private static final Identifier WHITE_CHRONOPLASM =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_chronoplasm_powder");
-    private static final Identifier WHITE_TARDIS_WALL =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_tardis_wall");
-    private static final Identifier WHITE_ROUNDEL_A =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_roundel_a");
-    private static final Identifier WHITE_ROUNDEL_B =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_roundel_b");
-    private static final Identifier WHITE_BIG_ROUNDEL_A =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_big_roundel_a");
-    private static final Identifier TARDIS_CHAIR_SMALL =
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "tardis_chair_small");
-
-    private static final List<FieldGuideChapter> CHAPTERS = List.of(
-            new FieldGuideChapter("quick_start", "dwm.guide.chapter.quick_start", List.of(
-                    FieldGuidePage.text("find_tardis", "dwm.guide.page.find_tardis.title", "dwm.guide.page.find_tardis.body"),
-                    FieldGuidePage.text("claim_tardis", "dwm.guide.page.claim_tardis.title", "dwm.guide.page.claim_tardis.body"),
-                    FieldGuidePage.text("first_hop", "dwm.guide.page.first_hop.title", "dwm.guide.page.first_hop.body"),
-                    FieldGuidePage.crafting("bind_key", "dwm.guide.page.bind_key.title", "dwm.guide.page.bind_key.body", TARDIS_KEY, false)
-            )),
-            new FieldGuideChapter("sonic", "dwm.guide.chapter.sonic", List.of(
-                    FieldGuidePage.crafting("craft_sonic", "dwm.guide.page.craft_sonic.title", "dwm.guide.page.craft_sonic.body", SONIC_THIRD_DOCTOR, false),
-                    FieldGuidePage.crafting("doctor_variants", "dwm.guide.page.doctor_variants.title", "dwm.guide.page.doctor_variants.body", SONIC_SECOND_DOCTOR_CASING, false),
-                    FieldGuidePage.text("use_sonic", "dwm.guide.page.use_sonic.title", "dwm.guide.page.use_sonic.body")
-            )),
-            new FieldGuideChapter("console_room", "dwm.guide.chapter.console_room", List.of(
-                    FieldGuidePage.crafting("chronoplasm", "dwm.guide.page.chronoplasm.title", "dwm.guide.page.chronoplasm.body", WHITE_CHRONOPLASM, true),
-                    FieldGuidePage.smelting("tardis_wall", "dwm.guide.page.tardis_wall.title", "dwm.guide.page.tardis_wall.body", WHITE_TARDIS_WALL, true),
-                    FieldGuidePage.crafting(
-                            "roundel",
-                            "dwm.guide.page.roundel.title",
-                            "dwm.guide.page.roundel.body",
-                            List.of(WHITE_ROUNDEL_A, WHITE_ROUNDEL_B, WHITE_BIG_ROUNDEL_A),
-                            true
-                    ),
-                    FieldGuidePage.crafting("interior_props", "dwm.guide.page.interior_props.title", "dwm.guide.page.interior_props.body", TARDIS_CHAIR_SMALL, false)
-            ))
-    );
+    private static final Logger LOGGER = LogUtils.getLogger();
 
     private FieldGuideCatalog() {
     }
 
-    public static List<FieldGuideChapter> chapters() {
-        return CHAPTERS;
+    public static List<FieldGuideChapter> chapters(RegistryAccess access) {
+        return resolve(
+                FieldGuideRegistries.FIELD_GUIDE_ID,
+                registryMap(access, FieldGuideRegistries.BOOK),
+                registryMap(access, FieldGuideRegistries.CHAPTER),
+                registryMap(access, FieldGuideRegistries.PAGE)
+        );
     }
 
-    public static List<FieldGuidePage> allPages() {
-        return CHAPTERS.stream().flatMap(chapter -> chapter.pages().stream()).toList();
+    public static List<FieldGuidePage> allPages(RegistryAccess access) {
+        return allPages(chapters(access));
     }
 
-    public static FieldGuideChapter chapterForPage(FieldGuidePage page) {
-        for (FieldGuideChapter chapter : CHAPTERS) {
+    public static List<FieldGuidePage> allPages(List<FieldGuideChapter> chapters) {
+        return chapters.stream().flatMap(chapter -> chapter.pages().stream()).toList();
+    }
+
+    public static FieldGuideChapter chapterForPage(List<FieldGuideChapter> chapters, FieldGuidePage page) {
+        for (FieldGuideChapter chapter : chapters) {
             if (chapter.pages().contains(page)) {
                 return chapter;
             }
@@ -74,7 +47,84 @@ public final class FieldGuideCatalog {
         throw new IllegalArgumentException("Unknown page: " + page.id());
     }
 
+    public static FieldGuideChapter chapterForPage(RegistryAccess access, FieldGuidePage page) {
+        return chapterForPage(chapters(access), page);
+    }
+
     public static int pageIndexInChapter(FieldGuideChapter chapter, FieldGuidePage page) {
         return chapter.pages().indexOf(page);
+    }
+
+    /**
+     * Assembles a catalog from in-memory datapack entries. Used by the live registries and unit tests.
+     * Missing refs and id mismatches are skipped with an error log.
+     */
+    public static List<FieldGuideChapter> resolve(
+            Identifier bookId,
+            Map<Identifier, FieldGuideBookData> books,
+            Map<Identifier, FieldGuideChapterData> chapters,
+            Map<Identifier, FieldGuidePageData> pages
+    ) {
+        FieldGuideBookData book = books.get(bookId);
+        if (book == null) {
+            LOGGER.error("Missing field guide book {}", bookId);
+            return List.of();
+        }
+        if (!bookId.equals(book.guide().id())) {
+            LOGGER.error("Field guide book id mismatch: file {} vs json {}", bookId, book.guide().id());
+            return List.of();
+        }
+
+        List<FieldGuideChapter> resolved = new ArrayList<>();
+        for (FieldGuideIdRef chapterRef : book.chapters()) {
+            Identifier chapterId = chapterRef.id();
+            FieldGuideChapterData chapterData = chapters.get(chapterId);
+            if (chapterData == null) {
+                LOGGER.error("Missing field guide chapter {}", chapterId);
+                continue;
+            }
+            if (!chapterId.equals(chapterData.chapter().id())) {
+                LOGGER.error("Field guide chapter id mismatch: file {} vs json {}", chapterId, chapterData.chapter().id());
+                continue;
+            }
+
+            List<FieldGuidePage> chapterPages = new ArrayList<>();
+            for (FieldGuideIdRef pageRef : chapterData.pages()) {
+                Identifier pageId = pageRef.id();
+                FieldGuidePageData pageData = pages.get(pageId);
+                if (pageData == null) {
+                    LOGGER.error("Missing field guide page {}", pageId);
+                    continue;
+                }
+                if (!pageId.equals(pageData.page().id())) {
+                    LOGGER.error("Field guide page id mismatch: file {} vs json {}", pageId, pageData.page().id());
+                    continue;
+                }
+                if (pageData.textBlockCount() != 1) {
+                    LOGGER.error("Field guide page {} must have exactly one text content block", pageId);
+                    continue;
+                }
+                chapterPages.add(new FieldGuidePage(pageId, pageData.content()));
+            }
+            if (chapterPages.isEmpty()) {
+                LOGGER.error("Field guide chapter {} has no valid pages", chapterId);
+                continue;
+            }
+            resolved.add(new FieldGuideChapter(chapterId, chapterData.titleKey(), chapterPages));
+        }
+        return List.copyOf(resolved);
+    }
+
+    private static <T> Map<Identifier, T> registryMap(
+            RegistryAccess access,
+            ResourceKey<Registry<T>> key
+    ) {
+        return access.lookup(key).map(registry -> {
+            Map<Identifier, T> map = new HashMap<>();
+            for (var entry : registry.entrySet()) {
+                map.put(entry.getKey().identifier(), entry.getValue());
+            }
+            return map;
+        }).orElseGet(Map::of);
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideCatalog.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideCatalog.java
@@ -67,7 +67,7 @@ public final class FieldGuideCatalog {
     ) {
         FieldGuideBookData book = books.get(bookId);
         if (book == null) {
-            LOGGER.error("Missing field guide book {}", bookId);
+            LOGGER.error("Missing field guide book {} ({} books loaded)", bookId, books.size());
             return List.of();
         }
         if (!bookId.equals(book.guide().id())) {
@@ -125,6 +125,9 @@ public final class FieldGuideCatalog {
                 map.put(entry.getKey().identifier(), entry.getValue());
             }
             return map;
-        }).orElseGet(Map::of);
+        }).orElseGet(() -> {
+            LOGGER.error("Field guide registry {} is not present in RegistryAccess", key.identifier());
+            return Map.of();
+        });
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideChapter.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideChapter.java
@@ -1,6 +1,11 @@
 package com.adamkali.dwm.guide;
 
+import net.minecraft.resources.Identifier;
+
 import java.util.List;
 
-public record FieldGuideChapter(String id, String titleKey, List<FieldGuidePage> pages) {
+public record FieldGuideChapter(Identifier id, String titleKey, List<FieldGuidePage> pages) {
+    public FieldGuideChapter {
+        pages = List.copyOf(pages);
+    }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideChapterData.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideChapterData.java
@@ -1,0 +1,21 @@
+package com.adamkali.dwm.guide;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.List;
+
+/**
+ * Datapack chapter entry under {@code data/<ns>/guide/chapter/}.
+ */
+public record FieldGuideChapterData(FieldGuideIdRef chapter, String titleKey, List<FieldGuideIdRef> pages) {
+    public static final Codec<FieldGuideChapterData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            FieldGuideIdRef.CODEC.fieldOf("chapter").forGetter(FieldGuideChapterData::chapter),
+            Codec.STRING.fieldOf("titleKey").forGetter(FieldGuideChapterData::titleKey),
+            FieldGuideIdRef.CODEC.listOf().fieldOf("pages").forGetter(FieldGuideChapterData::pages)
+    ).apply(instance, FieldGuideChapterData::new));
+
+    public FieldGuideChapterData {
+        pages = List.copyOf(pages);
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideContent.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideContent.java
@@ -1,0 +1,102 @@
+package com.adamkali.dwm.guide;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.MapCodec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.resources.Identifier;
+import net.minecraft.util.StringRepresentable;
+
+import java.util.List;
+
+/**
+ * Tagged page content block. Dispatch key is {@code type}.
+ */
+public sealed interface FieldGuideContent {
+    Kind kind();
+
+    Codec<FieldGuideContent> CODEC = Kind.CODEC.dispatch("type", FieldGuideContent::kind, Kind::mapCodec);
+
+    enum Kind implements StringRepresentable {
+        TEXT("text"),
+        CRAFTING("crafting"),
+        SMELTING("smelting"),
+        STONECUTTING("stonecutting");
+
+        public static final StringRepresentable.EnumCodec<Kind> CODEC = StringRepresentable.fromEnum(Kind::values);
+
+        private final String serializedName;
+
+        Kind(String serializedName) {
+            this.serializedName = serializedName;
+        }
+
+        @Override
+        public String getSerializedName() {
+            return serializedName;
+        }
+
+        MapCodec<? extends FieldGuideContent> mapCodec() {
+            return switch (this) {
+                case TEXT -> Text.MAP_CODEC;
+                case CRAFTING -> Crafting.MAP_CODEC;
+                case SMELTING -> Smelting.MAP_CODEC;
+                case STONECUTTING -> Stonecutting.MAP_CODEC;
+            };
+        }
+    }
+
+    record Text(String titleKey, String bodyKey) implements FieldGuideContent {
+        public static final MapCodec<Text> MAP_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Codec.STRING.fieldOf("titleKey").forGetter(Text::titleKey),
+                Codec.STRING.fieldOf("bodyKey").forGetter(Text::bodyKey)
+        ).apply(instance, Text::new));
+
+        @Override
+        public Kind kind() {
+            return Kind.TEXT;
+        }
+    }
+
+    record Crafting(List<Identifier> recipes, boolean pattern) implements FieldGuideContent {
+        public static final MapCodec<Crafting> MAP_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Identifier.CODEC.listOf().fieldOf("recipes").forGetter(Crafting::recipes),
+                Codec.BOOL.optionalFieldOf("pattern", false).forGetter(Crafting::pattern)
+        ).apply(instance, Crafting::new));
+
+        public Crafting {
+            recipes = List.copyOf(recipes);
+            if (recipes.isEmpty()) {
+                throw new IllegalArgumentException("crafting content requires at least one recipe");
+            }
+        }
+
+        @Override
+        public Kind kind() {
+            return Kind.CRAFTING;
+        }
+    }
+
+    record Smelting(Identifier recipe, boolean pattern) implements FieldGuideContent {
+        public static final MapCodec<Smelting> MAP_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Identifier.CODEC.fieldOf("recipe").forGetter(Smelting::recipe),
+                Codec.BOOL.optionalFieldOf("pattern", false).forGetter(Smelting::pattern)
+        ).apply(instance, Smelting::new));
+
+        @Override
+        public Kind kind() {
+            return Kind.SMELTING;
+        }
+    }
+
+    record Stonecutting(Identifier recipe, boolean pattern) implements FieldGuideContent {
+        public static final MapCodec<Stonecutting> MAP_CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
+                Identifier.CODEC.fieldOf("recipe").forGetter(Stonecutting::recipe),
+                Codec.BOOL.optionalFieldOf("pattern", false).forGetter(Stonecutting::pattern)
+        ).apply(instance, Stonecutting::new));
+
+        @Override
+        public Kind kind() {
+            return Kind.STONECUTTING;
+        }
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideIdRef.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideIdRef.java
@@ -1,0 +1,14 @@
+package com.adamkali.dwm.guide;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import net.minecraft.resources.Identifier;
+
+/**
+ * JSON wrapper {@code {"id": "dwm:..."}} used by book, chapter, and page files.
+ */
+public record FieldGuideIdRef(Identifier id) {
+    public static final Codec<FieldGuideIdRef> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            Identifier.CODEC.fieldOf("id").forGetter(FieldGuideIdRef::id)
+    ).apply(instance, FieldGuideIdRef::new));
+}

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuidePage.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuidePage.java
@@ -6,38 +6,74 @@ import org.jetbrains.annotations.Nullable;
 import java.util.List;
 
 /**
- * One Field Guide page: localized title/body plus optional recipe ids per station.
+ * One Field Guide page: localized title/body plus optional recipe ids per station,
+ * derived from datapack {@link FieldGuideContent} blocks.
  */
-public record FieldGuidePage(
-        String id,
-        String titleKey,
-        String bodyKey,
-        List<Identifier> craftingRecipes,
-        @Nullable Identifier smeltingRecipe,
-        @Nullable Identifier stonecuttingRecipe,
-        boolean patternPage
-) {
+public record FieldGuidePage(Identifier id, List<FieldGuideContent> content) {
     public FieldGuidePage {
-        craftingRecipes = List.copyOf(craftingRecipes);
+        content = List.copyOf(content);
+    }
+
+    public String titleKey() {
+        return text().titleKey();
+    }
+
+    public String bodyKey() {
+        return text().bodyKey();
+    }
+
+    public List<Identifier> craftingRecipes() {
+        return content.stream()
+                .filter(FieldGuideContent.Crafting.class::isInstance)
+                .map(FieldGuideContent.Crafting.class::cast)
+                .flatMap(block -> block.recipes().stream())
+                .toList();
     }
 
     public @Nullable Identifier craftingRecipe() {
-        return craftingRecipes.isEmpty() ? null : craftingRecipes.getFirst();
+        List<Identifier> recipes = craftingRecipes();
+        return recipes.isEmpty() ? null : recipes.getFirst();
     }
 
-    public static FieldGuidePage text(String id, String titleKey, String bodyKey) {
-        return new FieldGuidePage(id, titleKey, bodyKey, List.of(), null, null, false);
+    public @Nullable Identifier smeltingRecipe() {
+        return content.stream()
+                .filter(FieldGuideContent.Smelting.class::isInstance)
+                .map(FieldGuideContent.Smelting.class::cast)
+                .map(FieldGuideContent.Smelting::recipe)
+                .findFirst()
+                .orElse(null);
     }
 
-    public static FieldGuidePage crafting(String id, String titleKey, String bodyKey, Identifier recipe, boolean patternPage) {
-        return crafting(id, titleKey, bodyKey, List.of(recipe), patternPage);
+    public @Nullable Identifier stonecuttingRecipe() {
+        return content.stream()
+                .filter(FieldGuideContent.Stonecutting.class::isInstance)
+                .map(FieldGuideContent.Stonecutting.class::cast)
+                .map(FieldGuideContent.Stonecutting::recipe)
+                .findFirst()
+                .orElse(null);
     }
 
-    public static FieldGuidePage crafting(String id, String titleKey, String bodyKey, List<Identifier> recipes, boolean patternPage) {
-        return new FieldGuidePage(id, titleKey, bodyKey, recipes, null, null, patternPage);
+    public boolean patternPage() {
+        for (FieldGuideContent block : content) {
+            if (block instanceof FieldGuideContent.Crafting crafting && crafting.pattern()) {
+                return true;
+            }
+            if (block instanceof FieldGuideContent.Smelting smelting && smelting.pattern()) {
+                return true;
+            }
+            if (block instanceof FieldGuideContent.Stonecutting stonecutting && stonecutting.pattern()) {
+                return true;
+            }
+        }
+        return false;
     }
 
-    public static FieldGuidePage smelting(String id, String titleKey, String bodyKey, Identifier recipe, boolean patternPage) {
-        return new FieldGuidePage(id, titleKey, bodyKey, List.of(), recipe, null, patternPage);
+    private FieldGuideContent.Text text() {
+        for (FieldGuideContent block : content) {
+            if (block instanceof FieldGuideContent.Text text) {
+                return text;
+            }
+        }
+        throw new IllegalStateException("Page has no text content: " + id);
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuidePageData.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuidePageData.java
@@ -1,0 +1,24 @@
+package com.adamkali.dwm.guide;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import java.util.List;
+
+/**
+ * Datapack page entry under {@code data/<ns>/guide/page/}.
+ */
+public record FieldGuidePageData(FieldGuideIdRef page, List<FieldGuideContent> content) {
+    public static final Codec<FieldGuidePageData> CODEC = RecordCodecBuilder.create(instance -> instance.group(
+            FieldGuideIdRef.CODEC.fieldOf("page").forGetter(FieldGuidePageData::page),
+            FieldGuideContent.CODEC.listOf().fieldOf("content").forGetter(FieldGuidePageData::content)
+    ).apply(instance, FieldGuidePageData::new));
+
+    public FieldGuidePageData {
+        content = List.copyOf(content);
+    }
+
+    public long textBlockCount() {
+        return content.stream().filter(FieldGuideContent.Text.class::isInstance).count();
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideRegistries.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideRegistries.java
@@ -8,16 +8,21 @@ import net.minecraft.resources.ResourceKey;
 
 /**
  * Synced datapack registries for Field Guide books, chapters, and pages.
+ *
+ * <p>Keys use the vanilla {@code minecraft} namespace so Fabric does not prepend a registry
+ * namespace folder. Entries therefore load from {@code data/<entry ns>/guide/...} — for example
+ * {@code data/dwm/guide/book/field_guide.json}. A {@code dwm:} registry id would load from
+ * {@code data/<entry ns>/dwm/guide/...} instead.
  */
 public final class FieldGuideRegistries {
     public static final ResourceKey<Registry<FieldGuideBookData>> BOOK = ResourceKey.createRegistryKey(
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "guide/book")
+            Identifier.withDefaultNamespace("guide/book")
     );
     public static final ResourceKey<Registry<FieldGuideChapterData>> CHAPTER = ResourceKey.createRegistryKey(
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "guide/chapter")
+            Identifier.withDefaultNamespace("guide/chapter")
     );
     public static final ResourceKey<Registry<FieldGuidePageData>> PAGE = ResourceKey.createRegistryKey(
-            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "guide/page")
+            Identifier.withDefaultNamespace("guide/page")
     );
 
     public static final Identifier FIELD_GUIDE_ID =

--- a/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideRegistries.java
+++ b/dwm/src/main/java/com/adamkali/dwm/guide/FieldGuideRegistries.java
@@ -1,0 +1,34 @@
+package com.adamkali.dwm.guide;
+
+import com.adamkali.dwm.DWMReference;
+import net.fabricmc.fabric.api.event.registry.DynamicRegistries;
+import net.minecraft.core.Registry;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+
+/**
+ * Synced datapack registries for Field Guide books, chapters, and pages.
+ */
+public final class FieldGuideRegistries {
+    public static final ResourceKey<Registry<FieldGuideBookData>> BOOK = ResourceKey.createRegistryKey(
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "guide/book")
+    );
+    public static final ResourceKey<Registry<FieldGuideChapterData>> CHAPTER = ResourceKey.createRegistryKey(
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "guide/chapter")
+    );
+    public static final ResourceKey<Registry<FieldGuidePageData>> PAGE = ResourceKey.createRegistryKey(
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "guide/page")
+    );
+
+    public static final Identifier FIELD_GUIDE_ID =
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "field_guide");
+
+    private FieldGuideRegistries() {
+    }
+
+    public static void initialize() {
+        DynamicRegistries.registerSynced(BOOK, FieldGuideBookData.CODEC);
+        DynamicRegistries.registerSynced(CHAPTER, FieldGuideChapterData.CODEC);
+        DynamicRegistries.registerSynced(PAGE, FieldGuidePageData.CODEC);
+    }
+}

--- a/dwm/src/main/resources/data/dwm/guide/book/field_guide.json
+++ b/dwm/src/main/resources/data/dwm/guide/book/field_guide.json
@@ -1,0 +1,8 @@
+{
+  "guide": { "id": "dwm:field_guide" },
+  "chapters": [
+    { "id": "dwm:quick_start" },
+    { "id": "dwm:sonic" },
+    { "id": "dwm:console_room" }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/chapter/console_room.json
+++ b/dwm/src/main/resources/data/dwm/guide/chapter/console_room.json
@@ -1,0 +1,10 @@
+{
+  "chapter": { "id": "dwm:console_room" },
+  "titleKey": "dwm.guide.chapter.console_room",
+  "pages": [
+    { "id": "dwm:chronoplasm" },
+    { "id": "dwm:tardis_wall" },
+    { "id": "dwm:roundel" },
+    { "id": "dwm:interior_props" }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/chapter/quick_start.json
+++ b/dwm/src/main/resources/data/dwm/guide/chapter/quick_start.json
@@ -1,0 +1,10 @@
+{
+  "chapter": { "id": "dwm:quick_start" },
+  "titleKey": "dwm.guide.chapter.quick_start",
+  "pages": [
+    { "id": "dwm:find_tardis" },
+    { "id": "dwm:claim_tardis" },
+    { "id": "dwm:first_hop" },
+    { "id": "dwm:bind_key" }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/chapter/sonic.json
+++ b/dwm/src/main/resources/data/dwm/guide/chapter/sonic.json
@@ -1,0 +1,9 @@
+{
+  "chapter": { "id": "dwm:sonic" },
+  "titleKey": "dwm.guide.chapter.sonic",
+  "pages": [
+    { "id": "dwm:craft_sonic" },
+    { "id": "dwm:doctor_variants" },
+    { "id": "dwm:use_sonic" }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/bind_key.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/bind_key.json
@@ -1,0 +1,14 @@
+{
+  "page": { "id": "dwm:bind_key" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.bind_key.title",
+      "bodyKey": "dwm.guide.page.bind_key.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": ["dwm:tardis_key"]
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/chronoplasm.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/chronoplasm.json
@@ -1,0 +1,15 @@
+{
+  "page": { "id": "dwm:chronoplasm" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.chronoplasm.title",
+      "bodyKey": "dwm.guide.page.chronoplasm.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": ["dwm:white_chronoplasm_powder"],
+      "pattern": true
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/claim_tardis.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/claim_tardis.json
@@ -1,0 +1,10 @@
+{
+  "page": { "id": "dwm:claim_tardis" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.claim_tardis.title",
+      "bodyKey": "dwm.guide.page.claim_tardis.body"
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/craft_sonic.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/craft_sonic.json
@@ -1,0 +1,14 @@
+{
+  "page": { "id": "dwm:craft_sonic" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.craft_sonic.title",
+      "bodyKey": "dwm.guide.page.craft_sonic.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": ["dwm:sonic_third_doctor"]
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/doctor_variants.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/doctor_variants.json
@@ -1,0 +1,14 @@
+{
+  "page": { "id": "dwm:doctor_variants" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.doctor_variants.title",
+      "bodyKey": "dwm.guide.page.doctor_variants.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": ["dwm:sonic_second_doctor_casing"]
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/find_tardis.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/find_tardis.json
@@ -1,0 +1,10 @@
+{
+  "page": { "id": "dwm:find_tardis" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.find_tardis.title",
+      "bodyKey": "dwm.guide.page.find_tardis.body"
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/first_hop.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/first_hop.json
@@ -1,0 +1,10 @@
+{
+  "page": { "id": "dwm:first_hop" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.first_hop.title",
+      "bodyKey": "dwm.guide.page.first_hop.body"
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/interior_props.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/interior_props.json
@@ -1,0 +1,14 @@
+{
+  "page": { "id": "dwm:interior_props" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.interior_props.title",
+      "bodyKey": "dwm.guide.page.interior_props.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": ["dwm:tardis_chair_small"]
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/roundel.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/roundel.json
@@ -1,0 +1,19 @@
+{
+  "page": { "id": "dwm:roundel" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.roundel.title",
+      "bodyKey": "dwm.guide.page.roundel.body"
+    },
+    {
+      "type": "crafting",
+      "recipes": [
+        "dwm:white_roundel_a",
+        "dwm:white_roundel_b",
+        "dwm:white_big_roundel_a"
+      ],
+      "pattern": true
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/tardis_wall.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/tardis_wall.json
@@ -1,0 +1,15 @@
+{
+  "page": { "id": "dwm:tardis_wall" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.tardis_wall.title",
+      "bodyKey": "dwm.guide.page.tardis_wall.body"
+    },
+    {
+      "type": "smelting",
+      "recipe": "dwm:white_tardis_wall",
+      "pattern": true
+    }
+  ]
+}

--- a/dwm/src/main/resources/data/dwm/guide/page/use_sonic.json
+++ b/dwm/src/main/resources/data/dwm/guide/page/use_sonic.json
@@ -1,0 +1,10 @@
+{
+  "page": { "id": "dwm:use_sonic" },
+  "content": [
+    {
+      "type": "text",
+      "titleKey": "dwm.guide.page.use_sonic.title",
+      "bodyKey": "dwm.guide.page.use_sonic.body"
+    }
+  ]
+}

--- a/dwm/src/test/java/com/adamkali/dwm/guide/FieldGuideCatalogTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/guide/FieldGuideCatalogTest.java
@@ -124,6 +124,23 @@ class FieldGuideCatalogTest {
     }
 
     @Test
+    void registryKeysUseVanillaNamespaceForDatapackFolder() {
+        assertEquals(Identifier.DEFAULT_NAMESPACE, FieldGuideRegistries.BOOK.identifier().getNamespace());
+        assertEquals(Identifier.DEFAULT_NAMESPACE, FieldGuideRegistries.CHAPTER.identifier().getNamespace());
+        assertEquals(Identifier.DEFAULT_NAMESPACE, FieldGuideRegistries.PAGE.identifier().getNamespace());
+        assertEquals("guide/book", FieldGuideRegistries.BOOK.identifier().getPath());
+        assertEquals("guide/chapter", FieldGuideRegistries.CHAPTER.identifier().getPath());
+        assertEquals("guide/page", FieldGuideRegistries.PAGE.identifier().getPath());
+        Path book = GUIDE_ROOT.resolve("book/field_guide.json");
+        Path doubledNs = PROJECT_ROOT.resolve(
+                "src/main/resources/data/" + DWMReference.MOD_ID + "/" + DWMReference.MOD_ID
+                        + "/guide/book/field_guide.json"
+        );
+        assertTrue(Files.exists(book), book.toString());
+        assertFalse(Files.exists(doubledNs));
+    }
+
+    @Test
     void productionJsonRoundTrips() throws IOException {
         roundTripDir(GUIDE_ROOT.resolve("book"), FieldGuideBookData.CODEC);
         roundTripDir(GUIDE_ROOT.resolve("chapter"), FieldGuideChapterData.CODEC);

--- a/dwm/src/test/java/com/adamkali/dwm/guide/FieldGuideCatalogTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/guide/FieldGuideCatalogTest.java
@@ -1,16 +1,24 @@
 package com.adamkali.dwm.guide;
 
 import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.google.gson.JsonParser;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
 import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -18,16 +26,32 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class FieldGuideCatalogTest {
     private static final Path PROJECT_ROOT = Path.of(System.getProperty("user.dir"));
+    private static final Path GUIDE_ROOT = PROJECT_ROOT.resolve(
+            "src/main/resources/data/" + DWMReference.MOD_ID + "/guide"
+    );
     private static final Path RECIPE_ROOT = PROJECT_ROOT.resolve("src/main");
     private static final List<Path> RECIPE_DIRS = List.of(
             RECIPE_ROOT.resolve("resources/data/" + DWMReference.MOD_ID + "/recipe"),
             RECIPE_ROOT.resolve("generated/data/" + DWMReference.MOD_ID + "/recipe")
     );
 
+    private static List<FieldGuideChapter> catalog;
+
+    @BeforeAll
+    static void loadProductionCatalog() throws IOException {
+        MinecraftTestBootstrap.ensure();
+        catalog = FieldGuideCatalog.resolve(
+                FieldGuideRegistries.FIELD_GUIDE_ID,
+                loadAll(GUIDE_ROOT.resolve("book"), FieldGuideBookData.CODEC),
+                loadAll(GUIDE_ROOT.resolve("chapter"), FieldGuideChapterData.CODEC),
+                loadAll(GUIDE_ROOT.resolve("page"), FieldGuidePageData.CODEC)
+        );
+    }
+
     @Test
     void pageIdsAreUniqueWithinCatalog() {
-        Set<String> seen = new HashSet<>();
-        for (FieldGuidePage page : FieldGuideCatalog.allPages()) {
+        Set<Identifier> seen = new HashSet<>();
+        for (FieldGuidePage page : FieldGuideCatalog.allPages(catalog)) {
             assertTrue(seen.add(page.id()), "Duplicate page id: " + page.id());
         }
         assertFalse(seen.isEmpty());
@@ -35,21 +59,175 @@ class FieldGuideCatalogTest {
 
     @Test
     void chapterIdsAreUniqueWithinCatalog() {
-        Set<String> seen = new HashSet<>();
-        for (FieldGuideChapter chapter : FieldGuideCatalog.chapters()) {
+        Set<Identifier> seen = new HashSet<>();
+        for (FieldGuideChapter chapter : catalog) {
             assertTrue(seen.add(chapter.id()), "Duplicate chapter id: " + chapter.id());
         }
     }
 
     @Test
     void referencedRecipeFilesExist() throws IOException {
-        for (FieldGuidePage page : FieldGuideCatalog.allPages()) {
+        for (FieldGuidePage page : FieldGuideCatalog.allPages(catalog)) {
             for (Identifier recipeId : page.craftingRecipes()) {
                 assertRecipeExists(recipeId);
             }
             assertRecipeExists(page.smeltingRecipe());
             assertRecipeExists(page.stonecuttingRecipe());
         }
+    }
+
+    @Test
+    void everyChapterHasAtLeastOnePage() {
+        for (FieldGuideChapter chapter : catalog) {
+            assertFalse(chapter.pages().isEmpty(), "Chapter has no pages: " + chapter.id());
+        }
+    }
+
+    @Test
+    void allPagesBelongToKnownChapters() {
+        long pageCount = catalog.stream().mapToLong(chapter -> chapter.pages().size()).sum();
+        assertTrue(pageCount >= 10);
+        assertEquals(pageCount, FieldGuideCatalog.allPages(catalog).size());
+    }
+
+    @Test
+    void roundelPageListsAllShapeVariants() {
+        FieldGuidePage roundel = FieldGuideCatalog.allPages(catalog).stream()
+                .filter(page -> page.id().equals(id("roundel")))
+                .findFirst()
+                .orElseThrow();
+        assertEquals(
+                List.of(
+                        id("white_roundel_a"),
+                        id("white_roundel_b"),
+                        id("white_big_roundel_a")
+                ),
+                roundel.craftingRecipes()
+        );
+        assertTrue(roundel.patternPage());
+    }
+
+    @Test
+    void consoleRoomHasSingleRoundelPage() {
+        Set<Identifier> ids = catalog.stream()
+                .filter(chapter -> chapter.id().equals(id("console_room")))
+                .findFirst()
+                .orElseThrow()
+                .pages()
+                .stream()
+                .map(FieldGuidePage::id)
+                .collect(Collectors.toSet());
+        assertTrue(ids.contains(id("roundel")));
+        assertFalse(ids.contains(id("roundel_a")));
+        assertFalse(ids.contains(id("roundel_b")));
+        assertFalse(ids.contains(id("big_roundel")));
+    }
+
+    @Test
+    void productionJsonRoundTrips() throws IOException {
+        roundTripDir(GUIDE_ROOT.resolve("book"), FieldGuideBookData.CODEC);
+        roundTripDir(GUIDE_ROOT.resolve("chapter"), FieldGuideChapterData.CODEC);
+        roundTripDir(GUIDE_ROOT.resolve("page"), FieldGuidePageData.CODEC);
+    }
+
+    @Test
+    void unknownContentTypeFailsParse() {
+        var json = JsonParser.parseString(
+                "{\"type\":\"image\",\"titleKey\":\"x\",\"bodyKey\":\"y\"}"
+        );
+        assertTrue(FieldGuideContent.CODEC.parse(JsonOps.INSTANCE, json).isError());
+    }
+
+    @Test
+    void pageWithoutTextBlockIsSkipped() {
+        Identifier bookId = id("field_guide");
+        Identifier chapterId = id("quick_start");
+        Identifier pageId = id("broken");
+        FieldGuideBookData book = new FieldGuideBookData(
+                new FieldGuideIdRef(bookId),
+                List.of(new FieldGuideIdRef(chapterId))
+        );
+        FieldGuideChapterData chapter = new FieldGuideChapterData(
+                new FieldGuideIdRef(chapterId),
+                "dwm.guide.chapter.quick_start",
+                List.of(new FieldGuideIdRef(pageId))
+        );
+        FieldGuidePageData page = new FieldGuidePageData(
+                new FieldGuideIdRef(pageId),
+                List.of(new FieldGuideContent.Crafting(List.of(id("tardis_key")), false))
+        );
+
+        List<FieldGuideChapter> resolved = FieldGuideCatalog.resolve(
+                bookId,
+                Map.of(bookId, book),
+                Map.of(chapterId, chapter),
+                Map.of(pageId, page)
+        );
+        assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void missingChapterRefIsSkipped() {
+        Identifier bookId = id("field_guide");
+        Identifier missingChapter = id("does_not_exist");
+        FieldGuideBookData book = new FieldGuideBookData(
+                new FieldGuideIdRef(bookId),
+                List.of(new FieldGuideIdRef(missingChapter))
+        );
+        List<FieldGuideChapter> resolved = FieldGuideCatalog.resolve(
+                bookId,
+                Map.of(bookId, book),
+                Map.of(),
+                Map.of()
+        );
+        assertTrue(resolved.isEmpty());
+    }
+
+    @Test
+    void nestedIdMismatchIsSkipped() {
+        Identifier fileId = id("field_guide");
+        Identifier jsonId = id("other_book");
+        FieldGuideBookData book = new FieldGuideBookData(
+                new FieldGuideIdRef(jsonId),
+                List.of()
+        );
+        List<FieldGuideChapter> resolved = FieldGuideCatalog.resolve(
+                fileId,
+                Map.of(fileId, book),
+                Map.of(),
+                Map.of()
+        );
+        assertTrue(resolved.isEmpty());
+    }
+
+    private static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path);
+    }
+
+    private static <T> void roundTripDir(Path dir, Codec<T> codec) throws IOException {
+        try (Stream<Path> stream = Files.list(dir)) {
+            for (Path path : stream.filter(file -> file.getFileName().toString().endsWith(".json")).toList()) {
+                var json = JsonParser.parseString(Files.readString(path));
+                T decoded = codec.parse(JsonOps.INSTANCE, json).getOrThrow();
+                var encoded = codec.encodeStart(JsonOps.INSTANCE, decoded).getOrThrow();
+                T roundTripped = codec.parse(JsonOps.INSTANCE, encoded).getOrThrow();
+                assertEquals(decoded, roundTripped, path.getFileName().toString());
+            }
+        }
+    }
+
+    private static <T> Map<Identifier, T> loadAll(Path dir, Codec<T> codec) throws IOException {
+        Map<Identifier, T> map = new HashMap<>();
+        try (Stream<Path> stream = Files.list(dir)) {
+            for (Path path : stream.filter(file -> file.getFileName().toString().endsWith(".json")).toList()) {
+                String fileName = path.getFileName().toString();
+                String stem = fileName.substring(0, fileName.length() - ".json".length());
+                Identifier id = id(stem);
+                var json = JsonParser.parseString(Files.readString(path));
+                map.put(id, codec.parse(JsonOps.INSTANCE, json).getOrThrow());
+            }
+        }
+        return map;
     }
 
     private static void assertRecipeExists(Identifier recipeId) throws IOException {
@@ -66,54 +244,5 @@ class FieldGuideCatalogTest {
             }
         }
         assertTrue(found, "Missing recipe JSON for " + recipeId + " (expected " + fileName + " under recipe dirs)");
-    }
-
-    @Test
-    void everyChapterHasAtLeastOnePage() {
-        for (FieldGuideChapter chapter : FieldGuideCatalog.chapters()) {
-            assertFalse(chapter.pages().isEmpty(), "Chapter has no pages: " + chapter.id());
-        }
-    }
-
-    @Test
-    void allPagesBelongToKnownChapters() {
-        long pageCount = FieldGuideCatalog.chapters().stream()
-                .mapToLong(chapter -> chapter.pages().size())
-                .sum();
-        assertTrue(pageCount >= 10);
-        assertTrue(FieldGuideCatalog.allPages().size() == pageCount);
-    }
-
-    @Test
-    void roundelPageListsAllShapeVariants() {
-        FieldGuidePage roundel = FieldGuideCatalog.allPages().stream()
-                .filter(page -> page.id().equals("roundel"))
-                .findFirst()
-                .orElseThrow();
-        assertEquals(
-                List.of(
-                        Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_roundel_a"),
-                        Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_roundel_b"),
-                        Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "white_big_roundel_a")
-                ),
-                roundel.craftingRecipes()
-        );
-        assertTrue(roundel.patternPage());
-    }
-
-    @Test
-    void consoleRoomHasSingleRoundelPage() {
-        Set<String> ids = FieldGuideCatalog.chapters().stream()
-                .filter(chapter -> chapter.id().equals("console_room"))
-                .findFirst()
-                .orElseThrow()
-                .pages()
-                .stream()
-                .map(FieldGuidePage::id)
-                .collect(Collectors.toSet());
-        assertTrue(ids.contains("roundel"));
-        assertFalse(ids.contains("roundel_a"));
-        assertFalse(ids.contains("roundel_b"));
-        assertFalse(ids.contains("big_roundel"));
     }
 }


### PR DESCRIPTION
## Why this matters

- Datapacks can author and override the in-game Field Guide without a Java catalog change, so the playbook can grow with content packs and `/reload`.

## Proposed Implementation

- Register synced dynamic registries `dwm:guide/book`, `dwm:guide/chapter`, and `dwm:guide/page` loaded from `data/<ns>/guide/`.
- Resolve `dwm:field_guide` at runtime; the screen reads `level.registryAccess()` and stays empty if the book is missing.
- Page JSON uses tagged `content` blocks (`text`, `crafting`, `smelting`, `stonecutting`); getters still feed the existing layout toolkit and roundel variant selector.
- Unit tests parse production JSON, round-trip codecs, and cover missing refs / unknown types.

## Problems Encountered / Decisions Made

- Rebased onto current `main` after the layout-toolkit and combined-roundel PRs landed; catalog JSON now matches the single `dwm:roundel` page with three crafting recipes.
- Nested `id` fields are validated against the file path rather than used as the registry key (Minecraft file path is canonical).

Made with [Cursor](https://cursor.com)