### PR TITLE
Improve BOTI and SOTO lighting and fog

### DIFF
--- a/dwm/docs/feature-tardis-block.md
+++ b/dwm/docs/feature-tardis-block.md
@@ -69,15 +69,15 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 ## BOTI Notes
 - Visual illusion: does not stream the live `dwm:tardis` dimension to the exterior client.
 - When the player is near the exterior shell, the server deferred-preloads the console room (ticket chunks, then place on a later tick) and the client warms the BOTI portal stream so real ghost meshes are ready when the door opens.
-- Preview shows a synced portal stream (meta + chunk columns + live entities) of the 11×7×17 console-room footprint via `SotoGhostMeshCache`. Until meshes arrive the doorway stays blank (no blueprint fallback).
+- Preview shows a synced portal stream (meta + chunk columns + live entities) of the interior plot within Minecraft view/render distance (clipped to the allocated TARDIS plot so neighboring interiors stay hidden) via `SotoGhostMeshCache`. Until meshes arrive the doorway stays blank (no blueprint fallback).
 - Shared portal stream format (with SOTO): shell metadata + atmosphere + sparse chunks, compact block/sky-light volumes, and entity spawn/update/remove, keyed by `PortalStreamKind.BOTI`. The client reconstructs synthetic BEs/entities and best-effort renders via `BlockEntityRenderDispatcher` / `EntityRenderDispatcher` (vanilla + mods). Terrain, block entities, and entities use the sampled scene lighting. Entity poses are client-interpolated between sync samples. Players use a dedicated `OtherClientPlayerEntity` path because `EntityType.PLAYER` is not saveable. Interior doors remain excluded from BOTI (no dedicated interior-door BER in the exterior preview yet).
 - Uses the shared deferred portal FBO pipeline (`render.portal`) with a hitch-fixed look-in camera at the interior door plane; composite UV crop uses each chameleon's `PortalAperture`. No stencil framebuffer required.
-- Applies atmosphere-colored distance fog across the streamed room depth. Newly placed/rebuilt console rooms stamp and propagate their intended full-strength invisible console light before BOTI chunk sync.
+- Applies atmosphere-colored distance fog across the streamed view-distance depth. Newly placed/rebuilt console rooms stamp and propagate their intended full-strength invisible console light before BOTI chunk sync.
 - May not work with Fabulous graphics / order-independent transparency; disable via `enableDoorPortals` if needed.
 
 ## SOTO Notes
 - Uses the same deferred portal FBO pipeline and the same portal stream packet family as BOTI (shared `enableDoorPortals`, default on).
-- Visual illusion: portal-composites a streamed exterior scene (shell + atmosphere + Chebyshev-2 ghost chunks + entities) through the classic interior door aperture (not a live world stream); hitch-fixed look-out at the shell door plane.
+- Visual illusion: portal-composites a streamed exterior scene (shell + atmosphere + view-distance ghost chunks + entities) through the classic interior door aperture (not a live world stream); hitch-fixed look-out at the shell door plane.
 - Stream keyed by `PortalStreamKind.SOTO`; meta revision and chunk/entity lifecycle match BOTI's wire format. Sampled sky/block light illuminates terrain and features, while atmosphere-colored distance fog blends the outer stream into its backdrop.
 
 ## Known Constraints

--- a/dwm/docs/feature-tardis-block.md
+++ b/dwm/docs/feature-tardis-block.md
@@ -70,14 +70,15 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 - Visual illusion: does not stream the live `dwm:tardis` dimension to the exterior client.
 - When the player is near the exterior shell, the server deferred-preloads the console room (ticket chunks, then place on a later tick) and the client warms the BOTI portal stream so real ghost meshes are ready when the door opens.
 - Preview shows a synced portal stream (meta + chunk columns + live entities) of the 11×7×17 console-room footprint via `SotoGhostMeshCache`. Until meshes arrive the doorway stays blank (no blueprint fallback).
-- Shared portal stream format (with SOTO): shell metadata + atmosphere + sparse chunks + entity spawn/update/remove, keyed by `PortalStreamKind.BOTI`. The client reconstructs synthetic BEs/entities and best-effort renders via `BlockEntityRenderDispatcher` / `EntityRenderDispatcher` (vanilla + mods). Entity poses are client-interpolated between sync samples. Players use a dedicated `OtherClientPlayerEntity` path because `EntityType.PLAYER` is not saveable. Interior doors remain excluded from BOTI (no dedicated interior-door BER in the exterior preview yet).
+- Shared portal stream format (with SOTO): shell metadata + atmosphere + sparse chunks, compact block/sky-light volumes, and entity spawn/update/remove, keyed by `PortalStreamKind.BOTI`. The client reconstructs synthetic BEs/entities and best-effort renders via `BlockEntityRenderDispatcher` / `EntityRenderDispatcher` (vanilla + mods). Terrain, block entities, and entities use the sampled scene lighting. Entity poses are client-interpolated between sync samples. Players use a dedicated `OtherClientPlayerEntity` path because `EntityType.PLAYER` is not saveable. Interior doors remain excluded from BOTI (no dedicated interior-door BER in the exterior preview yet).
 - Uses the shared deferred portal FBO pipeline (`render.portal`) with a hitch-fixed look-in camera at the interior door plane; composite UV crop uses each chameleon's `PortalAperture`. No stencil framebuffer required.
+- Applies atmosphere-colored distance fog across the streamed room depth. Newly placed/rebuilt console rooms stamp and propagate their intended full-strength invisible console light before BOTI chunk sync.
 - May not work with Fabulous graphics / order-independent transparency; disable via `enableDoorPortals` if needed.
 
 ## SOTO Notes
 - Uses the same deferred portal FBO pipeline and the same portal stream packet family as BOTI (shared `enableDoorPortals`, default on).
 - Visual illusion: portal-composites a streamed exterior scene (shell + atmosphere + Chebyshev-2 ghost chunks + entities) through the classic interior door aperture (not a live world stream); hitch-fixed look-out at the shell door plane.
-- Stream keyed by `PortalStreamKind.SOTO`; meta revision and chunk/entity lifecycle match BOTI's wire format.
+- Stream keyed by `PortalStreamKind.SOTO`; meta revision and chunk/entity lifecycle match BOTI's wire format. Sampled sky/block light illuminates terrain and features, while atmosphere-colored distance fog blends the outer stream into its backdrop.
 
 ## Known Constraints
 - Interior visuals use the shipped `first_doctor_console_room` structure (11×7×17) with decor props; console and interior-door bank are linked to the exterior via `tardisId` on placement.

--- a/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -34,6 +34,7 @@ public final class BotiPortalContent implements PortalContent {
     private static final int DEFAULT_CLEAR_RGB = 0x203040;
     static final float BOTI_FOG_START = 7.0F;
     static final float BOTI_FOG_END = 17.0F;
+    private static boolean agentLoggedFog;
 
     private final UUID tardisId;
 
@@ -74,6 +75,17 @@ public final class BotiPortalContent implements PortalContent {
     public void renderInto(PortalContentContext context) {
         PortalAtmosphere portal = PortalSceneStore.getAtmosphere(PortalStreamKind.BOTI, tardisId);
         SotoAtmosphere atmosphere = portal != null ? SotoAtmosphere.fromPortal(portal) : SotoAtmosphere.DEFAULT;
+        // #region agent log
+        if (!agentLoggedFog) {
+            agentLoggedFog = true;
+            try {
+                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                        "{\"hypothesisId\":\"E\",\"location\":\"BotiPortalContent.renderInto\",\"message\":\"BOTI fog inputs\",\"data\":{\"portalAtmospherePresent\":" + (portal != null) + ",\"timeOfDay\":" + atmosphere.timeOfDay() + ",\"biomeFogColor\":" + atmosphere.biomeFogColor() + ",\"backdropRgb\":" + SotoSkyFogRenderer.portalBackdropRgb(atmosphere) + ",\"fogStart\":" + BOTI_FOG_START + ",\"fogEnd\":" + BOTI_FOG_END + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+            } catch (java.io.IOException ignored) {
+            }
+        }
+        // #endregion
         context.bindTarget();
         long fogStart = PortalPerfStats.begin();
         GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(

--- a/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -34,7 +34,6 @@ public final class BotiPortalContent implements PortalContent {
     private static final int DEFAULT_CLEAR_RGB = 0x203040;
     static final float BOTI_FOG_START = 7.0F;
     static final float BOTI_FOG_END = 17.0F;
-    private static boolean agentLoggedFog;
 
     private final UUID tardisId;
 
@@ -75,17 +74,6 @@ public final class BotiPortalContent implements PortalContent {
     public void renderInto(PortalContentContext context) {
         PortalAtmosphere portal = PortalSceneStore.getAtmosphere(PortalStreamKind.BOTI, tardisId);
         SotoAtmosphere atmosphere = portal != null ? SotoAtmosphere.fromPortal(portal) : SotoAtmosphere.DEFAULT;
-        // #region agent log
-        if (!agentLoggedFog) {
-            agentLoggedFog = true;
-            try {
-                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                        "{\"hypothesisId\":\"E\",\"location\":\"BotiPortalContent.renderInto\",\"message\":\"BOTI fog inputs\",\"data\":{\"portalAtmospherePresent\":" + (portal != null) + ",\"timeOfDay\":" + atmosphere.timeOfDay() + ",\"biomeFogColor\":" + atmosphere.biomeFogColor() + ",\"backdropRgb\":" + SotoSkyFogRenderer.portalBackdropRgb(atmosphere) + ",\"fogStart\":" + BOTI_FOG_START + ",\"fogEnd\":" + BOTI_FOG_END + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-            } catch (java.io.IOException ignored) {
-            }
-        }
-        // #endregion
         context.bindTarget();
         long fogStart = PortalPerfStats.begin();
         GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(

--- a/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -9,7 +9,9 @@ import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.render.soto.SotoExteriorMeshCache;
 import com.adamkali.dwm.render.soto.SotoSkyFogRenderer;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostMeshCache;
+import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphere;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
@@ -32,8 +34,6 @@ import net.minecraft.world.phys.Vec3;
  */
 public final class BotiPortalContent implements PortalContent {
     private static final int DEFAULT_CLEAR_RGB = 0x203040;
-    static final float BOTI_FOG_START = 7.0F;
-    static final float BOTI_FOG_END = 17.0F;
 
     private final UUID tardisId;
 
@@ -76,8 +76,9 @@ public final class BotiPortalContent implements PortalContent {
         SotoAtmosphere atmosphere = portal != null ? SotoAtmosphere.fromPortal(portal) : SotoAtmosphere.DEFAULT;
         context.bindTarget();
         long fogStart = PortalPerfStats.begin();
+        int radius = BotiInteriorSampler.clipStreamRadiusChunks(SotoSkyFogRenderer.clientStreamRadiusChunks());
         GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(
-                atmosphere, BOTI_FOG_START, BOTI_FOG_END
+                atmosphere, PortalSampler.fogStartBlocks(radius), PortalSampler.fogEndBlocks(radius)
         );
         PortalPerfStats.end(PortalPerfStats.Stage.SKY_FOG, fogStart);
         try {

--- a/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -22,7 +22,6 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
 import net.minecraft.core.Direction;
-import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.phys.Vec3;
 
 /**
@@ -31,7 +30,6 @@ import net.minecraft.world.phys.Vec3;
  * warms the stream before the door opens.
  */
 public final class BotiPortalContent implements PortalContent {
-    private static final int FULLBRIGHT = LightCoordsUtil.pack(15, 15);
     private static final int DEFAULT_CLEAR_RGB = 0x203040;
 
     private final UUID tardisId;
@@ -121,7 +119,7 @@ public final class BotiPortalContent implements PortalContent {
                             sceneMatrices,
                             submitStorage,
                             cameraState,
-                            FULLBRIGHT,
+                            -1,
                             tickDelta,
                             PortalStreamKind.BOTI,
                             id,

--- a/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/boti/BotiPortalContent.java
@@ -12,6 +12,7 @@ import com.adamkali.dwm.render.soto.ghost.SotoGhostMeshCache;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphere;
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import org.joml.Matrix4fStack;
@@ -31,6 +32,8 @@ import net.minecraft.world.phys.Vec3;
  */
 public final class BotiPortalContent implements PortalContent {
     private static final int DEFAULT_CLEAR_RGB = 0x203040;
+    static final float BOTI_FOG_START = 7.0F;
+    static final float BOTI_FOG_END = 17.0F;
 
     private final UUID tardisId;
 
@@ -69,12 +72,27 @@ public final class BotiPortalContent implements PortalContent {
 
     @Override
     public void renderInto(PortalContentContext context) {
+        PortalAtmosphere portal = PortalSceneStore.getAtmosphere(PortalStreamKind.BOTI, tardisId);
+        SotoAtmosphere atmosphere = portal != null ? SotoAtmosphere.fromPortal(portal) : SotoAtmosphere.DEFAULT;
+        context.bindTarget();
+        long fogStart = PortalPerfStats.begin();
+        GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(
+                atmosphere, BOTI_FOG_START, BOTI_FOG_END
+        );
+        PortalPerfStats.end(PortalPerfStats.Stage.SKY_FOG, fogStart);
+        try {
+            renderLitContent(context);
+        } finally {
+            SotoSkyFogRenderer.restoreFog(previousFog);
+        }
+    }
+
+    private void renderLitContent(PortalContentContext context) {
         UUID id = tardisId;
         float tickDelta = context.tickDelta();
         PortalCameraTransform.Result hitch = context.hitch();
         PoseStack sceneMatrices = context.sceneMatrices();
 
-        context.bindTarget();
         long opaqueStart = PortalPerfStats.begin();
         SotoGhostMeshCache.drawLayer(
                 PortalStreamKind.BOTI,

--- a/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalFogRenderer.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalFogRenderer.java
@@ -1,0 +1,67 @@
+package com.adamkali.dwm.render.portal;
+
+import com.mojang.blaze3d.buffers.GpuBufferSlice;
+import com.mojang.blaze3d.systems.RenderSystem;
+import net.minecraft.client.renderer.fog.FogData;
+import net.minecraft.client.renderer.fog.FogRenderer;
+import org.joml.Vector4f;
+
+/**
+ * Owns the fog UBO used by deferred portal passes. The vanilla world fog buffer cannot be
+ * overwritten because the main scene may still reference it.
+ */
+public final class PortalFogRenderer {
+    private static FogRenderer renderer;
+
+    private PortalFogRenderer() {
+    }
+
+    public static GpuBufferSlice apply(float start, float end, float red, float green, float blue) {
+        GpuBufferSlice previous = RenderSystem.getShaderFog();
+        FogRenderer fogRenderer = renderer();
+        fogRenderer.updateBuffer(buildFogData(start, end, red, green, blue));
+        RenderSystem.setShaderFog(fogRenderer.getBuffer(FogRenderer.FogMode.WORLD));
+        return previous;
+    }
+
+    static FogData buildFogData(float start, float end, float red, float green, float blue) {
+        if (start < 0.0F || end <= start) {
+            throw new IllegalArgumentException("Portal fog end must be greater than its non-negative start");
+        }
+        FogData fog = new FogData();
+        fog.color = new Vector4f(red, green, blue, 1.0F);
+        fog.environmentalStart = start;
+        fog.environmentalEnd = end;
+        fog.renderDistanceStart = start;
+        fog.renderDistanceEnd = end;
+        fog.skyEnd = end;
+        fog.cloudEnd = end;
+        return fog;
+    }
+
+    public static void restore(GpuBufferSlice previous) {
+        if (previous != null) {
+            RenderSystem.setShaderFog(previous);
+        }
+    }
+
+    public static void endFrame() {
+        if (renderer != null) {
+            renderer.endFrame();
+        }
+    }
+
+    public static void closeGlobal() {
+        if (renderer != null) {
+            renderer.close();
+            renderer = null;
+        }
+    }
+
+    private static FogRenderer renderer() {
+        if (renderer == null) {
+            renderer = new FogRenderer();
+        }
+        return renderer;
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalLightmap.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalLightmap.java
@@ -1,0 +1,79 @@
+package com.adamkali.dwm.render.portal;
+
+import com.adamkali.dwm.tardis.soto.SotoAtmosphere;
+import com.adamkali.dwm.tardis.soto.SotoAtmosphereColors;
+import com.adamkali.dwm.tardis.soto.SotoAtmosphereColors.EffectsKind;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.client.renderer.Lightmap;
+import net.minecraft.client.renderer.state.LightmapRenderState;
+import net.minecraft.util.ARGB;
+import org.joml.Vector3f;
+import org.joml.Vector3fc;
+
+/**
+ * Temporarily replaces the viewer's lightmap with one matching the looked-into portal atmosphere.
+ * Packed sky/block coords are sampled from the other dimension; without this overlay they are
+ * interpreted against {@code dwm:tardis} ({@code sky_light_factor=0}, black ambient).
+ */
+public final class PortalLightmap implements AutoCloseable {
+    private final Lightmap lightmap;
+    private final LightmapRenderState live;
+    private final Snapshot previous;
+    private boolean closed;
+
+    private PortalLightmap(Lightmap lightmap, LightmapRenderState live, Snapshot previous) {
+        this.lightmap = lightmap;
+        this.live = live;
+        this.previous = previous;
+    }
+
+    public static PortalLightmap apply(Minecraft client, SotoAtmosphere atmosphere) {
+        if (client == null || client.gameRenderer == null || atmosphere == null) {
+            return null;
+        }
+        GameRenderer renderer = client.gameRenderer;
+        LightmapRenderState live = renderer.gameRenderState.lightmapRenderState;
+        Snapshot previous = Snapshot.of(live);
+        overlay(live, atmosphere);
+        renderer.lightmap.render(live);
+        return new PortalLightmap(renderer.lightmap, live, previous);
+    }
+
+    static void overlay(LightmapRenderState state, SotoAtmosphere atmosphere) {
+        EffectsKind kind = SotoAtmosphereColors.effectsKind(atmosphere.dimensionEffectsId());
+        float skyAngle = SotoAtmosphereColors.skyAngle(atmosphere.timeOfDay());
+        state.skyFactor = SotoAtmosphereColors.skyLightFactor(
+                kind, skyAngle, atmosphere.rainGradient(), atmosphere.thunderGradient());
+        state.skyLightColor = ARGB.vector3fFromRGB24(SotoAtmosphereColors.skyLightColor(kind));
+        state.ambientColor = ARGB.vector3fFromRGB24(SotoAtmosphereColors.ambientLightColor(kind));
+        state.needsUpdate = true;
+    }
+
+    @Override
+    public void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        previous.restore(live);
+        live.needsUpdate = true;
+        lightmap.render(live);
+    }
+
+    private record Snapshot(float skyFactor, Vector3fc skyLightColor, Vector3fc ambientColor) {
+        static Snapshot of(LightmapRenderState state) {
+            return new Snapshot(
+                    state.skyFactor,
+                    new Vector3f(state.skyLightColor),
+                    new Vector3f(state.ambientColor)
+            );
+        }
+
+        void restore(LightmapRenderState state) {
+            state.skyFactor = skyFactor;
+            state.skyLightColor = skyLightColor;
+            state.ambientColor = ambientColor;
+        }
+    }
+}

--- a/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalSceneStore.java
@@ -51,7 +51,7 @@ public final class PortalSceneStore {
         PortalAtmosphere atmosphere = payload.atmosphere() == null ? PortalAtmosphere.DEFAULT : payload.atmosphere();
         META.put(key, new MetaEntry(payload.revision(), shell, atmosphere));
         // Do not clear LAST_REQUEST_MS here — that re-armed requestIfNeeded every meta
-        // packet and caused subscribe→sendFullChunks storms.
+        // packet and caused subscribe storms.
         PortalFrameCache.markDirty(payload.kind(), payload.tardisId());
     }
 

--- a/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalSupport.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/portal/PortalSupport.java
@@ -28,10 +28,17 @@ public final class PortalSupport {
         initialized = true;
         LevelRenderEvents.START_MAIN.register(context -> PortalRenderTarget.beginClientFrame());
         // Portal FBO clear/mesh draws must not run mid-BER (blacks out world/items on 26.2).
-        LevelRenderEvents.END_MAIN.register(context -> PortalScheduler.flushEndMain());
+        LevelRenderEvents.END_MAIN.register(context -> {
+            try {
+                PortalScheduler.flushEndMain();
+            } finally {
+                PortalFogRenderer.endFrame();
+            }
+        });
         ClientLifecycleEvents.CLIENT_STOPPING.register(client -> {
             PortalRenderTarget.closeGlobal();
             PortalFeatureFlush.closeGlobal();
+            PortalFogRenderer.closeGlobal();
         });
     }
 
@@ -71,6 +78,7 @@ public final class PortalSupport {
         }
         sessionAvailable = false;
         PortalRenderTarget.closeGlobal();
+        PortalFogRenderer.closeGlobal();
         if (!failureLogged) {
             failureLogged = true;
             if (error == null) {
@@ -85,5 +93,6 @@ public final class PortalSupport {
         sessionAvailable = true;
         failureLogged = false;
         PortalRenderTarget.closeGlobal();
+        PortalFogRenderer.closeGlobal();
     }
 }

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCache.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoExteriorMeshCache.java
@@ -125,7 +125,6 @@ public final class SotoExteriorMeshCache {
         }
         List<BlockEntity> bes = ghost.buildRenderedBlockEntities();
         int submitted = 0;
-        int lightCoords = light >= 0 ? light : FULLBRIGHT;
         Vec3 cameraPos = cameraState.pos;
         for (BlockEntity blockEntity : bes) {
             @SuppressWarnings("unchecked")
@@ -138,8 +137,8 @@ public final class SotoExteriorMeshCache {
             if (state == null) {
                 continue;
             }
-            state.lightCoords = lightCoords;
             BlockPos pos = blockEntity.getBlockPos();
+            state.lightCoords = light >= 0 ? light : ghost.packedLight(pos);
             matrices.pushPose();
             matrices.translate(
                     pos.getX() - cameraPos.x,
@@ -215,7 +214,10 @@ public final class SotoExteriorMeshCache {
                     itemState.bobOffset = ghost.bobOffset();
                     PortalPerfStats.noteItemAgeInTicks(itemState.ageInTicks);
                 }
-                entityState.lightCoords = FULLBRIGHT;
+                SotoGhostExterior exterior = SotoGhostExterior.get(kind, tardisId);
+                entityState.lightCoords = exterior == null
+                        ? FULLBRIGHT
+                        : exterior.packedLight(BlockPos.containing(pose.x(), pose.y(), pose.z()));
                 entityDispatcher.submit(
                         entityState,
                         cameraState,

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.render.portal.PortalCameraTransform;
 import com.adamkali.dwm.render.portal.PortalContent;
 import com.adamkali.dwm.render.portal.PortalContentContext;
 import com.adamkali.dwm.render.portal.PortalFeatureFlush;
+import com.adamkali.dwm.render.portal.PortalLightmap;
 import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.render.soto.ghost.SotoGhostExterior;
@@ -91,6 +92,7 @@ public final class SotoPortalContent implements PortalContent {
         context.bindTarget();
         GpuBufferSlice previousFog = SotoSkyFogRenderer.applyPortalTerrainFog(atmosphere);
         PortalPerfStats.end(PortalPerfStats.Stage.SKY_FOG, skyStart);
+        PortalLightmap portalLightmap = PortalLightmap.apply(Minecraft.getInstance(), atmosphere);
         try {
             long opaqueStart = PortalPerfStats.begin();
             SotoGhostMeshCache.drawLayer(
@@ -164,6 +166,9 @@ public final class SotoPortalContent implements PortalContent {
             }
         } finally {
             SotoSkyFogRenderer.restoreFog(previousFog);
+            if (portalLightmap != null) {
+                portalLightmap.close();
+            }
         }
     }
 }

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoPortalContent.java
@@ -24,14 +24,11 @@ import java.util.UUID;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeStorage;
 import net.minecraft.client.renderer.state.level.CameraRenderState;
-import net.minecraft.util.LightCoordsUtil;
 
 /**
  * SOTO portal content: hitch-fixed exterior look-out with ghost terrain + entities.
  */
 public final class SotoPortalContent implements PortalContent {
-    private static final int FULLBRIGHT = LightCoordsUtil.FULL_BRIGHT;
-
     private final UUID tardisId;
 
     public SotoPortalContent(UUID tardisId) {
@@ -139,7 +136,7 @@ public final class SotoPortalContent implements PortalContent {
                                 sceneMatrices,
                                 submitStorage,
                                 cameraState,
-                                FULLBRIGHT,
+                                -1,
                                 tickDelta,
                                 PortalStreamKind.SOTO,
                                 id,

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoSkyFogRenderer.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoSkyFogRenderer.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.render.soto;
 
+import com.adamkali.dwm.render.portal.PortalFogRenderer;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphere;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphereColors;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphereColors.EffectsKind;
@@ -110,23 +111,26 @@ public final class SotoSkyFogRenderer {
         };
     }
 
-    /**
-     * Remembers the previous shader fog slice. Minecraft 26.2 fog is a UBO slice; we cannot
-     * construct a custom portal fog buffer without FogRenderer internals, so terrain draws keep
-     * the active fog. Restore still swaps the captured slice back.
-     */
     public static GpuBufferSlice applyPortalTerrainFog(SotoAtmosphere atmosphere) {
-        // atmosphere retained for API stability / future FogData upload.
-        return RenderSystem.getShaderFog();
+        return applyPortalTerrainFog(atmosphere, PORTAL_FOG_START, PORTAL_FOG_END);
+    }
+
+    public static GpuBufferSlice applyPortalTerrainFog(SotoAtmosphere atmosphere, float start, float end) {
+        SotoAtmosphere resolved = atmosphere == null ? SotoAtmosphere.DEFAULT : atmosphere;
+        EffectsKind kind = SotoAtmosphereColors.effectsKind(resolved.dimensionEffectsId());
+        FogColor fog = buildFogColor(resolved, kind, start, end);
+        return PortalFogRenderer.apply(fog.start(), fog.end(), fog.red(), fog.green(), fog.blue());
     }
 
     public static void restoreFog(GpuBufferSlice previous) {
-        if (previous != null) {
-            RenderSystem.setShaderFog(previous);
-        }
+        PortalFogRenderer.restore(previous);
     }
 
     static FogColor buildFogColor(SotoAtmosphere atmosphere, EffectsKind kind) {
+        return buildFogColor(atmosphere, kind, PORTAL_FOG_START, PORTAL_FOG_END);
+    }
+
+    static FogColor buildFogColor(SotoAtmosphere atmosphere, EffectsKind kind, float start, float end) {
         float skyAngle = SotoAtmosphereColors.skyAngle(atmosphere.timeOfDay());
         Vec3 color = SotoAtmosphereColors.fogColor(
                 atmosphere.biomeFogColor(),
@@ -136,8 +140,8 @@ public final class SotoSkyFogRenderer {
                 atmosphere.thunderGradient()
         );
         return new FogColor(
-                PORTAL_FOG_START,
-                PORTAL_FOG_END,
+                start,
+                end,
                 (float) color.x,
                 (float) color.y,
                 (float) color.z

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoSkyFogRenderer.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/SotoSkyFogRenderer.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.render.soto;
 
 import com.adamkali.dwm.render.portal.PortalFogRenderer;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphere;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphereColors;
 import com.adamkali.dwm.tardis.soto.SotoAtmosphereColors.EffectsKind;
@@ -8,6 +9,7 @@ import com.adamkali.dwm.tardis.soto.SotoExteriorSampler;
 import com.mojang.blaze3d.buffers.GpuBufferSlice;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.SubmitNodeCollector;
 import net.minecraft.util.ARGB;
 import net.minecraft.world.phys.Vec3;
@@ -23,18 +25,28 @@ import org.lwjgl.opengl.GL11;
  * RenderPass helper lands. Terrain fog apply/restore preserves the previous GpuBufferSlice.
  */
 public final class SotoSkyFogRenderer {
-    /** Vanilla sky dome radius; scale so it sits behind the 11×7×11 footprint. */
+    /** Vanilla sky dome radius; scale so it sits behind the streamed exterior. */
     private static final float VANILLA_SKY_RADIUS = 512.0F;
     private static final float SKY_SCALE = 10.0F / VANILLA_SKY_RADIUS;
-
-    static final float PORTAL_FOG_START = 20.0F;
-    static final float PORTAL_FOG_END = 30.0F;
 
     private SotoSkyFogRenderer() {
     }
 
     /**
-     * Draws the Phase 3 sky with fog reaching the edge of the fixed two-chunk ghost stream.
+     * Client render distance used for portal fog / stream sizing, falling back to
+     * {@link PortalSampler#DEFAULT_STREAM_RADIUS_CHUNKS}.
+     */
+    public static int clientStreamRadiusChunks() {
+        Minecraft client = Minecraft.getInstance();
+        if (client == null || client.options == null) {
+            return PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS;
+        }
+        int renderDistance = client.options.getEffectiveRenderDistance();
+        return renderDistance > 0 ? renderDistance : PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS;
+    }
+
+    /**
+     * Draws the portal sky with fog reaching the edge of the view-distance ghost stream.
      * <p>
      * The shared entity submit collector must not be used for sky fills — it can rebind the main
      * framebuffer. Backdrop RGB is applied by the portal clear; optional mesh fill is a no-op
@@ -112,7 +124,9 @@ public final class SotoSkyFogRenderer {
     }
 
     public static GpuBufferSlice applyPortalTerrainFog(SotoAtmosphere atmosphere) {
-        return applyPortalTerrainFog(atmosphere, PORTAL_FOG_START, PORTAL_FOG_END);
+        int radius = clientStreamRadiusChunks();
+        return applyPortalTerrainFog(
+                atmosphere, PortalSampler.fogStartBlocks(radius), PortalSampler.fogEndBlocks(radius));
     }
 
     public static GpuBufferSlice applyPortalTerrainFog(SotoAtmosphere atmosphere, float start, float end) {
@@ -127,7 +141,9 @@ public final class SotoSkyFogRenderer {
     }
 
     static FogColor buildFogColor(SotoAtmosphere atmosphere, EffectsKind kind) {
-        return buildFogColor(atmosphere, kind, PORTAL_FOG_START, PORTAL_FOG_END);
+        int radius = clientStreamRadiusChunks();
+        return buildFogColor(
+                atmosphere, kind, PortalSampler.fogStartBlocks(radius), PortalSampler.fogEndBlocks(radius));
     }
 
     static FogColor buildFogColor(SotoAtmosphere atmosphere, EffectsKind kind, float start, float end) {

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -256,6 +256,24 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         Map<BlockPos, BlockState> newBlocks = new HashMap<>(payload.toBlockMap());
         Map<BlockPos, CompoundTag> newBes = new HashMap<>(payload.toBlockEntityMap());
         PortalLightData newLight = payload.lightData();
+        // #region agent log
+        try {
+            int firstPacked = newLight.isEmpty() ? -1 : newLight.packed(newLight.min());
+            int matchedBlocks = 0, maxMatchedBlock = 0, maxMatchedSky = 0;
+            for (BlockPos pos : newBlocks.keySet()) {
+                int packed = newLight.packed(pos);
+                if (packed >= 0) {
+                    matchedBlocks++;
+                    maxMatchedBlock = Math.max(maxMatchedBlock, packed & 0xF);
+                    maxMatchedSky = Math.max(maxMatchedSky, packed >>> 4);
+                }
+            }
+            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                    "{\"hypothesisId\":\"C\",\"location\":\"SotoGhostExterior.applyChunk\",\"message\":\"client received portal light\",\"data\":{\"kind\":\"" + kind + "\",\"chunkX\":" + payload.chunkX() + ",\"chunkZ\":" + payload.chunkZ() + ",\"blocks\":" + newBlocks.size() + ",\"originX\":" + payload.footprintOriginX() + ",\"originY\":" + payload.footprintOriginY() + ",\"originZ\":" + payload.footprintOriginZ() + ",\"lightMinX\":" + newLight.min().getX() + ",\"lightMinY\":" + newLight.min().getY() + ",\"lightMinZ\":" + newLight.min().getZ() + ",\"lightBytes\":" + newLight.packedCopy().length + ",\"firstPacked\":" + firstPacked + ",\"matchedBlocks\":" + matchedBlocks + ",\"maxMatchedBlock\":" + maxMatchedBlock + ",\"maxMatchedSky\":" + maxMatchedSky + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (java.io.IOException ignored) {
+        }
+        // #endregion
         Map<BlockPos, BlockState> previousBlocks = ghost.chunkBlocks.get(key);
         Map<BlockPos, CompoundTag> previousBes = ghost.chunkBlockEntities.get(key);
         PortalLightData previousLight = ghost.chunkLights.get(key);

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -10,6 +10,7 @@ import com.adamkali.dwm.render.portal.PortalFrameCache;
 import com.adamkali.dwm.render.portal.PortalPerfStats;
 import com.adamkali.dwm.render.portal.PortalSceneStore;
 import com.adamkali.dwm.tardis.boti.BotiEntitySample;
+import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.mojang.authlib.GameProfile;
 import net.minecraft.util.ProblemReporter;
@@ -74,6 +75,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
     private BlockPos footprintOrigin = BlockPos.ZERO;
     private final Map<Long, Map<BlockPos, BlockState>> chunkBlocks = new ConcurrentHashMap<>();
     private final Map<Long, Map<BlockPos, CompoundTag>> chunkBlockEntities = new ConcurrentHashMap<>();
+    private final Map<Long, PortalLightData> chunkLights = new ConcurrentHashMap<>();
     private final Map<BlockPos, BlockState> blocksByRel = new ConcurrentHashMap<>();
     private final Map<BlockPos, CompoundTag> blockEntitiesByRel = new ConcurrentHashMap<>();
     private final Map<UUID, GhostEntity> entities = new ConcurrentHashMap<>();
@@ -253,9 +255,13 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         long key = ChunkPos.pack(payload.chunkX(), payload.chunkZ());
         Map<BlockPos, BlockState> newBlocks = new HashMap<>(payload.toBlockMap());
         Map<BlockPos, CompoundTag> newBes = new HashMap<>(payload.toBlockEntityMap());
+        PortalLightData newLight = payload.lightData();
         Map<BlockPos, BlockState> previousBlocks = ghost.chunkBlocks.get(key);
         Map<BlockPos, CompoundTag> previousBes = ghost.chunkBlockEntities.get(key);
-        boolean contentUnchanged = chunkContentUnchanged(previousBlocks, newBlocks, previousBes, newBes);
+        PortalLightData previousLight = ghost.chunkLights.get(key);
+        boolean contentUnchanged = chunkContentUnchanged(
+                previousBlocks, newBlocks, previousBes, newBes, previousLight, newLight
+        );
         boolean hasDrawable = SotoGhostMeshCache.hasDrawableChunk(
                 kind, payload.tardisId(), payload.chunkX(), payload.chunkZ()
         );
@@ -263,11 +269,13 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             // Keep maps current (cheap) but skip tessellation / pass-batch rebuild.
             ghost.chunkBlocks.put(key, newBlocks);
             ghost.chunkBlockEntities.put(key, newBes);
+            ghost.chunkLights.put(key, newLight);
             PortalPerfStats.noteBakeSkip();
             return;
         }
         previousBlocks = ghost.chunkBlocks.put(key, newBlocks);
         previousBes = ghost.chunkBlockEntities.put(key, newBes);
+        ghost.chunkLights.put(key, newLight);
         if (previousBlocks != null) {
             for (BlockPos pos : previousBlocks.keySet()) {
                 ghost.blocksByRel.remove(pos);
@@ -280,7 +288,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         }
         ghost.blocksByRel.putAll(newBlocks);
         ghost.blockEntitiesByRel.putAll(newBes);
-        SotoGhostMeshCache.onChunkApplied(kind, payload.tardisId(), payload.chunkX(), payload.chunkZ(), ghost);
+        ghost.rebuildChunkAndLightNeighbors(payload.chunkX(), payload.chunkZ());
     }
 
     /**
@@ -291,10 +299,25 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             Map<BlockPos, BlockState> previousBlocks,
             Map<BlockPos, BlockState> newBlocks,
             Map<BlockPos, CompoundTag> previousBes,
-            Map<BlockPos, CompoundTag> newBes
+            Map<BlockPos, CompoundTag> newBes,
+            PortalLightData previousLight,
+            PortalLightData newLight
     ) {
         return Objects.equals(emptyToNull(previousBlocks), emptyToNull(newBlocks))
-                && Objects.equals(emptyToNull(previousBes), emptyToNull(newBes));
+                && Objects.equals(emptyToNull(previousBes), emptyToNull(newBes))
+                && Objects.equals(previousLight, newLight);
+    }
+
+    private void rebuildChunkAndLightNeighbors(int chunkX, int chunkZ) {
+        for (int dx = -1; dx <= 1; dx++) {
+            for (int dz = -1; dz <= 1; dz++) {
+                int affectedX = chunkX + dx;
+                int affectedZ = chunkZ + dz;
+                if (chunkBlocks.containsKey(ChunkPos.pack(affectedX, affectedZ))) {
+                    SotoGhostMeshCache.onChunkApplied(kind, tardisId, affectedX, affectedZ, this);
+                }
+            }
+        }
     }
 
     private static <K, V> Map<K, V> emptyToNull(Map<K, V> map) {
@@ -309,6 +332,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         long key = ChunkPos.pack(chunkX, chunkZ);
         Map<BlockPos, BlockState> removedBlocks = ghost.chunkBlocks.remove(key);
         Map<BlockPos, CompoundTag> removedBes = ghost.chunkBlockEntities.remove(key);
+        ghost.chunkLights.remove(key);
         if (removedBlocks != null) {
             for (BlockPos pos : removedBlocks.keySet()) {
                 ghost.blocksByRel.remove(pos);
@@ -320,6 +344,7 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
             }
         }
         SotoGhostMeshCache.onChunkUnloaded(kind, tardisId, chunkX, chunkZ);
+        ghost.rebuildChunkAndLightNeighbors(chunkX, chunkZ);
     }
 
     public static void applyEntitySpawn(PortalStreamKind kind, SyncPortalEntitySpawnS2CPayload payload) {
@@ -520,6 +545,16 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         return Map.copyOf(blocksByRel);
     }
 
+    public boolean hasLightData() {
+        return !chunkLights.isEmpty();
+    }
+
+    public int packedLight(BlockPos pos) {
+        int block = getBrightness(LightLayer.BLOCK, pos);
+        int sky = getBrightness(LightLayer.SKY, pos);
+        return net.minecraft.util.LightCoordsUtil.pack(block, sky);
+    }
+
     /**
      * Synthetic block entities for ghost BE rendering (same approach as snapshot mesh cache).
      */
@@ -673,7 +708,13 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
 
     @Override
     public int getBrightness(LightLayer type, BlockPos pos) {
-        return 15;
+        if (pos == null || chunkLights.isEmpty()) {
+            return 15;
+        }
+        int worldX = footprintOrigin.getX() + pos.getX();
+        int worldZ = footprintOrigin.getZ() + pos.getZ();
+        PortalLightData light = chunkLights.get(ChunkPos.pack(worldX >> 4, worldZ >> 4));
+        return light == null ? 15 : light.brightness(type, pos, 15);
     }
 
     public record RenderableGhostEntity(Entity entity, LerpedPose pose, float animAgeInTicks, float bobOffset) {

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExterior.java
@@ -256,24 +256,6 @@ public final class SotoGhostExterior implements BlockAndTintGetter {
         Map<BlockPos, BlockState> newBlocks = new HashMap<>(payload.toBlockMap());
         Map<BlockPos, CompoundTag> newBes = new HashMap<>(payload.toBlockEntityMap());
         PortalLightData newLight = payload.lightData();
-        // #region agent log
-        try {
-            int firstPacked = newLight.isEmpty() ? -1 : newLight.packed(newLight.min());
-            int matchedBlocks = 0, maxMatchedBlock = 0, maxMatchedSky = 0;
-            for (BlockPos pos : newBlocks.keySet()) {
-                int packed = newLight.packed(pos);
-                if (packed >= 0) {
-                    matchedBlocks++;
-                    maxMatchedBlock = Math.max(maxMatchedBlock, packed & 0xF);
-                    maxMatchedSky = Math.max(maxMatchedSky, packed >>> 4);
-                }
-            }
-            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"C\",\"location\":\"SotoGhostExterior.applyChunk\",\"message\":\"client received portal light\",\"data\":{\"kind\":\"" + kind + "\",\"chunkX\":" + payload.chunkX() + ",\"chunkZ\":" + payload.chunkZ() + ",\"blocks\":" + newBlocks.size() + ",\"originX\":" + payload.footprintOriginX() + ",\"originY\":" + payload.footprintOriginY() + ",\"originZ\":" + payload.footprintOriginZ() + ",\"lightMinX\":" + newLight.min().getX() + ",\"lightMinY\":" + newLight.min().getY() + ",\"lightMinZ\":" + newLight.min().getZ() + ",\"lightBytes\":" + newLight.packedCopy().length + ",\"firstPacked\":" + firstPacked + ",\"matchedBlocks\":" + matchedBlocks + ",\"maxMatchedBlock\":" + maxMatchedBlock + ",\"maxMatchedSky\":" + maxMatchedSky + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (java.io.IOException ignored) {
-        }
-        // #endregion
         Map<BlockPos, BlockState> previousBlocks = ghost.chunkBlocks.get(key);
         Map<BlockPos, CompoundTag> previousBes = ghost.chunkBlockEntities.get(key);
         PortalLightData previousLight = ghost.chunkLights.get(key);

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
@@ -23,7 +23,6 @@ import net.minecraft.client.renderer.rendertype.PreparedRenderType;
 import net.minecraft.client.renderer.rendertype.RenderTypes;
 import net.minecraft.client.resources.model.geometry.BakedQuad;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.LightCoordsUtil;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.RenderShape;
 import net.minecraft.world.level.block.state.BlockState;
@@ -46,7 +45,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * Keyed by (PortalStreamKind, UUID) so BOTI and SOTO share the same mesh infrastructure.
  */
 public final class SotoGhostMeshCache {
-    private static final int FULLBRIGHT = LightCoordsUtil.FULL_BRIGHT;
     private static final int QUAD_VERTEX_STRIDE = 4;
     private static final int QUAD_INDEX_STRIDE = 6;
 
@@ -296,7 +294,6 @@ public final class SotoGhostMeshCache {
             EnumMap<ChunkSectionLayer, ByteBufferBuilder> allocators = new EnumMap<>(ChunkSectionLayer.class);
             EnumMap<ChunkSectionLayer, BufferBuilder> builders = new EnumMap<>(ChunkSectionLayer.class);
             QuadInstance quadInstance = new QuadInstance();
-            quadInstance.setLightCoords(FULLBRIGHT);
             quadInstance.setOverlayCoords(0);
 
             for (Map.Entry<BlockPos, BlockState> entry : blocks.entrySet()) {

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
@@ -296,6 +296,23 @@ public final class SotoGhostMeshCache {
             QuadInstance quadInstance = new QuadInstance();
             quadInstance.setOverlayCoords(0);
 
+            // #region agent log
+            try {
+                int minBlock = 15, maxBlock = 0, minSky = 15, maxSky = 0;
+                for (BlockPos pos : blocks.keySet()) {
+                    int block = ghost.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, pos);
+                    int sky = ghost.getBrightness(net.minecraft.world.level.LightLayer.SKY, pos);
+                    minBlock = Math.min(minBlock, block);
+                    maxBlock = Math.max(maxBlock, block);
+                    minSky = Math.min(minSky, sky);
+                    maxSky = Math.max(maxSky, sky);
+                }
+                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                        "{\"hypothesisId\":\"D\",\"location\":\"SotoGhostMeshCache.bakeChunk\",\"message\":\"brightness visible to terrain baker\",\"data\":{\"blocks\":" + blocks.size() + ",\"minBlock\":" + minBlock + ",\"maxBlock\":" + maxBlock + ",\"minSky\":" + minSky + ",\"maxSky\":" + maxSky + ",\"hasLightData\":" + ghost.hasLightData() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+            } catch (java.io.IOException ignored) {
+            }
+            // #endregion
             for (Map.Entry<BlockPos, BlockState> entry : blocks.entrySet()) {
                 BlockPos pos = entry.getKey();
                 BlockState state = entry.getValue();
@@ -347,6 +364,14 @@ public final class SotoGhostMeshCache {
             }
             return new ChunkMesh(uploaded);
         } catch (Throwable ignored) {
+            // #region agent log
+            try {
+                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                        "{\"hypothesisId\":\"F\",\"location\":\"SotoGhostMeshCache.bakeChunk\",\"message\":\"terrain bake threw\",\"data\":{\"errorType\":\"" + ignored.getClass().getName() + "\"},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+            } catch (java.io.IOException logIgnored) {
+            }
+            // #endregion
             return ChunkMesh.MARKER;
         }
     }

--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/ghost/SotoGhostMeshCache.java
@@ -296,23 +296,6 @@ public final class SotoGhostMeshCache {
             QuadInstance quadInstance = new QuadInstance();
             quadInstance.setOverlayCoords(0);
 
-            // #region agent log
-            try {
-                int minBlock = 15, maxBlock = 0, minSky = 15, maxSky = 0;
-                for (BlockPos pos : blocks.keySet()) {
-                    int block = ghost.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, pos);
-                    int sky = ghost.getBrightness(net.minecraft.world.level.LightLayer.SKY, pos);
-                    minBlock = Math.min(minBlock, block);
-                    maxBlock = Math.max(maxBlock, block);
-                    minSky = Math.min(minSky, sky);
-                    maxSky = Math.max(maxSky, sky);
-                }
-                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                        "{\"hypothesisId\":\"D\",\"location\":\"SotoGhostMeshCache.bakeChunk\",\"message\":\"brightness visible to terrain baker\",\"data\":{\"blocks\":" + blocks.size() + ",\"minBlock\":" + minBlock + ",\"maxBlock\":" + maxBlock + ",\"minSky\":" + minSky + ",\"maxSky\":" + maxSky + ",\"hasLightData\":" + ghost.hasLightData() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-            } catch (java.io.IOException ignored) {
-            }
-            // #endregion
             for (Map.Entry<BlockPos, BlockState> entry : blocks.entrySet()) {
                 BlockPos pos = entry.getKey();
                 BlockState state = entry.getValue();
@@ -364,14 +347,6 @@ public final class SotoGhostMeshCache {
             }
             return new ChunkMesh(uploaded);
         } catch (Throwable ignored) {
-            // #region agent log
-            try {
-                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                        "{\"hypothesisId\":\"F\",\"location\":\"SotoGhostMeshCache.bakeChunk\",\"message\":\"terrain bake threw\",\"data\":{\"errorType\":\"" + ignored.getClass().getName() + "\"},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-            } catch (java.io.IOException logIgnored) {
-            }
-            // #endregion
             return ChunkMesh.MARKER;
         }
     }

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
@@ -208,6 +208,9 @@ public class TardisInteriorGameTests {
             }
             var sample = BotiInteriorSampler.sampleStreamChunk(
                     interior, tardisId, sourcePos.getX() >> 4, sourcePos.getZ() >> 4);
+            if (sample == null) {
+                throw new AssertionError("Expected BOTI stream sample after interior place (chunk should be FULL)");
+            }
             if (sample.lightData().brightness(LightLayer.BLOCK, sourcePos, -1) != 15) {
                 throw new AssertionError("Expected BOTI sample to retain propagated block light");
             }

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
@@ -194,7 +194,7 @@ public class TardisInteriorGameTests {
         context.succeed();
     }
 
-    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    @GameTest(structure = "fabric-gametest-api-v1:empty", maxTicks = 80)
     public void consoleRoomPlacer_EnablesAndCalculatesLightWithThreadedEngine(GameTestHelper context) {
         ServerLevel interior = context.getLevel();
         UUID tardisId = UUID.randomUUID();

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
@@ -23,7 +23,6 @@ import net.fabricmc.fabric.api.gametest.v1.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.GameType;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
@@ -206,10 +205,6 @@ public class TardisInteriorGameTests {
             int brightness = interior.getBrightness(LightLayer.BLOCK, sourcePos);
             if (brightness != 15) {
                 throw new AssertionError("Expected propagated block light 15 at " + sourcePos + " but got " + brightness);
-            }
-            if (!interior.getLightEngine().lightOnInColumn(
-                    ChunkPos.pack(sourcePos.getX() >> 4, sourcePos.getZ() >> 4))) {
-                throw new AssertionError("Expected light storage enabled for source column");
             }
             var sample = BotiInteriorSampler.sampleStreamChunk(
                     interior, tardisId, sourcePos.getX() >> 4, sourcePos.getZ() >> 4);

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
@@ -195,11 +195,8 @@ public class TardisInteriorGameTests {
     }
 
     @GameTest(structure = "fabric-gametest-api-v1:empty")
-    public void consoleRoomPlacer_EnablesAndCalculatesLightInTardisDimension(GameTestHelper context) {
-        ServerLevel interior = context.getLevel().getServer().getLevel(TardisDimensions.TARDIS_WORLD_KEY);
-        if (interior == null) {
-            throw new AssertionError("Expected dwm:tardis dimension");
-        }
+    public void consoleRoomPlacer_EnablesAndCalculatesLightWithThreadedEngine(GameTestHelper context) {
+        ServerLevel interior = context.getLevel();
         UUID tardisId = UUID.randomUUID();
         BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
         FirstDoctorConsoleRoomPlacer.place(interior, origin, tardisId);

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/TardisInteriorGameTests.java
@@ -5,6 +5,7 @@ import com.adamkali.dwm.block.TardisInteriorDoorBlock;
 import com.adamkali.dwm.block.entities.FirstDoctorConsoleBlockEntity;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.block.entities.TardisInteriorDoorBlockEntity;
+import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
 import com.adamkali.dwm.tardis.data.model.TardisDoorState;
@@ -20,8 +21,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.fabricmc.fabric.api.gametest.v1.GameTest;
 import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.GameType;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
@@ -188,6 +192,35 @@ public class TardisInteriorGameTests {
         }
 
         context.succeed();
+    }
+
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void consoleRoomPlacer_EnablesAndCalculatesLightInTardisDimension(GameTestHelper context) {
+        ServerLevel interior = context.getLevel().getServer().getLevel(TardisDimensions.TARDIS_WORLD_KEY);
+        if (interior == null) {
+            throw new AssertionError("Expected dwm:tardis dimension");
+        }
+        UUID tardisId = UUID.randomUUID();
+        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
+        FirstDoctorConsoleRoomPlacer.place(interior, origin, tardisId);
+        BlockPos sourcePos = origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+
+        context.runAfterDelay(40, () -> {
+            int brightness = interior.getBrightness(LightLayer.BLOCK, sourcePos);
+            if (brightness != 15) {
+                throw new AssertionError("Expected propagated block light 15 at " + sourcePos + " but got " + brightness);
+            }
+            if (!interior.getLightEngine().lightOnInColumn(
+                    ChunkPos.pack(sourcePos.getX() >> 4, sourcePos.getZ() >> 4))) {
+                throw new AssertionError("Expected light storage enabled for source column");
+            }
+            var sample = BotiInteriorSampler.sampleStreamChunk(
+                    interior, tardisId, sourcePos.getX() >> 4, sourcePos.getZ() >> 4);
+            if (sample.lightData().brightness(LightLayer.BLOCK, sourcePos, -1) != 15) {
+                throw new AssertionError("Expected BOTI sample to retain propagated block light");
+            }
+            context.succeed();
+        });
     }
 
     @GameTest(structure = "fabric-gametest-api-v1:empty")

--- a/dwm/src/main/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayload.java
+++ b/dwm/src/main/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayload.java
@@ -178,6 +178,14 @@ public record SyncPortalChunkS2CPayload(
                 -footprintOrigin.getY(),
                 -footprintOrigin.getZ()
         ));
+        // #region agent log
+        try {
+            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                    "{\"hypothesisId\":\"B\",\"location\":\"SyncPortalChunkS2CPayload.fromSample\",\"message\":\"translated portal light for wire\",\"data\":{\"kind\":\"" + kind + "\",\"chunkX\":" + sample.chunkX() + ",\"chunkZ\":" + sample.chunkZ() + ",\"originX\":" + footprintOrigin.getX() + ",\"originY\":" + footprintOrigin.getY() + ",\"originZ\":" + footprintOrigin.getZ() + ",\"worldMinX\":" + sample.lightData().min().getX() + ",\"worldMinY\":" + sample.lightData().min().getY() + ",\"worldMinZ\":" + sample.lightData().min().getZ() + ",\"relativeMinX\":" + relativeLight.min().getX() + ",\"relativeMinY\":" + relativeLight.min().getY() + ",\"relativeMinZ\":" + relativeLight.min().getZ() + ",\"bytes\":" + relativeLight.packedCopy().length + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (java.io.IOException ignored) {
+        }
+        // #endregion
         return new SyncPortalChunkS2CPayload(
                 kind,
                 tardisId,

--- a/dwm/src/main/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayload.java
+++ b/dwm/src/main/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayload.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.network;
 
 import com.adamkali.dwm.tardis.boti.BotiRelativePosCodec;
+import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import java.util.ArrayList;
@@ -29,8 +30,11 @@ public record SyncPortalChunkS2CPayload(
         int footprintOriginY,
         int footprintOriginZ,
         List<BlockEntry> blocks,
-        List<BlockEntityEntry> blockEntities
+        List<BlockEntityEntry> blockEntities,
+        PortalLightData lightData
 ) implements CustomPacketPayload {
+    private static final int MAX_LIGHT_BYTES = 16 * 384 * 16;
+
     public static final CustomPacketPayload.Type<SyncPortalChunkS2CPayload> ID =
             new CustomPacketPayload.Type<>(DWMPacketIds.SYNC_PORTAL_CHUNK_PACKET_ID);
 
@@ -41,6 +45,30 @@ public record SyncPortalChunkS2CPayload(
     }
 
     public record BlockEntityEntry(int relX, int relY, int relZ, CompoundTag nbt) {
+    }
+
+    public SyncPortalChunkS2CPayload(
+            PortalStreamKind kind,
+            UUID tardisId,
+            int chunkX,
+            int chunkZ,
+            int footprintOriginX,
+            int footprintOriginY,
+            int footprintOriginZ,
+            List<BlockEntry> blocks,
+            List<BlockEntityEntry> blockEntities
+    ) {
+        this(
+                kind, tardisId, chunkX, chunkZ,
+                footprintOriginX, footprintOriginY, footprintOriginZ,
+                blocks, blockEntities, PortalLightData.EMPTY
+        );
+    }
+
+    public SyncPortalChunkS2CPayload {
+        blocks = blocks == null ? List.of() : List.copyOf(blocks);
+        blockEntities = blockEntities == null ? List.of() : List.copyOf(blockEntities);
+        lightData = lightData == null ? PortalLightData.EMPTY : lightData;
     }
 
     private static void encode(SyncPortalChunkS2CPayload payload, RegistryFriendlyByteBuf buf) {
@@ -65,6 +93,14 @@ public record SyncPortalChunkS2CPayload(
             ByteBufCodecs.VAR_INT.encode(buf, entry.relZ());
             ByteBufCodecs.COMPOUND_TAG.encode(buf, entry.nbt());
         }
+        PortalLightData light = payload.lightData;
+        ByteBufCodecs.VAR_INT.encode(buf, light.min().getX());
+        ByteBufCodecs.VAR_INT.encode(buf, light.min().getY());
+        ByteBufCodecs.VAR_INT.encode(buf, light.min().getZ());
+        ByteBufCodecs.VAR_INT.encode(buf, light.sizeX());
+        ByteBufCodecs.VAR_INT.encode(buf, light.sizeY());
+        ByteBufCodecs.VAR_INT.encode(buf, light.sizeZ());
+        buf.writeByteArray(light.packedCopy());
     }
 
     private static SyncPortalChunkS2CPayload decode(RegistryFriendlyByteBuf buf) {
@@ -95,8 +131,19 @@ public record SyncPortalChunkS2CPayload(
                     ByteBufCodecs.COMPOUND_TAG.decode(buf)
             ));
         }
+        BlockPos lightMin = new BlockPos(
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf),
+                ByteBufCodecs.VAR_INT.decode(buf)
+        );
+        int lightSizeX = ByteBufCodecs.VAR_INT.decode(buf);
+        int lightSizeY = ByteBufCodecs.VAR_INT.decode(buf);
+        int lightSizeZ = ByteBufCodecs.VAR_INT.decode(buf);
+        PortalLightData lightData = new PortalLightData(
+                lightMin, lightSizeX, lightSizeY, lightSizeZ, buf.readByteArray(MAX_LIGHT_BYTES)
+        );
         return new SyncPortalChunkS2CPayload(
-                kind, tardisId, chunkX, chunkZ, originX, originY, originZ, blocks, blockEntities
+                kind, tardisId, chunkX, chunkZ, originX, originY, originZ, blocks, blockEntities, lightData
         );
     }
 
@@ -126,6 +173,11 @@ public record SyncPortalChunkS2CPayload(
                     entry.getValue()
             ));
         }
+        PortalLightData relativeLight = sample.lightData().translated(new BlockPos(
+                -footprintOrigin.getX(),
+                -footprintOrigin.getY(),
+                -footprintOrigin.getZ()
+        ));
         return new SyncPortalChunkS2CPayload(
                 kind,
                 tardisId,
@@ -135,7 +187,8 @@ public record SyncPortalChunkS2CPayload(
                 footprintOrigin.getY(),
                 footprintOrigin.getZ(),
                 blocks,
-                bes
+                bes,
+                relativeLight
         );
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayload.java
+++ b/dwm/src/main/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayload.java
@@ -178,14 +178,6 @@ public record SyncPortalChunkS2CPayload(
                 -footprintOrigin.getY(),
                 -footprintOrigin.getZ()
         ));
-        // #region agent log
-        try {
-            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"B\",\"location\":\"SyncPortalChunkS2CPayload.fromSample\",\"message\":\"translated portal light for wire\",\"data\":{\"kind\":\"" + kind + "\",\"chunkX\":" + sample.chunkX() + ",\"chunkZ\":" + sample.chunkZ() + ",\"originX\":" + footprintOrigin.getX() + ",\"originY\":" + footprintOrigin.getY() + ",\"originZ\":" + footprintOrigin.getZ() + ",\"worldMinX\":" + sample.lightData().min().getX() + ",\"worldMinY\":" + sample.lightData().min().getY() + ",\"worldMinZ\":" + sample.lightData().min().getZ() + ",\"relativeMinX\":" + relativeLight.min().getX() + ",\"relativeMinY\":" + relativeLight.min().getY() + ",\"relativeMinZ\":" + relativeLight.min().getZ() + ",\"bytes\":" + relativeLight.packedCopy().length + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (java.io.IOException ignored) {
-        }
-        // #endregion
         return new SyncPortalChunkS2CPayload(
                 kind,
                 tardisId,

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -228,6 +228,38 @@ public final class BotiInteriorSampler {
     }
 
     /**
+     * Enables vanilla light storage and queues source propagation for a newly stamped room.
+     * Empty flat-world chunks can reach FULL without lighting ever being enabled, so ordinary
+     * block-change checks alone have nowhere to retain their result.
+     */
+    public static void enableFootprintLighting(ServerLevel world, BlockPos plotOrigin) {
+        if (world == null || plotOrigin == null) {
+            return;
+        }
+        int[] bounds = footprintChunkBounds(plotOrigin);
+        var lightEngine = world.getLightEngine();
+        int scheduledColumns = 0;
+        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
+            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
+                ChunkPos chunkPos = new ChunkPos(cx, cz);
+                lightEngine.setLightEnabled(chunkPos, true);
+                lightEngine.propagateLightSources(chunkPos);
+                scheduledColumns++;
+            }
+        }
+        BlockPos sourcePos = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+        lightEngine.checkBlock(sourcePos);
+        // #region agent log
+        try {
+            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                    "{\"hypothesisId\":\"G,H\",\"location\":\"BotiInteriorSampler.enableFootprintLighting\",\"message\":\"queued footprint lighting\",\"data\":{\"columns\":" + scheduledColumns + ",\"sourceEmission\":" + world.getBlockState(sourcePos).getLightEmission() + ",\"lightOnInSourceColumn\":" + lightEngine.lightOnInColumn(ChunkPos.asLong(sourcePos)) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (java.io.IOException ignored) {
+        }
+        // #endregion
+    }
+
+    /**
      * Synchronously force-loads footprint chunks (blocking). Prefer {@link #addFootprintTickets}
      * + {@link #areFootprintChunksLoaded} for approach-time preload.
      */

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -446,6 +446,21 @@ public final class BotiInteriorSampler {
         } catch (java.io.IOException ignored) {
         }
         // #endregion
+        BlockPos expectedLight = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+        if ((expectedLight.getX() >> 4) == chunkX && (expectedLight.getZ() >> 4) == chunkZ) {
+            var lightEngine = interiorWorld.getLightEngine();
+            var sourceChunk = interiorWorld.getChunkAt(expectedLight);
+            BlockState sourceState = interiorWorld.getBlockState(expectedLight);
+            net.minecraft.core.SectionPos sourceSection = net.minecraft.core.SectionPos.of(expectedLight);
+            // #region agent log
+            try {
+                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                        "{\"hypothesisId\":\"G,H,I,J\",\"location\":\"BotiInteriorSampler.sampleStreamChunk:source\",\"message\":\"light source state when BOTI samples\",\"data\":{\"block\":\"" + net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(sourceState.getBlock()) + "\",\"isLight\":" + sourceState.is(Blocks.LIGHT) + ",\"emission\":" + sourceState.getLightEmission() + ",\"brightness\":" + interiorWorld.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight) + ",\"rawBrightness\":" + lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getLightValue(expectedLight) + ",\"neighborBrightness\":" + interiorWorld.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight.below()) + ",\"hasLightWork\":" + lightEngine.hasLightWork() + ",\"lightOnInColumn\":" + lightEngine.lightOnInColumn(sourceChunk.getPos().pack()) + ",\"chunkLightCorrect\":" + sourceChunk.isLightCorrect() + ",\"chunkStatus\":\"" + sourceChunk.getPersistedStatus() + "\",\"sectionType\":\"" + lightEngine.getDebugSectionType(net.minecraft.world.level.LightLayer.BLOCK, sourceSection) + "\",\"sectionDataPresent\":" + (lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getDataLayerData(sourceSection) != null) + ",\"engine\":\"" + lightEngine.getClass().getName() + "\",\"hasSkyLight\":" + interiorWorld.dimensionType().hasSkyLight() + ",\"ambientLight\":" + interiorWorld.dimensionType().ambientLight() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+            } catch (java.io.IOException ignored) {
+            }
+            // #endregion
+        }
         return new PortalStreamSample(
                 chunkX, chunkZ, Map.copyOf(blocks), Map.copyOf(blockEntities), lightData
         );

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -5,6 +5,7 @@ import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
+import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import com.mojang.authlib.GameProfile;
 import java.util.ArrayList;
@@ -389,7 +390,7 @@ public final class BotiInteriorSampler {
             int chunkZ
     ) {
         if (interiorWorld == null || tardisId == null) {
-            return new PortalStreamSample(chunkX, chunkZ, Map.of(), Map.of());
+            return new PortalStreamSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
         }
         BlockPos plotOrigin = TardisPlotAllocator.plotOrigin(tardisId);
         interiorWorld.getChunk(chunkX, chunkZ);
@@ -421,7 +422,18 @@ public final class BotiInteriorSampler {
                 }
             }
         }
-        return new PortalStreamSample(chunkX, chunkZ, Map.copyOf(blocks), Map.copyOf(blockEntities));
+        int minX = Math.max(baseX, plotOrigin.getX());
+        int maxX = Math.min(baseX + 15, plotOrigin.getX() + SIZE_X - 1);
+        int minZ = Math.max(baseZ, plotOrigin.getZ());
+        int maxZ = Math.min(baseZ + 15, plotOrigin.getZ() + SIZE_Z - 1);
+        PortalLightData lightData = PortalLightData.sample(
+                interiorWorld,
+                new BlockPos(minX, minY, minZ),
+                new BlockPos(maxX, maxY, maxZ)
+        );
+        return new PortalStreamSample(
+                chunkX, chunkZ, Map.copyOf(blocks), Map.copyOf(blockEntities), lightData
+        );
     }
 
     public static List<Entity> collectStreamEntities(ServerLevel interiorWorld, UUID tardisId) {

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -32,6 +32,7 @@ import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
@@ -207,24 +208,17 @@ public final class BotiInteriorSampler {
         return true;
     }
 
-    /**
-     * True once vanilla lighting has enabled every footprint column. Newly generated empty flat
-     * chunks can be FULL before their asynchronous light-engine initialization has completed.
-     */
+    /** True once the stamped room's known light source has propagated into vanilla light data. */
     public static boolean isFootprintLightReady(ServerLevel world, BlockPos plotOrigin) {
         if (world == null || plotOrigin == null) {
             return false;
         }
-        int[] bounds = footprintChunkBounds(plotOrigin);
-        var lightEngine = world.getLightEngine();
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                if (!lightEngine.lightOnInColumn(ChunkPos.pack(cx, cz))) {
-                    return false;
-                }
-            }
-        }
-        return true;
+        BlockPos sourcePos = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+        BlockState source = world.getBlockState(sourcePos);
+        int emission = source.getLightEmission();
+        return source.is(Blocks.LIGHT)
+                && emission > 0
+                && world.getBrightness(LightLayer.BLOCK, sourcePos) >= emission;
     }
 
     /**

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -6,6 +6,7 @@ import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
 import com.adamkali.dwm.tardis.portal.PortalLightData;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import com.mojang.authlib.GameProfile;
 import java.util.ArrayList;
@@ -20,23 +21,18 @@ import net.minecraft.core.UUIDUtil;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.DoubleTag;
 import net.minecraft.nbt.ListTag;
-import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.util.ProblemReporter;
-import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EntityTypes;
-import net.minecraft.world.entity.Mob;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.phys.AABB;
 
@@ -44,7 +40,7 @@ import net.minecraft.world.phys.AABB;
  * Samples the First Doctor console-room footprint for BOTI sync.
  * Relative coords match {@link FirstDoctorConsoleRoomLayout} / exterior alignment.
  */
-public final class BotiInteriorSampler {
+public final class BotiInteriorSampler extends PortalSampler {
     public static final int SIZE_X = FirstDoctorConsoleRoomLayout.SIZE_X;
     public static final int SIZE_Y = FirstDoctorConsoleRoomLayout.SIZE_Y;
     public static final int SIZE_Z = FirstDoctorConsoleRoomLayout.SIZE_Z;
@@ -55,7 +51,10 @@ public final class BotiInteriorSampler {
      */
     private static final TicketType BOTI_TICKET = new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION);
 
+    static final BotiInteriorSampler INSTANCE = new BotiInteriorSampler();
+
     private BotiInteriorSampler() {
+        super(SIZE_X, SIZE_Y, SIZE_Z, BOTI_TICKET);
     }
 
     /**
@@ -64,6 +63,11 @@ public final class BotiInteriorSampler {
      * The First Doctor console is included so its BER can draw via synced BE NBT.
      */
     public static boolean isBotiVisible(BlockState state) {
+        return INSTANCE.isVisible(state);
+    }
+
+    @Override
+    public boolean isVisible(BlockState state) {
         return state != null
                 && !state.isAir()
                 && !state.is(Blocks.LIGHT)
@@ -74,13 +78,7 @@ public final class BotiInteriorSampler {
      * Filters an arbitrary placement map the same way live sampling does.
      */
     public static Map<BlockPos, BlockState> filterVisible(Map<BlockPos, BlockState> placements) {
-        Map<BlockPos, BlockState> visible = new HashMap<>();
-        for (Map.Entry<BlockPos, BlockState> entry : placements.entrySet()) {
-            if (isBotiVisible(entry.getValue())) {
-                visible.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return visible;
+        return INSTANCE.filterVisibleBlocks(placements);
     }
 
     /**
@@ -137,26 +135,12 @@ public final class BotiInteriorSampler {
      * Chunk-sync NBT plus type {@code id} for client {@link BlockEntity#loadStatic} reconstruction.
      */
     public static CompoundTag captureSyncNbt(BlockEntity blockEntity, HolderLookup.Provider registries) {
-        CompoundTag nbt = blockEntity.getUpdateTag(registries);
-        TagValueOutput typeOut = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, registries);
-        BlockEntity.addEntityType(typeOut, blockEntity.getType());
-        CompoundTag typeTag = typeOut.buildResult();
-        for (String key : typeTag.keySet()) {
-            nbt.put(key, typeTag.get(key));
-        }
-        return nbt;
+        return PortalSampler.captureSyncNbt(blockEntity, registries);
     }
 
     /** Axis-aligned footprint box in world space for entity queries. */
     public static AABB footprintBox(BlockPos plotOrigin) {
-        return new AABB(
-                plotOrigin.getX(),
-                plotOrigin.getY(),
-                plotOrigin.getZ(),
-                plotOrigin.getX() + SIZE_X,
-                plotOrigin.getY() + SIZE_Y,
-                plotOrigin.getZ() + SIZE_Z
-        );
+        return INSTANCE.footprintAabb(plotOrigin);
     }
 
     /**
@@ -180,13 +164,7 @@ public final class BotiInteriorSampler {
         if (world == null || plotOrigin == null) {
             return;
         }
-        int[] bounds = footprintChunkBounds(plotOrigin);
-        var chunkManager = world.getChunkSource();
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                chunkManager.addTicketWithRadius(BOTI_TICKET, new ChunkPos(cx, cz), 2);
-            }
-        }
+        INSTANCE.addTickets(world, footprintChunkBounds(plotOrigin));
     }
 
     /**
@@ -272,7 +250,7 @@ public final class BotiInteriorSampler {
     public static boolean hasEntities(ServerLevel interiorWorld, UUID tardisId) {
         BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
         ensureFootprintChunksLoaded(interiorWorld, origin);
-        return !interiorWorld.getEntities((Entity) null, footprintBox(origin), entity -> !entity.isRemoved()).isEmpty();
+        return INSTANCE.hasLoadedEntities(interiorWorld, origin);
     }
 
     /**
@@ -284,17 +262,7 @@ public final class BotiInteriorSampler {
         if (interiorWorld == null || tardisId == null) {
             return;
         }
-        // Players in-dimension already reset the counter via MobEntity#checkDespawn.
-        if (!interiorWorld.players().isEmpty()) {
-            return;
-        }
-        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        ensureFootprintChunksLoaded(interiorWorld, origin);
-        for (Entity entity : interiorWorld.getEntities((Entity) null, footprintBox(origin), e -> !e.isRemoved())) {
-            if (entity instanceof Mob mob && mob.getNoActionTime() != 0) {
-                mob.setNoActionTime(0);
-            }
-        }
+        INSTANCE.resetMobAi(interiorWorld, TardisPlotAllocator.plotOrigin(tardisId));
     }
 
     /**
@@ -384,35 +352,12 @@ public final class BotiInteriorSampler {
     }
 
     public static boolean isInsideFootprint(BlockPos worldPos, BlockPos plotOrigin) {
-        int localX = worldPos.getX() - plotOrigin.getX();
-        int localY = worldPos.getY() - plotOrigin.getY();
-        int localZ = worldPos.getZ() - plotOrigin.getZ();
-        return localX >= 0 && localX < SIZE_X
-                && localY >= 0 && localY < SIZE_Y
-                && localZ >= 0 && localZ < SIZE_Z;
+        return INSTANCE.inFootprint(worldPos, plotOrigin);
     }
 
     /** Samples interior sky/fog atmosphere at the plot origin. */
     public static PortalAtmosphere sampleAtmosphere(ServerLevel interiorWorld, BlockPos plotOrigin) {
-        if (interiorWorld == null || plotOrigin == null) {
-            return PortalAtmosphere.DEFAULT;
-        }
-        Identifier effectsId = interiorWorld.dimensionTypeRegistration()
-                .unwrapKey()
-                .map(ResourceKey::identifier)
-                .orElseGet(BuiltinDimensionTypes.OVERWORLD::identifier);
-        long timeOfDay = interiorWorld.getOverworldClockTime();
-        float rain = interiorWorld.getRainLevel(0.0f);
-        float thunder = interiorWorld.getThunderLevel(0.0f);
-        var attrs = interiorWorld.environmentAttributes();
-        return new PortalAtmosphere(
-                effectsId,
-                timeOfDay,
-                rain,
-                thunder,
-                attrs.getValue(EnvironmentAttributes.SKY_COLOR, plotOrigin),
-                attrs.getValue(EnvironmentAttributes.FOG_COLOR, plotOrigin)
-        );
+        return PortalSampler.sampleAtmosphere(interiorWorld, plotOrigin);
     }
 
     /**
@@ -428,56 +373,47 @@ public final class BotiInteriorSampler {
         if (interiorWorld == null || tardisId == null) {
             return new PortalStreamSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
         }
-        BlockPos plotOrigin = TardisPlotAllocator.plotOrigin(tardisId);
-        interiorWorld.getChunk(chunkX, chunkZ);
-        Map<BlockPos, BlockState> blocks = new HashMap<>();
-        Map<BlockPos, CompoundTag> blockEntities = new HashMap<>();
-        HolderLookup.Provider registries = interiorWorld.registryAccess();
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-        int baseX = chunkX << 4;
-        int baseZ = chunkZ << 4;
-        int minY = plotOrigin.getY();
-        int maxY = plotOrigin.getY() + SIZE_Y - 1;
-        for (int lx = 0; lx < 16; lx++) {
-            for (int lz = 0; lz < 16; lz++) {
-                for (int y = minY; y <= maxY; y++) {
-                    mutable.set(baseX + lx, y, baseZ + lz);
-                    if (!isInsideFootprint(mutable, plotOrigin)) {
-                        continue;
-                    }
-                    BlockState state = interiorWorld.getBlockState(mutable);
-                    if (!isBotiVisible(state)) {
-                        continue;
-                    }
-                    BlockPos immutable = mutable.immutable();
-                    blocks.put(immutable, state);
-                    BlockEntity blockEntity = interiorWorld.getBlockEntity(mutable);
-                    if (blockEntity != null) {
-                        blockEntities.put(immutable, captureSyncNbt(blockEntity, registries));
-                    }
-                }
-            }
-        }
-        int minX = Math.max(baseX, plotOrigin.getX());
-        int maxX = Math.min(baseX + 15, plotOrigin.getX() + SIZE_X - 1);
-        int minZ = Math.max(baseZ, plotOrigin.getZ());
-        int maxZ = Math.min(baseZ + 15, plotOrigin.getZ() + SIZE_Z - 1);
-        PortalLightData lightData = PortalLightData.sample(
-                interiorWorld,
-                new BlockPos(minX, minY, minZ),
-                new BlockPos(maxX, maxY, maxZ)
-        );
-        return new PortalStreamSample(
-                chunkX, chunkZ, Map.copyOf(blocks), Map.copyOf(blockEntities), lightData
-        );
+        return INSTANCE.sampleChunkColumn(interiorWorld, TardisPlotAllocator.plotOrigin(tardisId), chunkX, chunkZ);
     }
 
     public static List<Entity> collectStreamEntities(ServerLevel interiorWorld, UUID tardisId) {
         if (interiorWorld == null || tardisId == null) {
             return List.of();
         }
-        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        ensureFootprintChunksLoaded(interiorWorld, origin);
-        return List.copyOf(interiorWorld.getEntities((Entity) null, footprintBox(origin), entity -> !entity.isRemoved()));
+        return INSTANCE.collectEntities(interiorWorld, TardisPlotAllocator.plotOrigin(tardisId));
+    }
+
+    @Override
+    protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
+        ensureFootprintChunksLoaded(world, anchor);
+    }
+
+    @Override
+    protected boolean includePos(BlockPos worldPos, BlockPos anchor) {
+        return inFootprint(worldPos, anchor);
+    }
+
+    @Override
+    protected PortalLightData sampleLight(
+            ServerLevel world,
+            BlockPos anchor,
+            int chunkX,
+            int chunkZ,
+            YRange yRange,
+            Map<BlockPos, BlockState> blocks,
+            int lowestVisibleY,
+            int highestVisibleY
+    ) {
+        int baseX = chunkX << 4;
+        int baseZ = chunkZ << 4;
+        int minX = Math.max(baseX, anchor.getX());
+        int maxX = Math.min(baseX + 15, anchor.getX() + sizeX - 1);
+        int minZ = Math.max(baseZ, anchor.getZ());
+        int maxZ = Math.min(baseZ + 15, anchor.getZ() + sizeZ - 1);
+        return PortalLightData.sample(
+                world,
+                new BlockPos(minX, yRange.min(), minZ),
+                new BlockPos(maxX, yRange.max(), maxZ)
+        );
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -144,7 +144,7 @@ public final class BotiInteriorSampler extends PortalSampler {
     }
 
     /**
-     * Inclusive chunk-grid bounds covering the footprint:
+     * Inclusive chunk-grid bounds covering the console-room footprint (preload / lighting).
      * {@code [minChunkX, maxChunkX, minChunkZ, maxChunkZ]}.
      */
     public static int[] footprintChunkBounds(BlockPos plotOrigin) {
@@ -154,6 +154,66 @@ public final class BotiInteriorSampler extends PortalSampler {
                 SectionPos.blockToSectionCoord(plotOrigin.getZ()),
                 SectionPos.blockToSectionCoord(plotOrigin.getZ() + SIZE_Z - 1)
         };
+    }
+
+    /**
+     * Inclusive chunk-grid bounds of the allocated plot
+     * {@code [origin, origin + PLOT_SPACING)}.
+     */
+    public static int[] plotChunkBounds(BlockPos plotOrigin) {
+        int minCX = SectionPos.blockToSectionCoord(plotOrigin.getX());
+        int maxCX = SectionPos.blockToSectionCoord(plotOrigin.getX() + TardisPlotAllocator.PLOT_SPACING - 1);
+        int minCZ = SectionPos.blockToSectionCoord(plotOrigin.getZ());
+        int maxCZ = SectionPos.blockToSectionCoord(plotOrigin.getZ() + TardisPlotAllocator.PLOT_SPACING - 1);
+        return new int[]{minCX, maxCX, minCZ, maxCZ};
+    }
+
+    /**
+     * View-distance Chebyshev box around {@code plotOrigin}, clipped to the owning plot.
+     */
+    public static int[] streamChunkBounds(BlockPos plotOrigin, int radiusChunks) {
+        int[] plot = plotChunkBounds(plotOrigin);
+        return PortalSampler.clipChunkBounds(
+                PortalSampler.streamChunkBounds(plotOrigin, radiusChunks),
+                plot[0],
+                plot[1],
+                plot[2],
+                plot[3]
+        );
+    }
+
+    public static int[] streamChunkBounds(ServerLevel world, BlockPos plotOrigin) {
+        return streamChunkBounds(plotOrigin, PortalSampler.streamRadiusChunks(world));
+    }
+
+    /** Caps a view-distance radius so fog/stream stay inside {@link TardisPlotAllocator#PLOT_SPACING}. */
+    public static int clipStreamRadiusChunks(int radiusChunks) {
+        int plotRadius = Math.max(0, (TardisPlotAllocator.PLOT_SPACING - 1) / 16);
+        return Math.min(Math.max(0, radiusChunks), plotRadius);
+    }
+
+    public static boolean isInsidePlotStream(BlockPos worldPos, BlockPos plotOrigin, int radiusChunks) {
+        if (worldPos == null || plotOrigin == null) {
+            return false;
+        }
+        int localX = worldPos.getX() - plotOrigin.getX();
+        int localZ = worldPos.getZ() - plotOrigin.getZ();
+        if (localX < 0 || localX >= TardisPlotAllocator.PLOT_SPACING
+                || localZ < 0 || localZ >= TardisPlotAllocator.PLOT_SPACING) {
+            return false;
+        }
+        return PortalSampler.isInsideStreamRadius(
+                worldPos, plotOrigin, radiusChunks, PortalSampler.streamYRadiusBlocks(radiusChunks));
+    }
+
+    /**
+     * Ticket-only keep-alive for the portal stream radius. Does not call {@code getChunk}.
+     */
+    public static void addStreamTickets(ServerLevel world, BlockPos plotOrigin) {
+        if (world == null || plotOrigin == null) {
+            return;
+        }
+        INSTANCE.addStreamTickets(world, plotOrigin, clipStreamRadiusChunks(PortalSampler.streamRadiusChunks(world)));
     }
 
     /**
@@ -385,12 +445,39 @@ public final class BotiInteriorSampler extends PortalSampler {
 
     @Override
     protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
-        ensureFootprintChunksLoaded(world, anchor);
+        addStreamTickets(world, anchor);
+    }
+
+    @Override
+    protected AABB entityBox(ServerLevel world, BlockPos anchor) {
+        int radius = PortalSampler.streamRadiusChunks(world);
+        int yRadius = PortalSampler.streamYRadiusBlocks(radius);
+        AABB stream = PortalSampler.streamBox(anchor, radius, yRadius);
+        AABB plot = new AABB(
+                anchor.getX(),
+                stream.minY,
+                anchor.getZ(),
+                anchor.getX() + TardisPlotAllocator.PLOT_SPACING,
+                stream.maxY,
+                anchor.getZ() + TardisPlotAllocator.PLOT_SPACING
+        );
+        return stream.intersect(plot);
     }
 
     @Override
     protected boolean includePos(BlockPos worldPos, BlockPos anchor) {
-        return inFootprint(worldPos, anchor);
+        int localX = worldPos.getX() - anchor.getX();
+        int localZ = worldPos.getZ() - anchor.getZ();
+        return localX >= 0 && localX < TardisPlotAllocator.PLOT_SPACING
+                && localZ >= 0 && localZ < TardisPlotAllocator.PLOT_SPACING;
+    }
+
+    @Override
+    protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
+        int yRadius = PortalSampler.streamYRadiusBlocks(PortalSampler.streamRadiusChunks(world));
+        int minY = Math.max(world.getMinY(), anchor.getY() - yRadius);
+        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + yRadius);
+        return yRange(minY, maxY);
     }
 
     @Override
@@ -407,9 +494,9 @@ public final class BotiInteriorSampler extends PortalSampler {
         int baseX = chunkX << 4;
         int baseZ = chunkZ << 4;
         int minX = Math.max(baseX, anchor.getX());
-        int maxX = Math.min(baseX + 15, anchor.getX() + sizeX - 1);
+        int maxX = Math.min(baseX + 15, anchor.getX() + TardisPlotAllocator.PLOT_SPACING - 1);
         int minZ = Math.max(baseZ, anchor.getZ());
-        int maxZ = Math.min(baseZ + 15, anchor.getZ() + sizeZ - 1);
+        int maxZ = Math.min(baseZ + 15, anchor.getZ() + TardisPlotAllocator.PLOT_SPACING - 1);
         return PortalLightData.sample(
                 world,
                 new BlockPos(minX, yRange.min(), minZ),

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -252,7 +252,7 @@ public final class BotiInteriorSampler {
         // #region agent log
         try {
             java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"G,H\",\"location\":\"BotiInteriorSampler.enableFootprintLighting\",\"message\":\"queued footprint lighting\",\"data\":{\"columns\":" + scheduledColumns + ",\"sourceEmission\":" + world.getBlockState(sourcePos).getLightEmission() + ",\"lightOnInSourceColumn\":" + lightEngine.lightOnInColumn(ChunkPos.asLong(sourcePos)) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    "{\"hypothesisId\":\"G,H\",\"location\":\"BotiInteriorSampler.enableFootprintLighting\",\"message\":\"queued footprint lighting\",\"data\":{\"columns\":" + scheduledColumns + ",\"sourceEmission\":" + world.getBlockState(sourcePos).getLightEmission() + ",\"lightOnInSourceColumn\":" + lightEngine.lightOnInColumn(ChunkPos.pack(sourcePos.getX() >> 4, sourcePos.getZ() >> 4)) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
                     java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
         } catch (java.io.IOException ignored) {
         }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -3,14 +3,13 @@ package com.adamkali.dwm.tardis.boti;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.entity.ConsoleControlInteractionEntity;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
+import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomPlacer;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
 import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalSampler;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import com.mojang.authlib.GameProfile;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -22,7 +21,6 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.DoubleTag;
 import net.minecraft.nbt.ListTag;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.TicketType;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -35,26 +33,15 @@ import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Samples the First Doctor console-room footprint for BOTI sync.
- * Relative coords match {@link FirstDoctorConsoleRoomLayout} / exterior alignment.
+ * Samples the TARDIS interior plot for BOTI portal streaming.
  */
 public final class BotiInteriorSampler extends PortalSampler {
-    public static final int SIZE_X = FirstDoctorConsoleRoomLayout.SIZE_X;
-    public static final int SIZE_Y = FirstDoctorConsoleRoomLayout.SIZE_Y;
-    public static final int SIZE_Z = FirstDoctorConsoleRoomLayout.SIZE_Z;
-
-    /**
-     * Keeps footprint chunks entity-accessible briefly after the player leaves the TARDIS
-     * dimension so BOTI can still sample live entities for the exterior preview.
-     */
-    private static final TicketType BOTI_TICKET = new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION);
-
     static final BotiInteriorSampler INSTANCE = new BotiInteriorSampler();
 
     private BotiInteriorSampler() {
-        super(SIZE_X, SIZE_Y, SIZE_Z, BOTI_TICKET);
     }
 
     /**
@@ -82,78 +69,10 @@ public final class BotiInteriorSampler extends PortalSampler {
     }
 
     /**
-     * Samples the live plot for {@code tardisId} into relative structure coordinates.
-     */
-    public static Map<BlockPos, BlockState> sample(ServerLevel interiorWorld, UUID tardisId) {
-        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        Map<BlockPos, BlockState> visible = new HashMap<>();
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-        for (int x = 0; x < SIZE_X; x++) {
-            for (int y = 0; y < SIZE_Y; y++) {
-                for (int z = 0; z < SIZE_Z; z++) {
-                    mutable.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
-                    BlockState state = interiorWorld.getBlockState(mutable);
-                    if (isBotiVisible(state)) {
-                        visible.put(new BlockPos(x, y, z), state);
-                    }
-                }
-            }
-        }
-        return visible;
-    }
-
-    /**
-     * Samples chunk-sync NBT for block entities in the footprint
-     * ({@link #isBotiVisible} — interior doors excluded).
-     * Each compound includes the BE type {@code id} for client reconstruction.
-     */
-    public static Map<BlockPos, CompoundTag> sampleBlockEntities(ServerLevel interiorWorld, UUID tardisId) {
-        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        HolderLookup.Provider registries = interiorWorld.registryAccess();
-        Map<BlockPos, CompoundTag> entities = new HashMap<>();
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-        for (int x = 0; x < SIZE_X; x++) {
-            for (int y = 0; y < SIZE_Y; y++) {
-                for (int z = 0; z < SIZE_Z; z++) {
-                    mutable.set(origin.getX() + x, origin.getY() + y, origin.getZ() + z);
-                    BlockState state = interiorWorld.getBlockState(mutable);
-                    if (!isBotiVisible(state)) {
-                        continue;
-                    }
-                    BlockEntity blockEntity = interiorWorld.getBlockEntity(mutable);
-                    if (blockEntity == null) {
-                        continue;
-                    }
-                    entities.put(new BlockPos(x, y, z), captureSyncNbt(blockEntity, registries));
-                }
-            }
-        }
-        return entities;
-    }
-
-    /**
      * Chunk-sync NBT plus type {@code id} for client {@link BlockEntity#loadStatic} reconstruction.
      */
     public static CompoundTag captureSyncNbt(BlockEntity blockEntity, HolderLookup.Provider registries) {
         return PortalSampler.captureSyncNbt(blockEntity, registries);
-    }
-
-    /** Axis-aligned footprint box in world space for entity queries. */
-    public static AABB footprintBox(BlockPos plotOrigin) {
-        return INSTANCE.footprintAabb(plotOrigin);
-    }
-
-    /**
-     * Inclusive chunk-grid bounds covering the console-room footprint (preload / lighting).
-     * {@code [minChunkX, maxChunkX, minChunkZ, maxChunkZ]}.
-     */
-    public static int[] footprintChunkBounds(BlockPos plotOrigin) {
-        return new int[]{
-                SectionPos.blockToSectionCoord(plotOrigin.getX()),
-                SectionPos.blockToSectionCoord(plotOrigin.getX() + SIZE_X - 1),
-                SectionPos.blockToSectionCoord(plotOrigin.getZ()),
-                SectionPos.blockToSectionCoord(plotOrigin.getZ() + SIZE_Z - 1)
-        };
     }
 
     /**
@@ -216,36 +135,6 @@ public final class BotiInteriorSampler extends PortalSampler {
         INSTANCE.addStreamTickets(world, plotOrigin, clipStreamRadiusChunks(PortalSampler.streamRadiusChunks(world)));
     }
 
-    /**
-     * Ticket-only keep-alive for the console-room footprint. Does not call {@code getChunk}
-     * (avoids synchronous force-loads — used by deferred interior preload).
-     */
-    public static void addFootprintTickets(ServerLevel world, BlockPos plotOrigin) {
-        if (world == null || plotOrigin == null) {
-            return;
-        }
-        INSTANCE.addTickets(world, footprintChunkBounds(plotOrigin));
-    }
-
-    /**
-     * True when every footprint column is already present in the chunk cache (no force-load).
-     */
-    public static boolean areFootprintChunksLoaded(ServerLevel world, BlockPos plotOrigin) {
-        if (world == null || plotOrigin == null) {
-            return false;
-        }
-        int[] bounds = footprintChunkBounds(plotOrigin);
-        var chunkManager = world.getChunkSource();
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                if (!chunkManager.hasChunk(cx, cz)) {
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
     /** True once the stamped room's known light source has propagated into vanilla light data. */
     public static boolean isFootprintLightReady(ServerLevel world, BlockPos plotOrigin) {
         if (world == null || plotOrigin == null) {
@@ -268,7 +157,7 @@ public final class BotiInteriorSampler extends PortalSampler {
         if (world == null || plotOrigin == null) {
             return;
         }
-        int[] bounds = footprintChunkBounds(plotOrigin);
+        int[] bounds = FirstDoctorConsoleRoomPlacer.roomChunkBounds(plotOrigin);
         var lightEngine = world.getLightEngine();
         for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
@@ -279,38 +168,6 @@ public final class BotiInteriorSampler extends PortalSampler {
         }
         BlockPos sourcePos = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
         lightEngine.checkBlock(sourcePos);
-    }
-
-    /**
-     * Synchronously force-loads footprint chunks (blocking). Prefer {@link #addFootprintTickets}
-     * + {@link #areFootprintChunksLoaded} for approach-time preload.
-     */
-    public static void forceLoadFootprintChunks(ServerLevel world, BlockPos plotOrigin) {
-        if (world == null || plotOrigin == null) {
-            return;
-        }
-        addFootprintTickets(world, plotOrigin);
-        int[] bounds = footprintChunkBounds(plotOrigin);
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                world.getChunk(cx, cz);
-            }
-        }
-    }
-
-    /**
-     * Ensures footprint chunks are loaded (and briefly ticketed) so entity queries work even when
-     * no player is in {@code dwm:tardis}.
-     */
-    public static void ensureFootprintChunksLoaded(ServerLevel world, BlockPos plotOrigin) {
-        forceLoadFootprintChunks(world, plotOrigin);
-    }
-
-    /** True if any non-removed entity intersects the plot footprint. */
-    public static boolean hasEntities(ServerLevel interiorWorld, UUID tardisId) {
-        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        ensureFootprintChunksLoaded(interiorWorld, origin);
-        return INSTANCE.hasLoadedEntities(interiorWorld, origin);
     }
 
     /**
@@ -326,52 +183,12 @@ public final class BotiInteriorSampler extends PortalSampler {
     }
 
     /**
-     * Samples entities intersecting the footprint into relative structure coordinates.
-     * Uses {@link Entity#saveAsPassenger}; players are special-cased ({@code EntityTypes.PLAYER} is not saveable).
-     */
-    public static List<BotiEntitySample> sampleEntities(ServerLevel interiorWorld, UUID tardisId) {
-        BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        ensureFootprintChunksLoaded(interiorWorld, origin);
-        List<Entity> found = interiorWorld.getEntities((Entity) null, footprintBox(origin), entity -> !entity.isRemoved());
-        if (found.isEmpty()) {
-            return List.of();
-        }
-        List<BotiEntitySample> samples = new ArrayList<>(found.size());
-        for (Entity entity : found) {
-            BotiEntitySample sample = captureEntity(entity, origin);
-            if (sample != null) {
-                samples.add(sample);
-            }
-        }
-        return List.copyOf(samples);
-    }
-
-    /**
-     * Captures one entity for BOTI sync. Returns null when the entity cannot be serialized.
-     */
-    public static BotiEntitySample captureEntity(Entity entity, BlockPos plotOrigin) {
-        if (entity == null || entity.isRemoved() || plotOrigin == null) {
-            return null;
-        }
-        if (entity instanceof ConsoleControlInteractionEntity) {
-            return null;
-        }
-        CompoundTag nbt = captureEntityNbt(entity);
-        if (nbt == null) {
-            return null;
-        }
-        float relX = (float) (entity.getX() - plotOrigin.getX());
-        float relY = (float) (entity.getY() - plotOrigin.getY());
-        float relZ = (float) (entity.getZ() - plotOrigin.getZ());
-        writeRelativePos(nbt, relX, relY, relZ);
-        writeRelativeAttachment(nbt, plotOrigin);
-        return new BotiEntitySample(relX, relY, relZ, entity.getYRot(), entity.getXRot(), nbt);
-    }
-
-    /**
      * Entity NBT with type {@code id}. Players get profile tags for client {@code OtherClientPlayerEntity}.
      */
     public static CompoundTag captureEntityNbt(Entity entity) {
+        if (entity == null || entity.isRemoved() || entity instanceof ConsoleControlInteractionEntity) {
+            return null;
+        }
         if (entity instanceof Player player) {
             TagValueOutput output = TagValueOutput.createWithContext(
                     ProblemReporter.DISCARDING, entity.registryAccess());
@@ -411,20 +228,18 @@ public final class BotiInteriorSampler extends PortalSampler {
         nbt.putInt("TileZ", nbt.getIntOr("TileZ", 0) - plotOrigin.getZ());
     }
 
-    public static boolean isInsideFootprint(BlockPos worldPos, BlockPos plotOrigin) {
-        return INSTANCE.inFootprint(worldPos, plotOrigin);
-    }
-
     /** Samples interior sky/fog atmosphere at the plot origin. */
     public static PortalAtmosphere sampleAtmosphere(ServerLevel interiorWorld, BlockPos plotOrigin) {
         return PortalSampler.sampleAtmosphere(interiorWorld, plotOrigin);
     }
 
     /**
-     * Collects visible block states (+ BE NBT) for one chunk column clipped to the footprint.
+     * Collects visible block states (+ BE NBT) for one chunk column clipped to the plot.
      * Positions in the returned maps are world-absolute.
+     *
+     * @return the sample, or {@code null} when the column is not yet {@code FULL}
      */
-    public static PortalStreamSample sampleStreamChunk(
+    public static @Nullable PortalStreamSample sampleStreamChunk(
             ServerLevel interiorWorld,
             UUID tardisId,
             int chunkX,
@@ -450,7 +265,7 @@ public final class BotiInteriorSampler extends PortalSampler {
 
     @Override
     protected AABB entityBox(ServerLevel world, BlockPos anchor) {
-        int radius = PortalSampler.streamRadiusChunks(world);
+        int radius = PortalSampler.simulationRadiusChunks(world);
         int yRadius = PortalSampler.streamYRadiusBlocks(radius);
         AABB stream = PortalSampler.streamBox(anchor, radius, yRadius);
         AABB plot = new AABB(
@@ -473,14 +288,6 @@ public final class BotiInteriorSampler extends PortalSampler {
     }
 
     @Override
-    protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
-        int yRadius = PortalSampler.streamYRadiusBlocks(PortalSampler.streamRadiusChunks(world));
-        int minY = Math.max(world.getMinY(), anchor.getY() - yRadius);
-        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + yRadius);
-        return yRange(minY, maxY);
-    }
-
-    @Override
     protected PortalLightData sampleLight(
             ServerLevel world,
             BlockPos anchor,
@@ -498,7 +305,7 @@ public final class BotiInteriorSampler extends PortalSampler {
         int minZ = Math.max(baseZ, anchor.getZ());
         int maxZ = Math.min(baseZ + 15, anchor.getZ() + TardisPlotAllocator.PLOT_SPACING - 1);
         return PortalLightData.sample(
-                world,
+                world.getLightEngine(),
                 new BlockPos(minX, yRange.min(), minZ),
                 new BlockPos(maxX, yRange.max(), maxZ)
         );

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -298,6 +298,13 @@ public final class BotiInteriorSampler extends PortalSampler {
             int lowestVisibleY,
             int highestVisibleY
     ) {
+        if (blocks.isEmpty()) {
+            return PortalLightData.EMPTY;
+        }
+        YRange lightY = lightYRange(yRange, lowestVisibleY, highestVisibleY);
+        if (lightY.min() > lightY.max()) {
+            return PortalLightData.EMPTY;
+        }
         int baseX = chunkX << 4;
         int baseZ = chunkZ << 4;
         int minX = Math.max(baseX, anchor.getX());
@@ -306,8 +313,8 @@ public final class BotiInteriorSampler extends PortalSampler {
         int maxZ = Math.min(baseZ + 15, anchor.getZ() + TardisPlotAllocator.PLOT_SPACING - 1);
         return PortalLightData.sample(
                 world.getLightEngine(),
-                new BlockPos(minX, yRange.min(), minZ),
-                new BlockPos(maxX, yRange.max(), maxZ)
+                new BlockPos(minX, lightY.min(), minZ),
+                new BlockPos(maxX, lightY.max(), maxZ)
         );
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -208,6 +208,26 @@ public final class BotiInteriorSampler {
     }
 
     /**
+     * True once vanilla lighting has enabled every footprint column. Newly generated empty flat
+     * chunks can be FULL before their asynchronous light-engine initialization has completed.
+     */
+    public static boolean isFootprintLightReady(ServerLevel world, BlockPos plotOrigin) {
+        if (world == null || plotOrigin == null) {
+            return false;
+        }
+        int[] bounds = footprintChunkBounds(plotOrigin);
+        var lightEngine = world.getLightEngine();
+        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
+            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
+                if (!lightEngine.lightOnInColumn(ChunkPos.pack(cx, cz))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
      * Synchronously force-loads footprint chunks (blocking). Prefer {@link #addFootprintTickets}
      * + {@link #areFootprintChunksLoaded} for approach-time preload.
      */

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -431,6 +431,21 @@ public final class BotiInteriorSampler {
                 new BlockPos(minX, minY, minZ),
                 new BlockPos(maxX, maxY, maxZ)
         );
+        // #region agent log
+        try {
+            int maxBlock = 0, maxSky = 0;
+            for (byte value : lightData.packedCopy()) {
+                int packed = Byte.toUnsignedInt(value);
+                maxBlock = Math.max(maxBlock, packed & 0xF);
+                maxSky = Math.max(maxSky, packed >>> 4);
+            }
+            BlockPos expectedLight = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                    "{\"hypothesisId\":\"A\",\"location\":\"BotiInteriorSampler.sampleStreamChunk\",\"message\":\"server sampled BOTI light\",\"data\":{\"chunkX\":" + chunkX + ",\"chunkZ\":" + chunkZ + ",\"blocks\":" + blocks.size() + ",\"minX\":" + lightData.min().getX() + ",\"minY\":" + lightData.min().getY() + ",\"minZ\":" + lightData.min().getZ() + ",\"sizeX\":" + lightData.sizeX() + ",\"sizeY\":" + lightData.sizeY() + ",\"sizeZ\":" + lightData.sizeZ() + ",\"maxBlock\":" + maxBlock + ",\"maxSky\":" + maxSky + ",\"expectedLightWorldBlock\":" + interiorWorld.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight) + ",\"expectedLightSampleBlock\":" + lightData.brightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight, -1) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (java.io.IOException ignored) {
+        }
+        // #endregion
         return new PortalStreamSample(
                 chunkX, chunkZ, Map.copyOf(blocks), Map.copyOf(blockEntities), lightData
         );

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiInteriorSampler.java
@@ -232,25 +232,15 @@ public final class BotiInteriorSampler {
         }
         int[] bounds = footprintChunkBounds(plotOrigin);
         var lightEngine = world.getLightEngine();
-        int scheduledColumns = 0;
         for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
                 ChunkPos chunkPos = new ChunkPos(cx, cz);
                 lightEngine.setLightEnabled(chunkPos, true);
                 lightEngine.propagateLightSources(chunkPos);
-                scheduledColumns++;
             }
         }
         BlockPos sourcePos = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
         lightEngine.checkBlock(sourcePos);
-        // #region agent log
-        try {
-            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"G,H\",\"location\":\"BotiInteriorSampler.enableFootprintLighting\",\"message\":\"queued footprint lighting\",\"data\":{\"columns\":" + scheduledColumns + ",\"sourceEmission\":" + world.getBlockState(sourcePos).getLightEmission() + ",\"lightOnInSourceColumn\":" + lightEngine.lightOnInColumn(ChunkPos.pack(sourcePos.getX() >> 4, sourcePos.getZ() >> 4)) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (java.io.IOException ignored) {
-        }
-        // #endregion
     }
 
     /**
@@ -477,36 +467,6 @@ public final class BotiInteriorSampler {
                 new BlockPos(minX, minY, minZ),
                 new BlockPos(maxX, maxY, maxZ)
         );
-        // #region agent log
-        try {
-            int maxBlock = 0, maxSky = 0;
-            for (byte value : lightData.packedCopy()) {
-                int packed = Byte.toUnsignedInt(value);
-                maxBlock = Math.max(maxBlock, packed & 0xF);
-                maxSky = Math.max(maxSky, packed >>> 4);
-            }
-            BlockPos expectedLight = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
-            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"A\",\"location\":\"BotiInteriorSampler.sampleStreamChunk\",\"message\":\"server sampled BOTI light\",\"data\":{\"chunkX\":" + chunkX + ",\"chunkZ\":" + chunkZ + ",\"blocks\":" + blocks.size() + ",\"minX\":" + lightData.min().getX() + ",\"minY\":" + lightData.min().getY() + ",\"minZ\":" + lightData.min().getZ() + ",\"sizeX\":" + lightData.sizeX() + ",\"sizeY\":" + lightData.sizeY() + ",\"sizeZ\":" + lightData.sizeZ() + ",\"maxBlock\":" + maxBlock + ",\"maxSky\":" + maxSky + ",\"expectedLightWorldBlock\":" + interiorWorld.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight) + ",\"expectedLightSampleBlock\":" + lightData.brightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight, -1) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (java.io.IOException ignored) {
-        }
-        // #endregion
-        BlockPos expectedLight = plotOrigin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
-        if ((expectedLight.getX() >> 4) == chunkX && (expectedLight.getZ() >> 4) == chunkZ) {
-            var lightEngine = interiorWorld.getLightEngine();
-            var sourceChunk = interiorWorld.getChunkAt(expectedLight);
-            BlockState sourceState = interiorWorld.getBlockState(expectedLight);
-            net.minecraft.core.SectionPos sourceSection = net.minecraft.core.SectionPos.of(expectedLight);
-            // #region agent log
-            try {
-                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                        "{\"hypothesisId\":\"G,H,I,J\",\"location\":\"BotiInteriorSampler.sampleStreamChunk:source\",\"message\":\"light source state when BOTI samples\",\"data\":{\"block\":\"" + net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(sourceState.getBlock()) + "\",\"isLight\":" + sourceState.is(Blocks.LIGHT) + ",\"emission\":" + sourceState.getLightEmission() + ",\"brightness\":" + interiorWorld.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight) + ",\"rawBrightness\":" + lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getLightValue(expectedLight) + ",\"neighborBrightness\":" + interiorWorld.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, expectedLight.below()) + ",\"hasLightWork\":" + lightEngine.hasLightWork() + ",\"lightOnInColumn\":" + lightEngine.lightOnInColumn(sourceChunk.getPos().pack()) + ",\"chunkLightCorrect\":" + sourceChunk.isLightCorrect() + ",\"chunkStatus\":\"" + sourceChunk.getPersistedStatus() + "\",\"sectionType\":\"" + lightEngine.getDebugSectionType(net.minecraft.world.level.LightLayer.BLOCK, sourceSection) + "\",\"sectionDataPresent\":" + (lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getDataLayerData(sourceSection) != null) + ",\"engine\":\"" + lightEngine.getClass().getName() + "\",\"hasSkyLight\":" + interiorWorld.dimensionType().hasSkyLight() + ",\"ambientLight\":" + interiorWorld.dimensionType().ambientLight() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-            } catch (java.io.IOException ignored) {
-            }
-            // #endregion
-        }
         return new PortalStreamSample(
                 chunkX, chunkZ, Map.copyOf(blocks), Map.copyOf(blockEntities), lightData
         );

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiPlotIndex.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/boti/BotiPlotIndex.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.tardis.boti;
 
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -49,9 +50,13 @@ public final class BotiPlotIndex {
 
     /**
      * Resolves the owning TARDIS for a world position in {@code dwm:tardis}, or null if outside a
-     * registered footprint.
+     * registered plot stream.
      */
     public static @Nullable UUID resolve(BlockPos worldPos) {
+        return resolve(worldPos, PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+    }
+
+    public static @Nullable UUID resolve(BlockPos worldPos, int radiusChunks) {
         int gridX = Math.floorDiv(worldPos.getX(), TardisPlotAllocator.PLOT_SPACING);
         int gridZ = Math.floorDiv(worldPos.getZ(), TardisPlotAllocator.PLOT_SPACING);
         BlockPos origin = new BlockPos(
@@ -63,7 +68,7 @@ public final class BotiPlotIndex {
         if (owner == null) {
             return null;
         }
-        if (!BotiInteriorSampler.isInsideFootprint(worldPos, origin)) {
+        if (!BotiInteriorSampler.isInsidePlotStream(worldPos, origin, radiusChunks)) {
             return null;
         }
         return owner;

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -13,8 +13,11 @@ import java.util.Optional;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.TicketType;
 import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
@@ -39,7 +42,75 @@ public final class FirstDoctorConsoleRoomPlacer {
     /** Local entrance standing position relative to structure origin (feet). */
     public static final BlockPos LOCAL_ENTRANCE = FirstDoctorConsoleRoomLayout.LOCAL_ENTRANCE;
 
+    /** Distinct from portal stream tickets so preload radius-0 columns do not merge with view-distance tickets. */
+    private static final TicketType ROOM_LOAD_TICKET = new TicketType(40L, TicketType.FLAG_LOADING);
+
     private FirstDoctorConsoleRoomPlacer() {
+    }
+
+    /**
+     * Inclusive chunk-grid bounds covering the console-room AABB.
+     * {@code [minChunkX, maxChunkX, minChunkZ, maxChunkZ]}.
+     */
+    public static int[] roomChunkBounds(BlockPos origin) {
+        return new int[]{
+                SectionPos.blockToSectionCoord(origin.getX()),
+                SectionPos.blockToSectionCoord(origin.getX() + SIZE_X - 1),
+                SectionPos.blockToSectionCoord(origin.getZ()),
+                SectionPos.blockToSectionCoord(origin.getZ() + SIZE_Z - 1)
+        };
+    }
+
+    /**
+     * Ticket-only keep-alive for the console-room footprint. Does not call {@code getChunk}.
+     */
+    public static void addRoomTickets(ServerLevel world, BlockPos origin) {
+        if (world == null || origin == null) {
+            return;
+        }
+        int[] bounds = roomChunkBounds(origin);
+        var chunkManager = world.getChunkSource();
+        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
+            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
+                chunkManager.addTicketWithRadius(ROOM_LOAD_TICKET, new ChunkPos(cx, cz), 0);
+            }
+        }
+    }
+
+    /**
+     * True when every room column is already present in the chunk cache (no force-load).
+     */
+    public static boolean areRoomChunksLoaded(ServerLevel world, BlockPos origin) {
+        if (world == null || origin == null) {
+            return false;
+        }
+        int[] bounds = roomChunkBounds(origin);
+        var chunkManager = world.getChunkSource();
+        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
+            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
+                if (!chunkManager.hasChunk(cx, cz)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Synchronously force-loads room chunks (blocking). Prefer {@link #addRoomTickets}
+     * + {@link #areRoomChunksLoaded} for approach-time preload.
+     */
+    public static void forceLoadRoomChunks(ServerLevel world, BlockPos origin) {
+        if (world == null || origin == null) {
+            return;
+        }
+        addRoomTickets(world, origin);
+        int[] bounds = roomChunkBounds(origin);
+        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
+            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
+                world.getChunk(cx, cz);
+            }
+        }
     }
 
     /**
@@ -47,7 +118,7 @@ public final class FirstDoctorConsoleRoomPlacer {
      * Prefer {@link #placeAssumingChunksLoaded} when chunks were ticketed asynchronously first.
      */
     public static BlockPos place(ServerLevel world, BlockPos origin, UUID tardisId) {
-        BotiInteriorSampler.forceLoadFootprintChunks(world, origin);
+        forceLoadRoomChunks(world, origin);
         return placeAssumingChunksLoaded(world, origin, tardisId);
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -90,29 +90,11 @@ public final class FirstDoctorConsoleRoomPlacer {
     }
 
     static void placeInteriorLight(ServerLevel world, BlockPos origin) {
-        BlockPos lightPos = origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
-        BlockState requested = Blocks.LIGHT.defaultBlockState();
-        BlockState before = world.getBlockState(lightPos);
-        var lightEngine = world.getLightEngine();
-        var chunk = world.getChunkAt(lightPos);
-        // #region agent log
-        try {
-            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"G,H,I,J\",\"location\":\"FirstDoctorConsoleRoomPlacer.placeInteriorLight:before\",\"message\":\"light source before stamp\",\"data\":{\"block\":\"" + net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(before.getBlock()) + "\",\"isLight\":" + before.is(Blocks.LIGHT) + ",\"emission\":" + before.getLightEmission() + ",\"brightness\":" + world.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, lightPos) + ",\"rawBrightness\":" + lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getLightValue(lightPos) + ",\"hasLightWork\":" + lightEngine.hasLightWork() + ",\"lightOnInColumn\":" + lightEngine.lightOnInColumn(chunk.getPos().pack()) + ",\"chunkLightCorrect\":" + chunk.isLightCorrect() + ",\"chunkStatus\":\"" + chunk.getPersistedStatus() + "\",\"engine\":\"" + lightEngine.getClass().getName() + "\",\"hasSkyLight\":" + world.dimensionType().hasSkyLight() + ",\"ambientLight\":" + world.dimensionType().ambientLight() + ",\"requestedEmission\":" + requested.getLightEmission() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (java.io.IOException ignored) {
-        }
-        // #endregion
-        boolean changed = world.setBlock(lightPos, requested, Block.UPDATE_CLIENTS);
-        BlockState after = world.getBlockState(lightPos);
-        // #region agent log
-        try {
-            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                    "{\"hypothesisId\":\"G,H,I\",\"location\":\"FirstDoctorConsoleRoomPlacer.placeInteriorLight:after\",\"message\":\"light source after stamp\",\"data\":{\"setBlockChanged\":" + changed + ",\"block\":\"" + net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(after.getBlock()) + "\",\"isLight\":" + after.is(Blocks.LIGHT) + ",\"emission\":" + after.getLightEmission() + ",\"brightness\":" + world.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, lightPos) + ",\"rawBrightness\":" + lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getLightValue(lightPos) + ",\"hasLightWork\":" + lightEngine.hasLightWork() + ",\"lightOnInColumn\":" + lightEngine.lightOnInColumn(chunk.getPos().pack()) + ",\"chunkLightCorrect\":" + chunk.isLightCorrect() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-        } catch (java.io.IOException ignored) {
-        }
-        // #endregion
+        world.setBlock(
+                origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3)),
+                Blocks.LIGHT.defaultBlockState(),
+                Block.UPDATE_CLIENTS
+        );
     }
 
     /**

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -89,11 +89,29 @@ public final class FirstDoctorConsoleRoomPlacer {
     }
 
     static void placeInteriorLight(ServerLevel world, BlockPos origin) {
-        world.setBlock(
-                origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3)),
-                Blocks.LIGHT.defaultBlockState(),
-                Block.UPDATE_CLIENTS
-        );
+        BlockPos lightPos = origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+        BlockState requested = Blocks.LIGHT.defaultBlockState();
+        BlockState before = world.getBlockState(lightPos);
+        var lightEngine = world.getLightEngine();
+        var chunk = world.getChunkAt(lightPos);
+        // #region agent log
+        try {
+            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                    "{\"hypothesisId\":\"G,H,I,J\",\"location\":\"FirstDoctorConsoleRoomPlacer.placeInteriorLight:before\",\"message\":\"light source before stamp\",\"data\":{\"block\":\"" + net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(before.getBlock()) + "\",\"isLight\":" + before.is(Blocks.LIGHT) + ",\"emission\":" + before.getLightEmission() + ",\"brightness\":" + world.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, lightPos) + ",\"rawBrightness\":" + lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getLightValue(lightPos) + ",\"hasLightWork\":" + lightEngine.hasLightWork() + ",\"lightOnInColumn\":" + lightEngine.lightOnInColumn(chunk.getPos().pack()) + ",\"chunkLightCorrect\":" + chunk.isLightCorrect() + ",\"chunkStatus\":\"" + chunk.getPersistedStatus() + "\",\"engine\":\"" + lightEngine.getClass().getName() + "\",\"hasSkyLight\":" + world.dimensionType().hasSkyLight() + ",\"ambientLight\":" + world.dimensionType().ambientLight() + ",\"requestedEmission\":" + requested.getLightEmission() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (java.io.IOException ignored) {
+        }
+        // #endregion
+        boolean changed = world.setBlock(lightPos, requested, Block.UPDATE_CLIENTS);
+        BlockState after = world.getBlockState(lightPos);
+        // #region agent log
+        try {
+            java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                    "{\"hypothesisId\":\"G,H,I\",\"location\":\"FirstDoctorConsoleRoomPlacer.placeInteriorLight:after\",\"message\":\"light source after stamp\",\"data\":{\"setBlockChanged\":" + changed + ",\"block\":\"" + net.minecraft.core.registries.BuiltInRegistries.BLOCK.getKey(after.getBlock()) + "\",\"isLight\":" + after.is(Blocks.LIGHT) + ",\"emission\":" + after.getLightEmission() + ",\"brightness\":" + world.getBrightness(net.minecraft.world.level.LightLayer.BLOCK, lightPos) + ",\"rawBrightness\":" + lightEngine.getLayerListener(net.minecraft.world.level.LightLayer.BLOCK).getLightValue(lightPos) + ",\"hasLightWork\":" + lightEngine.hasLightWork() + ",\"lightOnInColumn\":" + lightEngine.lightOnInColumn(chunk.getPos().pack()) + ",\"chunkLightCorrect\":" + chunk.isLightCorrect() + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                    java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+        } catch (java.io.IOException ignored) {
+        }
+        // #endregion
     }
 
     /**

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -68,6 +68,7 @@ public final class FirstDoctorConsoleRoomPlacer {
         placeInteriorLight(world, origin);
         stampInteriorEntities(world, origin, tardisId);
         applyDoorOpenFromModel(world, origin, tardisId);
+        BotiInteriorSampler.enableFootprintLighting(world, origin);
         FirstDoctorConsoleSync.syncFromModel(world.getServer(), tardisId);
 
         return origin.offset(LOCAL_ENTRANCE);

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/FirstDoctorConsoleRoomPlacer.java
@@ -16,6 +16,7 @@ import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import net.minecraft.world.level.block.state.BlockState;
@@ -64,6 +65,7 @@ public final class FirstDoctorConsoleRoomPlacer {
         }
 
         completeInteriorDoorBank(world, origin);
+        placeInteriorLight(world, origin);
         stampInteriorEntities(world, origin, tardisId);
         applyDoorOpenFromModel(world, origin, tardisId);
         FirstDoctorConsoleSync.syncFromModel(world.getServer(), tardisId);
@@ -84,6 +86,14 @@ public final class FirstDoctorConsoleRoomPlacer {
                 .setIgnoreEntities(true);
         structure.get().placeInWorld(world, origin, origin, data, RandomSource.create(), Block.UPDATE_CLIENTS);
         return true;
+    }
+
+    static void placeInteriorLight(ServerLevel world, BlockPos origin) {
+        world.setBlock(
+                origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3)),
+                Blocks.LIGHT.defaultBlockState(),
+                Block.UPDATE_CLIENTS
+        );
     }
 
     /**

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/TardisInteriorPreloadService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/TardisInteriorPreloadService.java
@@ -2,7 +2,6 @@ package com.adamkali.dwm.tardis.interior;
 
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.config.DWMConfig;
-import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.boti.BotiPlotIndex;
 import java.util.ArrayList;
 import java.util.List;
@@ -127,8 +126,8 @@ public final class TardisInteriorPreloadService {
             }
             BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
             if (job.phase() == Phase.LOADING) {
-                BotiInteriorSampler.addFootprintTickets(interiorWorld, origin);
-                if (!BotiInteriorSampler.areFootprintChunksLoaded(interiorWorld, origin)) {
+                FirstDoctorConsoleRoomPlacer.addRoomTickets(interiorWorld, origin);
+                if (!FirstDoctorConsoleRoomPlacer.areRoomChunksLoaded(interiorWorld, origin)) {
                     continue;
                 }
                 job = job.withPhase(Phase.READY_TO_PLACE);

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/interior/TardisInteriorService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/interior/TardisInteriorService.java
@@ -5,7 +5,6 @@ import com.adamkali.dwm.block.TardisBlock;
 import com.adamkali.dwm.block.entities.TardisBlockEntity;
 import com.adamkali.dwm.block.entities.TardisInteriorDoorBlockEntity;
 import com.adamkali.dwm.tardis.TardisExteriorFacing;
-import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.boti.BotiPlotIndex;
 import com.adamkali.dwm.tardis.data.TardisDataLoader;
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
@@ -198,7 +197,7 @@ public final class TardisInteriorService {
         int sizeX = FirstDoctorConsoleRoomPlacer.SIZE_X;
         int sizeY = FirstDoctorConsoleRoomPlacer.SIZE_Y;
         int sizeZ = FirstDoctorConsoleRoomPlacer.SIZE_Z;
-        BotiInteriorSampler.forceLoadFootprintChunks(world, origin);
+        FirstDoctorConsoleRoomPlacer.forceLoadRoomChunks(world, origin);
 
         AABB roomBox = new AABB(
                 origin.getX(),

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelAudio.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/TardisTravelAudio.java
@@ -1,7 +1,6 @@
 package com.adamkali.dwm.tardis.logic;
 
 import com.adamkali.dwm.network.TravelAudioS2CPayload;
-import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisDimensions;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
@@ -60,7 +59,7 @@ public final class TardisTravelAudio {
         }
         BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
         for (ServerPlayer player : interior.players()) {
-            if (BotiInteriorSampler.isInsideFootprint(player.blockPosition(), origin)
+            if (isInsideConsoleRoom(player.blockPosition(), origin)
                     || player.blockPosition().closerThan(console, EXTERIOR_RANGE)) {
                 ServerPlayNetworking.send(player, interiorCue);
             }
@@ -89,7 +88,7 @@ public final class TardisTravelAudio {
         if (interior != null) {
             BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
             for (ServerPlayer player : interior.players()) {
-                if (BotiInteriorSampler.isInsideFootprint(player.blockPosition(), origin)
+                if (isInsideConsoleRoom(player.blockPosition(), origin)
                         || player.blockPosition().closerThan(consolePos(tardisId), EXTERIOR_RANGE)) {
                     ServerPlayNetworking.send(player, interiorStop);
                 }
@@ -123,7 +122,7 @@ public final class TardisTravelAudio {
         }
         BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
         for (ServerPlayer player : interior.players()) {
-            if (BotiInteriorSampler.isInsideFootprint(player.blockPosition(), origin)
+            if (isInsideConsoleRoom(player.blockPosition(), origin)
                     || player.blockPosition().closerThan(console, EXTERIOR_RANGE)) {
                 ServerPlayNetworking.send(player, interiorCue);
             }
@@ -132,5 +131,14 @@ public final class TardisTravelAudio {
 
     static BlockPos consolePos(UUID tardisId) {
         return TardisPlotAllocator.plotOrigin(tardisId).offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE);
+    }
+
+    static boolean isInsideConsoleRoom(BlockPos worldPos, BlockPos origin) {
+        int localX = worldPos.getX() - origin.getX();
+        int localY = worldPos.getY() - origin.getY();
+        int localZ = worldPos.getZ() - origin.getZ();
+        return localX >= 0 && localX < FirstDoctorConsoleRoomLayout.SIZE_X
+                && localY >= 0 && localY < FirstDoctorConsoleRoomLayout.SIZE_Y
+                && localZ >= 0 && localZ < FirstDoctorConsoleRoomLayout.SIZE_Z;
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalLightData.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalLightData.java
@@ -1,0 +1,131 @@
+package com.adamkali.dwm.tardis.portal;
+
+import java.util.Arrays;
+import java.util.Objects;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.LevelReader;
+
+/**
+ * Dense, bounded portal light volume. One byte stores block light in the low nibble and sky light
+ * in the high nibble. Coordinates use the same space as {@link #min()}.
+ */
+public final class PortalLightData {
+    public static final PortalLightData EMPTY = new PortalLightData(BlockPos.ZERO, 0, 0, 0, new byte[0]);
+
+    private final BlockPos min;
+    private final int sizeX;
+    private final int sizeY;
+    private final int sizeZ;
+    private final byte[] packed;
+
+    public PortalLightData(BlockPos min, int sizeX, int sizeY, int sizeZ, byte[] packed) {
+        this.min = Objects.requireNonNull(min, "min").immutable();
+        if (sizeX < 0 || sizeY < 0 || sizeZ < 0) {
+            throw new IllegalArgumentException("Portal light dimensions must be non-negative");
+        }
+        long expected = (long) sizeX * sizeY * sizeZ;
+        if (expected > Integer.MAX_VALUE || packed == null || packed.length != (int) expected) {
+            throw new IllegalArgumentException("Portal light data length does not match dimensions");
+        }
+        this.sizeX = sizeX;
+        this.sizeY = sizeY;
+        this.sizeZ = sizeZ;
+        this.packed = packed.clone();
+    }
+
+    public static PortalLightData sample(LevelReader level, BlockPos min, BlockPos max) {
+        Objects.requireNonNull(level, "level");
+        Objects.requireNonNull(min, "min");
+        Objects.requireNonNull(max, "max");
+        if (max.getX() < min.getX() || max.getY() < min.getY() || max.getZ() < min.getZ()) {
+            return EMPTY;
+        }
+        int sizeX = max.getX() - min.getX() + 1;
+        int sizeY = max.getY() - min.getY() + 1;
+        int sizeZ = max.getZ() - min.getZ() + 1;
+        byte[] values = new byte[Math.multiplyExact(Math.multiplyExact(sizeX, sizeY), sizeZ)];
+        BlockPos.MutableBlockPos cursor = new BlockPos.MutableBlockPos();
+        int index = 0;
+        for (int y = 0; y < sizeY; y++) {
+            for (int z = 0; z < sizeZ; z++) {
+                for (int x = 0; x < sizeX; x++) {
+                    cursor.set(min.getX() + x, min.getY() + y, min.getZ() + z);
+                    int block = level.getBrightness(LightLayer.BLOCK, cursor);
+                    int sky = level.getBrightness(LightLayer.SKY, cursor);
+                    values[index++] = pack(block, sky);
+                }
+            }
+        }
+        return new PortalLightData(min, sizeX, sizeY, sizeZ, values);
+    }
+
+    public static byte pack(int block, int sky) {
+        if (block < 0 || block > 15 || sky < 0 || sky > 15) {
+            throw new IllegalArgumentException("Portal light levels must be between 0 and 15");
+        }
+        return (byte) ((sky << 4) | block);
+    }
+
+    public int brightness(LightLayer layer, BlockPos pos, int fallback) {
+        int packedValue = packed(pos);
+        if (packedValue < 0) {
+            return fallback;
+        }
+        return layer == LightLayer.SKY ? packedValue >>> 4 : packedValue & 0xF;
+    }
+
+    public int packed(BlockPos pos) {
+        int x = pos.getX() - min.getX();
+        int y = pos.getY() - min.getY();
+        int z = pos.getZ() - min.getZ();
+        if (x < 0 || x >= sizeX || y < 0 || y >= sizeY || z < 0 || z >= sizeZ) {
+            return -1;
+        }
+        return packed[(y * sizeZ + z) * sizeX + x] & 0xFF;
+    }
+
+    public PortalLightData translated(BlockPos offset) {
+        return isEmpty() ? EMPTY : new PortalLightData(min.offset(offset), sizeX, sizeY, sizeZ, packed);
+    }
+
+    public boolean isEmpty() {
+        return packed.length == 0;
+    }
+
+    public BlockPos min() {
+        return min;
+    }
+
+    public int sizeX() {
+        return sizeX;
+    }
+
+    public int sizeY() {
+        return sizeY;
+    }
+
+    public int sizeZ() {
+        return sizeZ;
+    }
+
+    public byte[] packedCopy() {
+        return packed.clone();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof PortalLightData that
+                && sizeX == that.sizeX
+                && sizeY == that.sizeY
+                && sizeZ == that.sizeZ
+                && min.equals(that.min)
+                && Arrays.equals(packed, that.packed);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Objects.hash(min, sizeX, sizeY, sizeZ);
+        return 31 * result + Arrays.hashCode(packed);
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalLightData.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalLightData.java
@@ -3,8 +3,12 @@ package com.adamkali.dwm.tardis.portal;
 import java.util.Arrays;
 import java.util.Objects;
 import net.minecraft.core.BlockPos;
+import net.minecraft.core.SectionPos;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.chunk.DataLayer;
+import net.minecraft.world.level.lighting.LayerLightEventListener;
+import net.minecraft.world.level.lighting.LevelLightEngine;
 
 /**
  * Dense, bounded portal light volume. One byte stores block light in the low nibble and sky light
@@ -34,6 +38,76 @@ public final class PortalLightData {
         this.packed = packed.clone();
     }
 
+    public static PortalLightData sample(LevelLightEngine lightEngine, BlockPos min, BlockPos max) {
+        Objects.requireNonNull(lightEngine, "lightEngine");
+        return sample(
+                lightEngine.getLayerListener(LightLayer.BLOCK),
+                lightEngine.getLayerListener(LightLayer.SKY),
+                min,
+                max
+        );
+    }
+
+    /**
+     * Copies nibble light layers into the packed volume. Null section layers read as zero.
+     */
+    public static PortalLightData sample(
+            LayerLightEventListener blockLight,
+            LayerLightEventListener skyLight,
+            BlockPos min,
+            BlockPos max
+    ) {
+        Objects.requireNonNull(blockLight, "blockLight");
+        Objects.requireNonNull(skyLight, "skyLight");
+        Objects.requireNonNull(min, "min");
+        Objects.requireNonNull(max, "max");
+        if (max.getX() < min.getX() || max.getY() < min.getY() || max.getZ() < min.getZ()) {
+            return EMPTY;
+        }
+        int sizeX = max.getX() - min.getX() + 1;
+        int sizeY = max.getY() - min.getY() + 1;
+        int sizeZ = max.getZ() - min.getZ() + 1;
+        byte[] values = new byte[Math.multiplyExact(Math.multiplyExact(sizeX, sizeY), sizeZ)];
+        DataLayer cachedBlock = null;
+        DataLayer cachedSky = null;
+        long cachedSection = Long.MIN_VALUE;
+        int index = 0;
+        for (int y = 0; y < sizeY; y++) {
+            int wy = min.getY() + y;
+            for (int z = 0; z < sizeZ; z++) {
+                int wz = min.getZ() + z;
+                for (int x = 0; x < sizeX; x++) {
+                    int wx = min.getX() + x;
+                    long sectionKey = SectionPos.asLong(
+                            SectionPos.blockToSectionCoord(wx),
+                            SectionPos.blockToSectionCoord(wy),
+                            SectionPos.blockToSectionCoord(wz)
+                    );
+                    if (sectionKey != cachedSection) {
+                        SectionPos sectionPos = SectionPos.of(
+                                SectionPos.blockToSectionCoord(wx),
+                                SectionPos.blockToSectionCoord(wy),
+                                SectionPos.blockToSectionCoord(wz)
+                        );
+                        cachedBlock = blockLight.getDataLayerData(sectionPos);
+                        cachedSky = skyLight.getDataLayerData(sectionPos);
+                        cachedSection = sectionKey;
+                    }
+                    int lx = wx & 15;
+                    int ly = wy & 15;
+                    int lz = wz & 15;
+                    int block = cachedBlock == null ? 0 : cachedBlock.get(lx, ly, lz);
+                    int sky = cachedSky == null ? 0 : cachedSky.get(lx, ly, lz);
+                    values[index++] = pack(block, sky);
+                }
+            }
+        }
+        return new PortalLightData(min, sizeX, sizeY, sizeZ, values);
+    }
+
+    /**
+     * Fallback brightness walk used by unit tests that mock {@link LevelReader}.
+     */
     public static PortalLightData sample(LevelReader level, BlockPos min, BlockPos max) {
         Objects.requireNonNull(level, "level");
         Objects.requireNonNull(min, "min");

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalLightData.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalLightData.java
@@ -68,41 +68,55 @@ public final class PortalLightData {
         int sizeY = max.getY() - min.getY() + 1;
         int sizeZ = max.getZ() - min.getZ() + 1;
         byte[] values = new byte[Math.multiplyExact(Math.multiplyExact(sizeX, sizeY), sizeZ)];
-        DataLayer cachedBlock = null;
-        DataLayer cachedSky = null;
-        long cachedSection = Long.MIN_VALUE;
-        int index = 0;
-        for (int y = 0; y < sizeY; y++) {
-            int wy = min.getY() + y;
-            for (int z = 0; z < sizeZ; z++) {
-                int wz = min.getZ() + z;
-                for (int x = 0; x < sizeX; x++) {
-                    int wx = min.getX() + x;
-                    long sectionKey = SectionPos.asLong(
-                            SectionPos.blockToSectionCoord(wx),
-                            SectionPos.blockToSectionCoord(wy),
-                            SectionPos.blockToSectionCoord(wz)
-                    );
-                    if (sectionKey != cachedSection) {
-                        SectionPos sectionPos = SectionPos.of(
-                                SectionPos.blockToSectionCoord(wx),
-                                SectionPos.blockToSectionCoord(wy),
-                                SectionPos.blockToSectionCoord(wz)
-                        );
-                        cachedBlock = blockLight.getDataLayerData(sectionPos);
-                        cachedSky = skyLight.getDataLayerData(sectionPos);
-                        cachedSection = sectionKey;
+        int minX = min.getX();
+        int minY = min.getY();
+        int minZ = min.getZ();
+        int maxX = max.getX();
+        int maxY = max.getY();
+        int maxZ = max.getZ();
+        int minSectionX = SectionPos.blockToSectionCoord(minX);
+        int maxSectionX = SectionPos.blockToSectionCoord(maxX);
+        int minSectionY = SectionPos.blockToSectionCoord(minY);
+        int maxSectionY = SectionPos.blockToSectionCoord(maxY);
+        int minSectionZ = SectionPos.blockToSectionCoord(minZ);
+        int maxSectionZ = SectionPos.blockToSectionCoord(maxZ);
+        for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
+            int y0 = Math.max(minY, SectionPos.sectionToBlockCoord(sectionY));
+            int y1 = Math.min(maxY, SectionPos.sectionToBlockCoord(sectionY) + 15);
+            for (int sectionZ = minSectionZ; sectionZ <= maxSectionZ; sectionZ++) {
+                int z0 = Math.max(minZ, SectionPos.sectionToBlockCoord(sectionZ));
+                int z1 = Math.min(maxZ, SectionPos.sectionToBlockCoord(sectionZ) + 15);
+                for (int sectionX = minSectionX; sectionX <= maxSectionX; sectionX++) {
+                    int x0 = Math.max(minX, SectionPos.sectionToBlockCoord(sectionX));
+                    int x1 = Math.min(maxX, SectionPos.sectionToBlockCoord(sectionX) + 15);
+                    SectionPos sectionPos = SectionPos.of(sectionX, sectionY, sectionZ);
+                    DataLayer cachedBlock = blockLight.getDataLayerData(sectionPos);
+                    DataLayer cachedSky = skyLight.getDataLayerData(sectionPos);
+                    if (isZeroLayer(cachedBlock) && isZeroLayer(cachedSky)) {
+                        continue;
                     }
-                    int lx = wx & 15;
-                    int ly = wy & 15;
-                    int lz = wz & 15;
-                    int block = cachedBlock == null ? 0 : cachedBlock.get(lx, ly, lz);
-                    int sky = cachedSky == null ? 0 : cachedSky.get(lx, ly, lz);
-                    values[index++] = pack(block, sky);
+                    for (int y = y0; y <= y1; y++) {
+                        int ly = y & 15;
+                        int iy = y - minY;
+                        for (int z = z0; z <= z1; z++) {
+                            int lz = z & 15;
+                            int row = (iy * sizeZ + (z - minZ)) * sizeX;
+                            for (int x = x0; x <= x1; x++) {
+                                int lx = x & 15;
+                                int block = cachedBlock == null ? 0 : cachedBlock.get(lx, ly, lz);
+                                int sky = cachedSky == null ? 0 : cachedSky.get(lx, ly, lz);
+                                values[row + (x - minX)] = pack(block, sky);
+                            }
+                        }
+                    }
                 }
             }
         }
         return new PortalLightData(min, sizeX, sizeY, sizeZ, values);
+    }
+
+    private static boolean isZeroLayer(DataLayer layer) {
+        return layer == null || layer.isEmpty();
     }
 
     /**

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
@@ -5,10 +5,13 @@ import java.util.List;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.SectionPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.util.ProblemReporter;
 import net.minecraft.world.attribute.EnvironmentAttributes;
@@ -26,6 +29,11 @@ import net.minecraft.world.phys.AABB;
  * Subclasses supply visibility, load strategy, and light-volume bounds.
  */
 public abstract class PortalSampler {
+    /** Fallback when server/player view distance is unavailable (matches former Phase-1 cap). */
+    public static final int DEFAULT_STREAM_RADIUS_CHUNKS = 2;
+    /** Fog starts at this fraction of the streamed block radius. */
+    public static final float FOG_START_FRACTION = 0.6f;
+
     protected final int sizeX;
     protected final int sizeY;
     protected final int sizeZ;
@@ -36,6 +44,120 @@ public abstract class PortalSampler {
         this.sizeY = sizeY;
         this.sizeZ = sizeZ;
         this.ticket = ticket;
+    }
+
+    /**
+     * Server view distance in chunks, or {@link #DEFAULT_STREAM_RADIUS_CHUNKS} when unavailable.
+     */
+    public static int streamRadiusChunks(ServerLevel world) {
+        if (world == null) {
+            return DEFAULT_STREAM_RADIUS_CHUNKS;
+        }
+        MinecraftServer server = world.getServer();
+        if (server == null) {
+            return DEFAULT_STREAM_RADIUS_CHUNKS;
+        }
+        int view = server.getPlayerList().getViewDistance();
+        return view > 0 ? view : DEFAULT_STREAM_RADIUS_CHUNKS;
+    }
+
+    /**
+     * Per-viewer stream radius: {@code min(server view distance, player requested view distance)}.
+     */
+    public static int streamRadiusChunks(ServerPlayer player) {
+        if (player == null) {
+            return DEFAULT_STREAM_RADIUS_CHUNKS;
+        }
+        ServerLevel world = player.level() instanceof ServerLevel serverLevel ? serverLevel : null;
+        int serverView = streamRadiusChunks(world);
+        int requested = player.requestedViewDistance();
+        if (requested <= 0) {
+            return serverView;
+        }
+        return Math.min(serverView, requested);
+    }
+
+    /** Vertical half-extent in blocks matching a Chebyshev chunk radius. */
+    public static int streamYRadiusBlocks(int radiusChunks) {
+        return Math.max(0, radiusChunks) * 16;
+    }
+
+    /**
+     * Inclusive chunk-grid bounds covering a Chebyshev radius around {@code anchor}:
+     * {@code [minChunkX, maxChunkX, minChunkZ, maxChunkZ]}.
+     */
+    public static int[] streamChunkBounds(BlockPos anchor, int radiusChunks) {
+        if (anchor == null) {
+            return new int[]{0, 0, 0, 0};
+        }
+        int cx = SectionPos.blockToSectionCoord(anchor.getX());
+        int cz = SectionPos.blockToSectionCoord(anchor.getZ());
+        int radius = Math.max(0, radiusChunks);
+        return new int[]{cx - radius, cx + radius, cz - radius, cz + radius};
+    }
+
+    /** Inclusive intersection of two chunk-grid rectangles. */
+    public static int[] clipChunkBounds(int[] bounds, int minCX, int maxCX, int minCZ, int maxCZ) {
+        if (bounds == null || bounds.length < 4) {
+            return new int[]{minCX, maxCX, minCZ, maxCZ};
+        }
+        return new int[]{
+                Math.max(bounds[0], minCX),
+                Math.min(bounds[1], maxCX),
+                Math.max(bounds[2], minCZ),
+                Math.min(bounds[3], maxCZ)
+        };
+    }
+
+    /** Axis-aligned box covering the Chebyshev chunk radius plus a vertical half-extent. */
+    public static AABB streamBox(BlockPos anchor, int radiusChunks, int yRadius) {
+        int half = Math.max(0, radiusChunks) * 16;
+        int y = Math.max(0, yRadius);
+        return new AABB(
+                anchor.getX() - half,
+                anchor.getY() - y,
+                anchor.getZ() - half,
+                anchor.getX() + half + 1,
+                anchor.getY() + y + 1,
+                anchor.getZ() + half + 1
+        );
+    }
+
+    public static boolean isInsideStreamRadius(
+            BlockPos worldPos,
+            BlockPos anchor,
+            int radiusChunks,
+            int yRadius
+    ) {
+        if (worldPos == null || anchor == null) {
+            return false;
+        }
+        int cx = SectionPos.blockToSectionCoord(worldPos.getX());
+        int cz = SectionPos.blockToSectionCoord(worldPos.getZ());
+        int anchorCx = SectionPos.blockToSectionCoord(anchor.getX());
+        int anchorCz = SectionPos.blockToSectionCoord(anchor.getZ());
+        int radius = Math.max(0, radiusChunks);
+        if (Math.abs(cx - anchorCx) > radius || Math.abs(cz - anchorCz) > radius) {
+            return false;
+        }
+        return Math.abs(worldPos.getY() - anchor.getY()) <= Math.max(0, yRadius);
+    }
+
+    /** Fog start distance in blocks for a streamed Chebyshev radius. */
+    public static float fogStartBlocks(int radiusChunks) {
+        return streamYRadiusBlocks(radiusChunks) * FOG_START_FRACTION;
+    }
+
+    /** Fog end distance in blocks (the streamed Chebyshev radius). Always greater than start. */
+    public static float fogEndBlocks(int radiusChunks) {
+        float start = fogStartBlocks(radiusChunks);
+        float end = streamYRadiusBlocks(radiusChunks);
+        return end > start ? end : start + 1.0f;
+    }
+
+    /** Ticket pos + radius for a stream centered on {@code anchor} (one ticket, not per-column). */
+    public static ChunkPos streamTicketChunk(BlockPos anchor) {
+        return new ChunkPos(anchor.getX() >> 4, anchor.getZ() >> 4);
     }
 
     /** Whether a block should appear in this sampler's portal preview. */
@@ -112,7 +234,7 @@ public abstract class PortalSampler {
         return nbt;
     }
 
-    /** Ticket-only keep-alive for {@code bounds} ({@code [minCX, maxCX, minCZ, maxCZ]}). */
+    /** Ticket-only keep-alive for a small footprint ({@code [minCX, maxCX, minCZ, maxCZ]}). */
     protected void addTickets(ServerLevel world, int[] bounds) {
         if (world == null || bounds == null) {
             return;
@@ -120,15 +242,27 @@ public abstract class PortalSampler {
         var chunkManager = world.getChunkSource();
         for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                chunkManager.addTicketWithRadius(ticket, new ChunkPos(cx, cz), 2);
+                chunkManager.addTicketWithRadius(ticket, new ChunkPos(cx, cz), 0);
             }
         }
+    }
+
+    /** One ticket at {@code anchor}'s chunk covering the Chebyshev stream radius. */
+    protected void addStreamTickets(ServerLevel world, BlockPos anchor, int radiusChunks) {
+        if (world == null || anchor == null) {
+            return;
+        }
+        world.getChunkSource().addTicketWithRadius(
+                ticket,
+                streamTicketChunk(anchor),
+                Math.max(0, radiusChunks)
+        );
     }
 
     protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
     }
 
-    protected AABB entityBox(BlockPos anchor) {
+    protected AABB entityBox(ServerLevel world, BlockPos anchor) {
         return footprintAabb(anchor);
     }
 
@@ -161,7 +295,7 @@ public abstract class PortalSampler {
         if (world == null || anchor == null) {
             return false;
         }
-        return !world.getEntities((Entity) null, entityBox(anchor), entity -> !entity.isRemoved()).isEmpty();
+        return !world.getEntities((Entity) null, entityBox(world, anchor), entity -> !entity.isRemoved()).isEmpty();
     }
 
     protected void resetMobAi(ServerLevel world, BlockPos anchor) {
@@ -173,7 +307,7 @@ public abstract class PortalSampler {
             return;
         }
         ensureLoaded(world, anchor);
-        for (Entity entity : world.getEntities((Entity) null, entityBox(anchor), e -> !e.isRemoved())) {
+        for (Entity entity : world.getEntities((Entity) null, entityBox(world, anchor), e -> !e.isRemoved())) {
             if (entity instanceof Mob mob && mob.getNoActionTime() != 0) {
                 mob.setNoActionTime(0);
             }
@@ -185,7 +319,7 @@ public abstract class PortalSampler {
             return List.of();
         }
         ensureLoaded(world, anchor);
-        return List.copyOf(world.getEntities((Entity) null, entityBox(anchor), entity -> !entity.isRemoved()));
+        return List.copyOf(world.getEntities((Entity) null, entityBox(world, anchor), entity -> !entity.isRemoved()));
     }
 
     /**

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
@@ -20,13 +20,20 @@ import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunk;
+import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import net.minecraft.world.level.storage.TagValueOutput;
 import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Shared sampling helpers for BOTI (look-in) and SOTO (look-out) portal streams.
  * Subclasses supply visibility, load strategy, and light-volume bounds.
+ *
+ * <p>Streaming matches vanilla {@code PlayerChunkSender}: tickets request async load, sampling
+ * reads only {@code FULL} chunks via {@code getChunkNow}, and never force-generates on the
+ * server thread.
  */
 public abstract class PortalSampler {
     /** Fallback when server/player view distance is unavailable (matches former Phase-1 cap). */
@@ -34,16 +41,15 @@ public abstract class PortalSampler {
     /** Fog starts at this fraction of the streamed block radius. */
     public static final float FOG_START_FRACTION = 0.6f;
 
-    protected final int sizeX;
-    protected final int sizeY;
-    protected final int sizeZ;
-    protected final TicketType ticket;
+    static final long STREAM_TICKET_TIMEOUT = 80L;
+    static final TicketType STREAM_LOADING_TICKET =
+            new TicketType(STREAM_TICKET_TIMEOUT, TicketType.FLAG_LOADING);
+    static final TicketType STREAM_SIMULATION_TICKET = new TicketType(
+            STREAM_TICKET_TIMEOUT,
+            TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE
+    );
 
-    protected PortalSampler(int sizeX, int sizeY, int sizeZ, TicketType ticket) {
-        this.sizeX = sizeX;
-        this.sizeY = sizeY;
-        this.sizeZ = sizeZ;
-        this.ticket = ticket;
+    protected PortalSampler() {
     }
 
     /**
@@ -75,6 +81,26 @@ public abstract class PortalSampler {
             return serverView;
         }
         return Math.min(serverView, requested);
+    }
+
+    /**
+     * Simulation radius in chunks: {@code min(stream radius, server simulation distance)}.
+     * Matches vanilla loading-at-view / ticking-at-simulation split.
+     */
+    public static int simulationRadiusChunks(ServerLevel world) {
+        int stream = streamRadiusChunks(world);
+        if (world == null) {
+            return stream;
+        }
+        MinecraftServer server = world.getServer();
+        if (server == null) {
+            return stream;
+        }
+        int simulation = server.getPlayerList().getSimulationDistance();
+        if (simulation <= 0) {
+            return stream;
+        }
+        return Math.min(stream, simulation);
     }
 
     /** Vertical half-extent in blocks matching a Chebyshev chunk radius. */
@@ -173,27 +199,6 @@ public abstract class PortalSampler {
         return visible;
     }
 
-    public boolean inFootprint(BlockPos worldPos, BlockPos origin) {
-        int localX = worldPos.getX() - origin.getX();
-        int localY = worldPos.getY() - origin.getY();
-        int localZ = worldPos.getZ() - origin.getZ();
-        return localX >= 0 && localX < sizeX
-                && localY >= 0 && localY < sizeY
-                && localZ >= 0 && localZ < sizeZ;
-    }
-
-    /** Axis-aligned footprint box in world space for entity queries. */
-    public AABB footprintAabb(BlockPos origin) {
-        return new AABB(
-                origin.getX(),
-                origin.getY(),
-                origin.getZ(),
-                origin.getX() + sizeX,
-                origin.getY() + sizeY,
-                origin.getZ() + sizeZ
-        );
-    }
-
     /**
      * Samples sky/fog atmosphere at {@code samplePos}. Returns {@link PortalAtmosphere#DEFAULT}
      * when the world or position is missing.
@@ -234,36 +239,27 @@ public abstract class PortalSampler {
         return nbt;
     }
 
-    /** Ticket-only keep-alive for a small footprint ({@code [minCX, maxCX, minCZ, maxCZ]}). */
-    protected void addTickets(ServerLevel world, int[] bounds) {
-        if (world == null || bounds == null) {
-            return;
-        }
-        var chunkManager = world.getChunkSource();
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                chunkManager.addTicketWithRadius(ticket, new ChunkPos(cx, cz), 0);
-            }
-        }
-    }
-
-    /** One ticket at {@code anchor}'s chunk covering the Chebyshev stream radius. */
+    /**
+     * LOADING ticket at {@code radiusChunks} plus a SIMULATION ticket at simulation distance.
+     * Does not call {@code getChunk}.
+     */
     protected void addStreamTickets(ServerLevel world, BlockPos anchor, int radiusChunks) {
         if (world == null || anchor == null) {
             return;
         }
-        world.getChunkSource().addTicketWithRadius(
-                ticket,
-                streamTicketChunk(anchor),
-                Math.max(0, radiusChunks)
-        );
+        ChunkPos ticketChunk = streamTicketChunk(anchor);
+        int loadRadius = Math.max(0, radiusChunks);
+        world.getChunkSource().addTicketWithRadius(STREAM_LOADING_TICKET, ticketChunk, loadRadius);
+        int simRadius = Math.min(loadRadius, simulationRadiusChunks(world));
+        world.getChunkSource().addTicketWithRadius(STREAM_SIMULATION_TICKET, ticketChunk, simRadius);
     }
 
     protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
     }
 
     protected AABB entityBox(ServerLevel world, BlockPos anchor) {
-        return footprintAabb(anchor);
+        int radius = simulationRadiusChunks(world);
+        return streamBox(anchor, radius, streamYRadiusBlocks(radius));
     }
 
     protected boolean includePos(BlockPos worldPos, BlockPos anchor) {
@@ -271,7 +267,10 @@ public abstract class PortalSampler {
     }
 
     protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
-        return yRange(anchor.getY(), anchor.getY() + sizeY - 1);
+        int yRadius = streamYRadiusBlocks(streamRadiusChunks(world));
+        int minY = Math.max(world.getMinY(), anchor.getY() - yRadius);
+        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + yRadius);
+        return yRange(minY, maxY);
     }
 
     protected static YRange yRange(int min, int max) {
@@ -325,8 +324,10 @@ public abstract class PortalSampler {
     /**
      * Collects visible block states (+ BE NBT) for one chunk column.
      * Positions in the returned maps are world-absolute.
+     *
+     * @return the sample, or {@code null} when the column is not yet {@code FULL} (retry later)
      */
-    protected PortalStreamSample sampleChunkColumn(
+    protected @Nullable PortalStreamSample sampleChunkColumn(
             ServerLevel world,
             BlockPos anchor,
             int chunkX,
@@ -335,37 +336,72 @@ public abstract class PortalSampler {
         if (world == null || anchor == null) {
             return new PortalStreamSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
         }
-        world.getChunk(chunkX, chunkZ);
+        LevelChunk chunk = world.getChunkSource().getChunkNow(chunkX, chunkZ);
+        if (chunk == null) {
+            return null;
+        }
         Map<BlockPos, BlockState> blocks = new HashMap<>();
         Map<BlockPos, CompoundTag> blockEntities = new HashMap<>();
         int lowestVisibleY = Integer.MAX_VALUE;
         int highestVisibleY = Integer.MIN_VALUE;
         HolderLookup.Provider registries = world.registryAccess();
         YRange yRange = sampleYRange(world, anchor);
+        if (yRange.min() > yRange.max()) {
+            return new PortalStreamSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
+        }
         BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
         int baseX = chunkX << 4;
         int baseZ = chunkZ << 4;
-        for (int lx = 0; lx < 16; lx++) {
-            for (int lz = 0; lz < 16; lz++) {
-                for (int y = yRange.min(); y <= yRange.max(); y++) {
-                    mutable.set(baseX + lx, y, baseZ + lz);
+        int minSectionY = Math.max(chunk.getMinSectionY(), SectionPos.blockToSectionCoord(yRange.min()));
+        int maxSectionY = Math.min(chunk.getMaxSectionY(), SectionPos.blockToSectionCoord(yRange.max()));
+        for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
+            LevelChunkSection section = chunk.getSection(chunk.getSectionIndexFromSectionY(sectionY));
+            if (section.hasOnlyAir()) {
+                continue;
+            }
+            int sectionMinY = SectionPos.sectionToBlockCoord(sectionY);
+            int localMinY = Math.max(0, yRange.min() - sectionMinY);
+            int localMaxY = Math.min(15, yRange.max() - sectionMinY);
+            for (int lx = 0; lx < 16; lx++) {
+                for (int lz = 0; lz < 16; lz++) {
+                    mutable.set(baseX + lx, yRange.min(), baseZ + lz);
                     if (!includePos(mutable, anchor)) {
                         continue;
                     }
-                    BlockState state = world.getBlockState(mutable);
-                    if (!isVisible(state)) {
-                        continue;
-                    }
-                    BlockPos immutable = mutable.immutable();
-                    blocks.put(immutable, state);
-                    lowestVisibleY = Math.min(lowestVisibleY, y);
-                    highestVisibleY = Math.max(highestVisibleY, y);
-                    BlockEntity blockEntity = world.getBlockEntity(mutable);
-                    if (blockEntity != null) {
-                        blockEntities.put(immutable, captureSyncNbt(blockEntity, registries));
+                    for (int ly = localMinY; ly <= localMaxY; ly++) {
+                        int y = sectionMinY + ly;
+                        mutable.set(baseX + lx, y, baseZ + lz);
+                        BlockState state = section.getBlockState(lx, ly, lz);
+                        if (!isVisible(state)) {
+                            continue;
+                        }
+                        BlockPos immutable = mutable.immutable();
+                        blocks.put(immutable, state);
+                        lowestVisibleY = Math.min(lowestVisibleY, y);
+                        highestVisibleY = Math.max(highestVisibleY, y);
                     }
                 }
             }
+        }
+        for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
+            BlockPos pos = blockEntity.getBlockPos();
+            if (pos.getY() < yRange.min() || pos.getY() > yRange.max()) {
+                continue;
+            }
+            if (!includePos(pos, anchor)) {
+                continue;
+            }
+            BlockState state = blocks.get(pos);
+            if (state == null) {
+                state = blockEntity.getBlockState();
+                if (!isVisible(state)) {
+                    continue;
+                }
+                blocks.put(pos.immutable(), state);
+                lowestVisibleY = Math.min(lowestVisibleY, pos.getY());
+                highestVisibleY = Math.max(highestVisibleY, pos.getY());
+            }
+            blockEntities.put(pos.immutable(), captureSyncNbt(blockEntity, registries));
         }
         PortalLightData lightData = sampleLight(
                 world, anchor, chunkX, chunkZ, yRange, blocks, lowestVisibleY, highestVisibleY);

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
@@ -1,0 +1,243 @@
+package com.adamkali.dwm.tardis.portal;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.HolderLookup;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.TicketType;
+import net.minecraft.util.ProblemReporter;
+import net.minecraft.world.attribute.EnvironmentAttributes;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
+import net.minecraft.world.level.storage.TagValueOutput;
+import net.minecraft.world.phys.AABB;
+
+/**
+ * Shared sampling helpers for BOTI (look-in) and SOTO (look-out) portal streams.
+ * Subclasses supply visibility, load strategy, and light-volume bounds.
+ */
+public abstract class PortalSampler {
+    protected final int sizeX;
+    protected final int sizeY;
+    protected final int sizeZ;
+    protected final TicketType ticket;
+
+    protected PortalSampler(int sizeX, int sizeY, int sizeZ, TicketType ticket) {
+        this.sizeX = sizeX;
+        this.sizeY = sizeY;
+        this.sizeZ = sizeZ;
+        this.ticket = ticket;
+    }
+
+    /** Whether a block should appear in this sampler's portal preview. */
+    public abstract boolean isVisible(BlockState state);
+
+    public Map<BlockPos, BlockState> filterVisibleBlocks(Map<BlockPos, BlockState> placements) {
+        Map<BlockPos, BlockState> visible = new HashMap<>();
+        for (Map.Entry<BlockPos, BlockState> entry : placements.entrySet()) {
+            if (isVisible(entry.getValue())) {
+                visible.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return visible;
+    }
+
+    public boolean inFootprint(BlockPos worldPos, BlockPos origin) {
+        int localX = worldPos.getX() - origin.getX();
+        int localY = worldPos.getY() - origin.getY();
+        int localZ = worldPos.getZ() - origin.getZ();
+        return localX >= 0 && localX < sizeX
+                && localY >= 0 && localY < sizeY
+                && localZ >= 0 && localZ < sizeZ;
+    }
+
+    /** Axis-aligned footprint box in world space for entity queries. */
+    public AABB footprintAabb(BlockPos origin) {
+        return new AABB(
+                origin.getX(),
+                origin.getY(),
+                origin.getZ(),
+                origin.getX() + sizeX,
+                origin.getY() + sizeY,
+                origin.getZ() + sizeZ
+        );
+    }
+
+    /**
+     * Samples sky/fog atmosphere at {@code samplePos}. Returns {@link PortalAtmosphere#DEFAULT}
+     * when the world or position is missing.
+     */
+    public static PortalAtmosphere sampleAtmosphere(ServerLevel world, BlockPos samplePos) {
+        if (world == null || samplePos == null) {
+            return PortalAtmosphere.DEFAULT;
+        }
+        Identifier effectsId = world.dimensionTypeRegistration()
+                .unwrapKey()
+                .map(ResourceKey::identifier)
+                .orElseGet(BuiltinDimensionTypes.OVERWORLD::identifier);
+        long timeOfDay = world.getOverworldClockTime();
+        float rain = world.getRainLevel(0.0f);
+        float thunder = world.getThunderLevel(0.0f);
+        var attrs = world.environmentAttributes();
+        return new PortalAtmosphere(
+                effectsId,
+                timeOfDay,
+                rain,
+                thunder,
+                attrs.getValue(EnvironmentAttributes.SKY_COLOR, samplePos),
+                attrs.getValue(EnvironmentAttributes.FOG_COLOR, samplePos)
+        );
+    }
+
+    /**
+     * Chunk-sync NBT plus type {@code id} for client {@link BlockEntity#loadStatic} reconstruction.
+     */
+    public static CompoundTag captureSyncNbt(BlockEntity blockEntity, HolderLookup.Provider registries) {
+        CompoundTag nbt = blockEntity.getUpdateTag(registries);
+        TagValueOutput typeOut = TagValueOutput.createWithContext(ProblemReporter.DISCARDING, registries);
+        BlockEntity.addEntityType(typeOut, blockEntity.getType());
+        CompoundTag typeTag = typeOut.buildResult();
+        for (String key : typeTag.keySet()) {
+            nbt.put(key, typeTag.get(key));
+        }
+        return nbt;
+    }
+
+    /** Ticket-only keep-alive for {@code bounds} ({@code [minCX, maxCX, minCZ, maxCZ]}). */
+    protected void addTickets(ServerLevel world, int[] bounds) {
+        if (world == null || bounds == null) {
+            return;
+        }
+        var chunkManager = world.getChunkSource();
+        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
+            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
+                chunkManager.addTicketWithRadius(ticket, new ChunkPos(cx, cz), 2);
+            }
+        }
+    }
+
+    protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
+    }
+
+    protected AABB entityBox(BlockPos anchor) {
+        return footprintAabb(anchor);
+    }
+
+    protected boolean includePos(BlockPos worldPos, BlockPos anchor) {
+        return true;
+    }
+
+    protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
+        return yRange(anchor.getY(), anchor.getY() + sizeY - 1);
+    }
+
+    protected static YRange yRange(int min, int max) {
+        return new YRange(min, max);
+    }
+
+    protected PortalLightData sampleLight(
+            ServerLevel world,
+            BlockPos anchor,
+            int chunkX,
+            int chunkZ,
+            YRange yRange,
+            Map<BlockPos, BlockState> blocks,
+            int lowestVisibleY,
+            int highestVisibleY
+    ) {
+        return PortalLightData.EMPTY;
+    }
+
+    protected boolean hasLoadedEntities(ServerLevel world, BlockPos anchor) {
+        if (world == null || anchor == null) {
+            return false;
+        }
+        return !world.getEntities((Entity) null, entityBox(anchor), entity -> !entity.isRemoved()).isEmpty();
+    }
+
+    protected void resetMobAi(ServerLevel world, BlockPos anchor) {
+        if (world == null || anchor == null) {
+            return;
+        }
+        // Players in-dimension already reset the counter via MobEntity#checkDespawn.
+        if (!world.players().isEmpty()) {
+            return;
+        }
+        ensureLoaded(world, anchor);
+        for (Entity entity : world.getEntities((Entity) null, entityBox(anchor), e -> !e.isRemoved())) {
+            if (entity instanceof Mob mob && mob.getNoActionTime() != 0) {
+                mob.setNoActionTime(0);
+            }
+        }
+    }
+
+    protected List<Entity> collectEntities(ServerLevel world, BlockPos anchor) {
+        if (world == null || anchor == null) {
+            return List.of();
+        }
+        ensureLoaded(world, anchor);
+        return List.copyOf(world.getEntities((Entity) null, entityBox(anchor), entity -> !entity.isRemoved()));
+    }
+
+    /**
+     * Collects visible block states (+ BE NBT) for one chunk column.
+     * Positions in the returned maps are world-absolute.
+     */
+    protected PortalStreamSample sampleChunkColumn(
+            ServerLevel world,
+            BlockPos anchor,
+            int chunkX,
+            int chunkZ
+    ) {
+        if (world == null || anchor == null) {
+            return new PortalStreamSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
+        }
+        world.getChunk(chunkX, chunkZ);
+        Map<BlockPos, BlockState> blocks = new HashMap<>();
+        Map<BlockPos, CompoundTag> blockEntities = new HashMap<>();
+        int lowestVisibleY = Integer.MAX_VALUE;
+        int highestVisibleY = Integer.MIN_VALUE;
+        HolderLookup.Provider registries = world.registryAccess();
+        YRange yRange = sampleYRange(world, anchor);
+        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
+        int baseX = chunkX << 4;
+        int baseZ = chunkZ << 4;
+        for (int lx = 0; lx < 16; lx++) {
+            for (int lz = 0; lz < 16; lz++) {
+                for (int y = yRange.min(); y <= yRange.max(); y++) {
+                    mutable.set(baseX + lx, y, baseZ + lz);
+                    if (!includePos(mutable, anchor)) {
+                        continue;
+                    }
+                    BlockState state = world.getBlockState(mutable);
+                    if (!isVisible(state)) {
+                        continue;
+                    }
+                    BlockPos immutable = mutable.immutable();
+                    blocks.put(immutable, state);
+                    lowestVisibleY = Math.min(lowestVisibleY, y);
+                    highestVisibleY = Math.max(highestVisibleY, y);
+                    BlockEntity blockEntity = world.getBlockEntity(mutable);
+                    if (blockEntity != null) {
+                        blockEntities.put(immutable, captureSyncNbt(blockEntity, registries));
+                    }
+                }
+            }
+        }
+        PortalLightData lightData = sampleLight(
+                world, anchor, chunkX, chunkZ, yRange, blocks, lowestVisibleY, highestVisibleY);
+        return new PortalStreamSample(chunkX, chunkZ, blocks, blockEntities, lightData);
+    }
+
+    protected record YRange(int min, int max) {
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalSampler.java
@@ -1,5 +1,6 @@
 package com.adamkali.dwm.tardis.portal;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,6 +19,8 @@ import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.chunk.LevelChunk;
@@ -48,6 +51,9 @@ public abstract class PortalSampler {
             STREAM_TICKET_TIMEOUT,
             TicketType.FLAG_SIMULATION | TicketType.FLAG_KEEP_DIMENSION_ACTIVE
     );
+    private static final int COLUMN_STRIDE_Y = 256;
+    private static final ThreadLocal<BlockState[]> COLUMN_GRID =
+            ThreadLocal.withInitial(() -> new BlockState[384 * COLUMN_STRIDE_Y]);
 
     protected PortalSampler() {
     }
@@ -266,6 +272,15 @@ public abstract class PortalSampler {
         return true;
     }
 
+    /**
+     * When true, only sample each column from its world-surface height down to the lowest
+     * neighboring surface (plus a 1-block pad). Soto uses this so buried cave layers are not
+     * walked; BOTI keeps the full plot Y range.
+     */
+    protected boolean useSurfaceSkin() {
+        return false;
+    }
+
     protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
         int yRadius = streamYRadiusBlocks(streamRadiusChunks(world));
         int minY = Math.max(world.getMinY(), anchor.getY() - yRadius);
@@ -275,6 +290,159 @@ public abstract class PortalSampler {
 
     protected static YRange yRange(int min, int max) {
         return new YRange(min, max);
+    }
+
+    /** Inclusive Y span covering visible blocks plus a 1-block pad, clipped to {@code yRange}. */
+    protected static YRange lightYRange(YRange yRange, int lowestVisibleY, int highestVisibleY) {
+        if (yRange == null || lowestVisibleY > highestVisibleY) {
+            return yRange(1, 0);
+        }
+        return yRange(
+                Math.max(yRange.min(), lowestVisibleY - 1),
+                Math.min(yRange.max(), highestVisibleY + 1)
+        );
+    }
+
+    /**
+     * True when {@code state} is a full solid cube whose six neighbors are also full solid cubes,
+     * so the client mesh would emit no faces.
+     */
+    static boolean isHiddenInterior(
+            BlockState state,
+            BlockState east,
+            BlockState west,
+            BlockState up,
+            BlockState down,
+            BlockState south,
+            BlockState north
+    ) {
+        if (state == null || !state.isSolidRender()) {
+            return false;
+        }
+        return isSolidOccluder(east)
+                && isSolidOccluder(west)
+                && isSolidOccluder(up)
+                && isSolidOccluder(down)
+                && isSolidOccluder(south)
+                && isSolidOccluder(north);
+    }
+
+    private static boolean isSolidOccluder(BlockState neighbor) {
+        return neighbor != null && neighbor.isSolidRender();
+    }
+
+    /** True when every palette entry is a full solid cube (buried stone, packed dirt, …). */
+    static boolean isSolidFilledSection(LevelChunkSection section) {
+        return section != null
+                && !section.hasOnlyAir()
+                && !section.maybeHas(state -> state != null && !state.isSolidRender());
+    }
+
+    /**
+     * Per-column inclusive Y bounds from a 16×16 WORLD_SURFACE heightmap.
+     * Interior columns keep a 1-block pad below the lowest 4-neighbor surface; chunk-edge
+     * columns extend 16 blocks down so cliffs on a chunk border still get a face.
+     */
+    static void computeSurfaceSkinBounds(int[] heightY, int rangeMin, int rangeMax, int[] colMin, int[] colMax) {
+        for (int lz = 0; lz < 16; lz++) {
+            for (int lx = 0; lx < 16; lx++) {
+                int index = (lz << 4) | lx;
+                int own = heightY[index];
+                int floor = own;
+                if (lx > 0) {
+                    floor = Math.min(floor, heightY[index - 1]);
+                }
+                if (lx < 15) {
+                    floor = Math.min(floor, heightY[index + 1]);
+                }
+                if (lz > 0) {
+                    floor = Math.min(floor, heightY[index - 16]);
+                }
+                if (lz < 15) {
+                    floor = Math.min(floor, heightY[index + 16]);
+                }
+                int minY = floor - 1;
+                if (lx == 0 || lx == 15 || lz == 0 || lz == 15) {
+                    minY = Math.min(minY, own - 16);
+                }
+                colMax[index] = Math.min(rangeMax, own);
+                colMin[index] = Math.max(rangeMin, minY);
+            }
+        }
+    }
+
+    private static boolean isSolidAtWorldY(
+            boolean[] solidSection,
+            int minSectionY,
+            int maxSectionY,
+            int minY,
+            int maxY,
+            int y
+    ) {
+        if (y < minY || y > maxY) {
+            return false;
+        }
+        int sectionY = SectionPos.blockToSectionCoord(y);
+        return sectionY >= minSectionY
+                && sectionY <= maxSectionY
+                && solidSection[sectionY - minSectionY];
+    }
+
+    private static BlockState occludeOrSolidSection(
+            BlockState neighbor,
+            boolean[] solidSection,
+            int minSectionY,
+            int maxSectionY,
+            int neighborY,
+            int minY,
+            int ySize
+    ) {
+        if (neighbor != null) {
+            return neighbor;
+        }
+        if (isSolidAtWorldY(solidSection, minSectionY, maxSectionY, minY, minY + ySize - 1, neighborY)) {
+            return Blocks.STONE.defaultBlockState();
+        }
+        return null;
+    }
+
+    private int emitSolidSectionLayer(
+            LevelChunkSection section,
+            boolean[] includeColumn,
+            Map<BlockPos, BlockState> blocks,
+            int baseX,
+            int baseZ,
+            int sectionMinY,
+            int ly,
+            int neighborY,
+            BlockState[] grid,
+            int minY,
+            int ySize
+    ) {
+        int emitted = 0;
+        int y = sectionMinY + ly;
+        int neighborGy = neighborY - minY;
+        for (int lz = 0; lz < 16; lz++) {
+            for (int lx = 0; lx < 16; lx++) {
+                if (!includeColumn[(lz << 4) | lx]) {
+                    continue;
+                }
+                BlockState neighbor = null;
+                if (neighborGy >= 0 && neighborGy < ySize) {
+                    neighbor = grid[neighborGy * COLUMN_STRIDE_Y + (lz << 4) + lx];
+                }
+                if (isSolidOccluder(neighbor)) {
+                    continue;
+                }
+                BlockState state = section.getBlockState(lx, ly, lz);
+                if (!isVisible(state)) {
+                    continue;
+                }
+                blocks.put(new BlockPos(baseX + lx, y, baseZ + lz), state);
+                emitted++;
+            }
+        }
+        return emitted;
     }
 
     protected PortalLightData sampleLight(
@@ -340,7 +508,6 @@ public abstract class PortalSampler {
         if (chunk == null) {
             return null;
         }
-        Map<BlockPos, BlockState> blocks = new HashMap<>();
         Map<BlockPos, CompoundTag> blockEntities = new HashMap<>();
         int lowestVisibleY = Integer.MAX_VALUE;
         int highestVisibleY = Integer.MIN_VALUE;
@@ -354,35 +521,153 @@ public abstract class PortalSampler {
         int baseZ = chunkZ << 4;
         int minSectionY = Math.max(chunk.getMinSectionY(), SectionPos.blockToSectionCoord(yRange.min()));
         int maxSectionY = Math.min(chunk.getMaxSectionY(), SectionPos.blockToSectionCoord(yRange.max()));
+        int ySize = yRange.max() - yRange.min() + 1;
+        int gridLen = ySize * COLUMN_STRIDE_Y;
+        BlockState[] grid = COLUMN_GRID.get();
+        if (grid.length < gridLen) {
+            grid = new BlockState[gridLen];
+            COLUMN_GRID.set(grid);
+        }
+        boolean[] includeColumn = new boolean[256];
+        for (int lz = 0; lz < 16; lz++) {
+            for (int lx = 0; lx < 16; lx++) {
+                mutable.set(baseX + lx, yRange.min(), baseZ + lz);
+                includeColumn[(lz << 4) | lx] = includePos(mutable, anchor);
+            }
+        }
+        int[] colMin = new int[256];
+        int[] colMax = new int[256];
+        if (useSurfaceSkin()) {
+            int[] heights = new int[256];
+            for (int lz = 0; lz < 16; lz++) {
+                for (int lx = 0; lx < 16; lx++) {
+                    heights[(lz << 4) | lx] = chunk.getHeight(Heightmap.Types.WORLD_SURFACE, lx, lz);
+                }
+            }
+            computeSurfaceSkinBounds(heights, yRange.min(), yRange.max(), colMin, colMax);
+        } else {
+            Arrays.fill(colMin, yRange.min());
+            Arrays.fill(colMax, yRange.max());
+        }
+        int minSkin = colMin[0];
+        int maxSkin = colMax[0];
+        for (int i = 1; i < 256; i++) {
+            minSkin = Math.min(minSkin, colMin[i]);
+            maxSkin = Math.max(maxSkin, colMax[i]);
+        }
+        int gridVisible = 0;
+        int minGy = ySize;
+        int maxGy = -1;
+        int sectionCount = maxSectionY - minSectionY + 1;
+        boolean[] solidSection = new boolean[sectionCount];
         for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
             LevelChunkSection section = chunk.getSection(chunk.getSectionIndexFromSectionY(sectionY));
+            int sectionMinY = SectionPos.sectionToBlockCoord(sectionY);
+            if (sectionMinY + 15 < minSkin || sectionMinY > maxSkin) {
+                continue;
+            }
             if (section.hasOnlyAir()) {
                 continue;
             }
-            int sectionMinY = SectionPos.sectionToBlockCoord(sectionY);
+            if (!section.maybeHas(this::isVisible)) {
+                continue;
+            }
+            if (isSolidFilledSection(section)) {
+                solidSection[sectionY - minSectionY] = true;
+                continue;
+            }
             int localMinY = Math.max(0, yRange.min() - sectionMinY);
             int localMaxY = Math.min(15, yRange.max() - sectionMinY);
-            for (int lx = 0; lx < 16; lx++) {
+            for (int ly = localMinY; ly <= localMaxY; ly++) {
+                int y = sectionMinY + ly;
+                if (y < minSkin || y > maxSkin) {
+                    continue;
+                }
+                int gy = y - yRange.min();
+                int yBase = gy * COLUMN_STRIDE_Y;
                 for (int lz = 0; lz < 16; lz++) {
-                    mutable.set(baseX + lx, yRange.min(), baseZ + lz);
-                    if (!includePos(mutable, anchor)) {
-                        continue;
-                    }
-                    for (int ly = localMinY; ly <= localMaxY; ly++) {
-                        int y = sectionMinY + ly;
-                        mutable.set(baseX + lx, y, baseZ + lz);
+                    int zBase = yBase + (lz << 4);
+                    for (int lx = 0; lx < 16; lx++) {
+                        int col = (lz << 4) | lx;
+                        if (!includeColumn[col] || y < colMin[col] || y > colMax[col]) {
+                            continue;
+                        }
                         BlockState state = section.getBlockState(lx, ly, lz);
                         if (!isVisible(state)) {
                             continue;
                         }
-                        BlockPos immutable = mutable.immutable();
-                        blocks.put(immutable, state);
-                        lowestVisibleY = Math.min(lowestVisibleY, y);
-                        highestVisibleY = Math.max(highestVisibleY, y);
+                        grid[zBase + lx] = state;
+                        gridVisible++;
+                        minGy = Math.min(minGy, gy);
+                        maxGy = Math.max(maxGy, gy);
                     }
                 }
             }
         }
+        Map<BlockPos, BlockState> blocks = new HashMap<>(Math.max(16, gridVisible / 4 + 32));
+        int minY = yRange.min();
+        for (int gy = minGy; gy <= maxGy; gy++) {
+            int yBase = gy * COLUMN_STRIDE_Y;
+            int y = minY + gy;
+            for (int lz = 0; lz < 16; lz++) {
+                for (int lx = 0; lx < 16; lx++) {
+                    int index = yBase + (lz << 4) + lx;
+                    BlockState state = grid[index];
+                    if (state == null) {
+                        continue;
+                    }
+                    BlockState down = gy > 0 ? grid[index - COLUMN_STRIDE_Y] : null;
+                    BlockState up = gy + 1 < ySize ? grid[index + COLUMN_STRIDE_Y] : null;
+                    BlockState north = lz > 0 ? grid[index - 16] : null;
+                    BlockState south = lz < 15 ? grid[index + 16] : null;
+                    BlockState west = lx > 0 ? grid[index - 1] : null;
+                    BlockState east = lx < 15 ? grid[index + 1] : null;
+                    int col = (lz << 4) | lx;
+                    if (down == null && y - 1 < colMin[col]) {
+                        down = Blocks.STONE.defaultBlockState();
+                    } else {
+                        down = occludeOrSolidSection(
+                                down, solidSection, minSectionY, maxSectionY, y - 1, minY, ySize);
+                    }
+                    up = occludeOrSolidSection(
+                            up, solidSection, minSectionY, maxSectionY, y + 1, minY, ySize);
+                    if (isHiddenInterior(state, east, west, up, down, south, north)) {
+                        continue;
+                    }
+                    blocks.put(new BlockPos(baseX + lx, y, baseZ + lz), state);
+                    lowestVisibleY = Math.min(lowestVisibleY, y);
+                    highestVisibleY = Math.max(highestVisibleY, y);
+                }
+            }
+        }
+        for (int sectionY = minSectionY; sectionY <= maxSectionY; sectionY++) {
+            if (!solidSection[sectionY - minSectionY]) {
+                continue;
+            }
+            LevelChunkSection section = chunk.getSection(chunk.getSectionIndexFromSectionY(sectionY));
+            int sectionMinY = SectionPos.sectionToBlockCoord(sectionY);
+            int localMinY = Math.max(0, yRange.min() - sectionMinY);
+            int localMaxY = Math.min(15, yRange.max() - sectionMinY);
+            int topY = sectionMinY + localMaxY;
+            int bottomY = sectionMinY + localMinY;
+            if (!isSolidAtWorldY(solidSection, minSectionY, maxSectionY, minY, yRange.max(), topY + 1)) {
+                int emitted = emitSolidSectionLayer(
+                        section, includeColumn, blocks, baseX, baseZ, sectionMinY, localMaxY, topY + 1, grid, minY, ySize);
+                if (emitted > 0) {
+                    lowestVisibleY = Math.min(lowestVisibleY, topY);
+                    highestVisibleY = Math.max(highestVisibleY, topY);
+                }
+            }
+            if (!isSolidAtWorldY(solidSection, minSectionY, maxSectionY, minY, yRange.max(), bottomY - 1)) {
+                int emitted = emitSolidSectionLayer(
+                        section, includeColumn, blocks, baseX, baseZ, sectionMinY, localMinY, bottomY - 1, grid, minY, ySize);
+                if (emitted > 0) {
+                    lowestVisibleY = Math.min(lowestVisibleY, bottomY);
+                    highestVisibleY = Math.max(highestVisibleY, bottomY);
+                }
+            }
+        }
+        Arrays.fill(grid, 0, gridLen, null);
         for (BlockEntity blockEntity : chunk.getBlockEntities().values()) {
             BlockPos pos = blockEntity.getBlockPos();
             if (pos.getY() < yRange.min() || pos.getY() > yRange.max()) {

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSample.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSample.java
@@ -12,6 +12,21 @@ public record PortalStreamSample(
         int chunkX,
         int chunkZ,
         Map<BlockPos, BlockState> blocks,
-        Map<BlockPos, CompoundTag> blockEntities
+        Map<BlockPos, CompoundTag> blockEntities,
+        PortalLightData lightData
 ) {
+    public PortalStreamSample(
+            int chunkX,
+            int chunkZ,
+            Map<BlockPos, BlockState> blocks,
+            Map<BlockPos, CompoundTag> blockEntities
+    ) {
+        this(chunkX, chunkZ, blocks, blockEntities, PortalLightData.EMPTY);
+    }
+
+    public PortalStreamSample {
+        blocks = blocks == null ? Map.of() : Map.copyOf(blocks);
+        blockEntities = blockEntities == null ? Map.of() : Map.copyOf(blockEntities);
+        lightData = lightData == null ? PortalLightData.EMPTY : lightData;
+    }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -36,8 +36,10 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -54,6 +56,8 @@ public final class PortalStreamSyncService {
     private static final int VIEWER_LEAVE_GRACE_TICKS = 40;
     static final int MAX_BOTI_LIGHT_DEFER_TICKS = 40;
     static final int CHUNK_SEND_BUDGET_PER_VIEWER_TICK = 8;
+    static final int GLOBAL_SAMPLE_BUDGET_PER_TICK = 16;
+    static final long SAMPLE_TIME_BUDGET_NS = 2_000_000L;
     private static final int LIGHT_GATE_PASSED = -1;
 
     private static final Map<StreamKey, Set<UUID>> SUBSCRIBERS = new ConcurrentHashMap<>();
@@ -201,7 +205,7 @@ public final class PortalStreamSyncService {
         sendMeta(player, ctx);
         SENT_CHUNKS.computeIfAbsent(viewerKey, k -> ConcurrentHashMap.newKeySet());
         TRACKED_ENTITIES.computeIfAbsent(viewerKey, k -> ConcurrentHashMap.newKeySet());
-        ensureChunks(player, ctx);
+        sendViewerChunks(player, ctx, new HashMap<>(), SampleBudget.start(), new HashMap<>());
         syncEntities(player, ctx);
         return true;
     }
@@ -220,14 +224,15 @@ public final class PortalStreamSyncService {
         }
         TardisInteriorPreloadService.tick(server);
         markShellAnimatingDirty();
+        SampleBudget budget = SampleBudget.start();
         long metaStart = PortalStreamPerfStats.begin();
         flushMeta(server);
         PortalStreamPerfStats.endFlushMeta(metaStart);
         long sotoStart = PortalStreamPerfStats.begin();
-        flushStreams(server, PortalStreamKind.SOTO);
+        flushStreams(server, PortalStreamKind.SOTO, budget);
         PortalStreamPerfStats.endFlushSoto(sotoStart);
         long botiStart = PortalStreamPerfStats.begin();
-        flushStreams(server, PortalStreamKind.BOTI);
+        flushStreams(server, PortalStreamKind.BOTI, budget);
         PortalStreamPerfStats.endFlushBoti(botiStart);
         if (diag) {
             PortalStreamPerfStats.endTick();
@@ -299,12 +304,11 @@ public final class PortalStreamSyncService {
         }
     }
 
-    private static void flushStreams(MinecraftServer server, PortalStreamKind kind) {
+    private static void flushStreams(MinecraftServer server, PortalStreamKind kind, SampleBudget budget) {
         Set<UUID> registered = kind == PortalStreamKind.SOTO
                 ? SotoExteriorIndex.registeredIds()
                 : BotiPlotIndex.registeredIds();
         Set<UUID> active = new HashSet<>();
-        Set<StreamKey> dirtyFlushed = new HashSet<>();
         for (UUID tardisId : registered) {
             StreamKey streamKey = new StreamKey(kind, tardisId);
             Set<ServerPlayer> viewers = collectViewers(server, kind, tardisId);
@@ -328,22 +332,67 @@ public final class PortalStreamSyncService {
             )) {
                 continue;
             }
+            Map<Long, PortalStreamSample> sampleCache = new HashMap<>();
+            Map<Long, Integer> dirtyNeed = new HashMap<>();
+            Map<Long, Integer> dirtyGot = new HashMap<>();
+            Set<Long> dirty = DIRTY_CHUNKS.getOrDefault(streamKey, Set.of());
             for (ServerPlayer viewer : viewers) {
-                ensureChunks(viewer, ctx);
-                flushDirtyChunks(viewer, ctx);
+                ViewerKey viewerKey = new ViewerKey(kind, tardisId, viewer.getUUID());
+                Set<Long> sent = SENT_CHUNKS.get(viewerKey);
+                if (sent == null || dirty.isEmpty()) {
+                    continue;
+                }
+                for (long packed : dirty) {
+                    if (sent.contains(packed)) {
+                        dirtyNeed.merge(packed, 1, Integer::sum);
+                    }
+                }
             }
-            dirtyFlushed.add(streamKey);
+            for (ServerPlayer viewer : viewers) {
+                sendViewerChunks(viewer, ctx, sampleCache, budget, dirtyGot);
+            }
+            retainUnsentDirty(streamKey, dirtyNeed, dirtyGot);
             if (tickCounter % ENTITY_UPDATE_INTERVAL_TICKS == 0) {
                 for (ServerPlayer viewer : viewers) {
                     syncEntities(viewer, ctx);
                 }
             }
         }
-        for (StreamKey key : dirtyFlushed) {
-            DIRTY_CHUNKS.remove(key);
-        }
         SUBSCRIBERS.keySet().removeIf(key ->
                 key.kind() == kind && !registered.contains(key.tardisId()) && !active.contains(key.tardisId()));
+    }
+
+    static Set<Long> leftoverDirty(Map<Long, Integer> dirtyNeed, Map<Long, Integer> dirtyGot) {
+        Set<Long> leftover = new HashSet<>();
+        for (Map.Entry<Long, Integer> entry : dirtyNeed.entrySet()) {
+            int need = entry.getValue();
+            if (need <= 0) {
+                continue;
+            }
+            int got = dirtyGot.getOrDefault(entry.getKey(), 0);
+            if (got < need) {
+                leftover.add(entry.getKey());
+            }
+        }
+        return leftover;
+    }
+
+    private static void retainUnsentDirty(
+            StreamKey streamKey,
+            Map<Long, Integer> dirtyNeed,
+            Map<Long, Integer> dirtyGot
+    ) {
+        Set<Long> current = DIRTY_CHUNKS.get(streamKey);
+        if (current == null || current.isEmpty()) {
+            return;
+        }
+        Set<Long> leftover = leftoverDirty(dirtyNeed, dirtyGot);
+        leftover.retainAll(current);
+        if (leftover.isEmpty()) {
+            DIRTY_CHUNKS.remove(streamKey);
+        } else {
+            current.retainAll(leftover);
+        }
     }
 
     static boolean shouldDeferBotiStreamForTest(UUID tardisId, boolean lightReady, int currentTick) {
@@ -449,7 +498,13 @@ public final class PortalStreamSyncService {
         PortalStreamPerfStats.noteMetaPacket();
     }
 
-    private static void ensureChunks(ServerPlayer player, SceneContext ctx) {
+    private static void sendViewerChunks(
+            ServerPlayer player,
+            SceneContext ctx,
+            Map<Long, PortalStreamSample> sampleCache,
+            SampleBudget budget,
+            Map<Long, Integer> dirtyGot
+    ) {
         ViewerKey key = new ViewerKey(ctx.kind(), ctx.tardisId(), player.getUUID());
         Set<Long> sent = SENT_CHUNKS.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
         int[] bounds = ctx.chunkBounds(player);
@@ -467,28 +522,46 @@ public final class PortalStreamSyncService {
                 ));
             }
         }
-        int sentThisTick = 0;
         int anchorCx = ctx.anchorPos().getX() >> 4;
         int anchorCz = ctx.anchorPos().getZ() >> 4;
-        List<Long> toSend = new ArrayList<>();
-        for (long packed : desired) {
-            if (!sent.contains(packed)) {
-                toSend.add(packed);
+        Set<Long> dirty = DIRTY_CHUNKS.getOrDefault(new StreamKey(ctx.kind(), ctx.tardisId()), Set.of());
+        List<Long> dirtyQueue = new ArrayList<>();
+        List<Long> newQueue = new ArrayList<>();
+        for (long packed : dirty) {
+            if (sent.contains(packed)) {
+                dirtyQueue.add(packed);
             }
         }
-        toSend.sort(Comparator.comparingInt(packed -> {
-            int dx = Math.abs(ChunkPos.getX(packed) - anchorCx);
-            int dz = Math.abs(ChunkPos.getZ(packed) - anchorCz);
-            return Math.max(dx, dz);
-        }));
-        for (long packed : toSend) {
+        for (long packed : desired) {
+            if (!sent.contains(packed)) {
+                newQueue.add(packed);
+            }
+        }
+        Comparator<Long> nearer = Comparator.comparingInt(packed -> chebyshevDistance(packed, anchorCx, anchorCz));
+        dirtyQueue.sort(nearer);
+        newQueue.sort(nearer);
+        List<Long> queue = new ArrayList<>(dirtyQueue.size() + newQueue.size());
+        queue.addAll(dirtyQueue);
+        queue.addAll(newQueue);
+        int sentThisTick = 0;
+        for (long packed : queue) {
             if (sentThisTick >= CHUNK_SEND_BUDGET_PER_VIEWER_TICK) {
                 break;
             }
-            int cx = ChunkPos.getX(packed);
-            int cz = ChunkPos.getZ(packed);
-            PortalStreamSample sample = ctx.sampleChunk(cx, cz);
-            PortalStreamPerfStats.noteChunkSample();
+            boolean alreadySent = sent.contains(packed);
+            PortalStreamSample sample = sampleCache.get(packed);
+            if (sample == null) {
+                if (!budget.canSample()) {
+                    break;
+                }
+                sample = ctx.sampleChunk(ChunkPos.getX(packed), ChunkPos.getZ(packed));
+                if (sample == null) {
+                    continue;
+                }
+                budget.noteSample();
+                PortalStreamPerfStats.noteChunkSample();
+                sampleCache.put(packed, sample);
+            }
             ServerPlayNetworking.send(
                     player,
                     SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
@@ -496,33 +569,16 @@ public final class PortalStreamSyncService {
             PortalStreamPerfStats.noteChunkPacket();
             sent.add(packed);
             sentThisTick++;
+            if (alreadySent && dirty.contains(packed)) {
+                dirtyGot.merge(packed, 1, Integer::sum);
+            }
         }
     }
 
-    private static void flushDirtyChunks(ServerPlayer player, SceneContext ctx) {
-        Set<Long> dirty = DIRTY_CHUNKS.get(new StreamKey(ctx.kind(), ctx.tardisId()));
-        if (dirty == null || dirty.isEmpty()) {
-            return;
-        }
-        ViewerKey key = new ViewerKey(ctx.kind(), ctx.tardisId(), player.getUUID());
-        Set<Long> sent = SENT_CHUNKS.get(key);
-        if (sent == null) {
-            return;
-        }
-        for (long packed : Set.copyOf(dirty)) {
-            if (!sent.contains(packed)) {
-                continue;
-            }
-            int cx = ChunkPos.getX(packed);
-            int cz = ChunkPos.getZ(packed);
-            PortalStreamSample sample = ctx.sampleChunk(cx, cz);
-            PortalStreamPerfStats.noteChunkSample();
-            ServerPlayNetworking.send(
-                    player,
-                    SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
-            );
-            PortalStreamPerfStats.noteChunkPacket();
-        }
+    static int chebyshevDistance(long packed, int anchorCx, int anchorCz) {
+        int dx = Math.abs(ChunkPos.getX(packed) - anchorCx);
+        int dz = Math.abs(ChunkPos.getZ(packed) - anchorCz);
+        return Math.max(dx, dz);
     }
 
     private static void syncEntities(ServerPlayer player, SceneContext ctx) {
@@ -636,7 +692,7 @@ public final class PortalStreamSyncService {
             return BotiInteriorSampler.streamChunkBounds(footprintOrigin, radius);
         }
 
-        PortalStreamSample sampleChunk(int chunkX, int chunkZ) {
+        @Nullable PortalStreamSample sampleChunk(int chunkX, int chunkZ) {
             if (kind == PortalStreamKind.SOTO) {
                 return SotoExteriorSampler.samplePortalStreamChunk(world, anchorPos, chunkX, chunkZ);
             }
@@ -648,6 +704,28 @@ public final class PortalStreamSyncService {
                 return SotoExteriorSampler.collectStreamEntities(world, anchorPos);
             }
             return BotiInteriorSampler.collectStreamEntities(world, tardisId);
+        }
+    }
+
+    static final class SampleBudget {
+        int remainingSamples;
+        final long deadlineNs;
+
+        private SampleBudget(int remainingSamples, long deadlineNs) {
+            this.remainingSamples = remainingSamples;
+            this.deadlineNs = deadlineNs;
+        }
+
+        static SampleBudget start() {
+            return new SampleBudget(GLOBAL_SAMPLE_BUDGET_PER_TICK, System.nanoTime() + SAMPLE_TIME_BUDGET_NS);
+        }
+
+        boolean canSample() {
+            return remainingSamples > 0 && System.nanoTime() < deadlineNs;
+        }
+
+        void noteSample() {
+            remainingSamples--;
         }
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -299,6 +299,10 @@ public final class PortalStreamSyncService {
                 continue;
             }
             keepAlive(ctx);
+            if (kind == PortalStreamKind.BOTI
+                    && !BotiInteriorSampler.isFootprintLightReady(ctx.world(), ctx.footprintOrigin())) {
+                continue;
+            }
             for (ServerPlayer viewer : viewers) {
                 ensureChunks(viewer, ctx);
                 flushDirtyChunks(viewer, ctx);

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -36,6 +36,8 @@ import net.minecraft.world.InteractionResult;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -51,6 +53,7 @@ public final class PortalStreamSyncService {
     private static final int ENTITY_UPDATE_INTERVAL_TICKS = 2;
     private static final int VIEWER_LEAVE_GRACE_TICKS = 40;
     static final int MAX_BOTI_LIGHT_DEFER_TICKS = 40;
+    static final int CHUNK_SEND_BUDGET_PER_VIEWER_TICK = 8;
     private static final int LIGHT_GATE_PASSED = -1;
 
     private static final Map<StreamKey, Set<UUID>> SUBSCRIBERS = new ConcurrentHashMap<>();
@@ -69,15 +72,15 @@ public final class PortalStreamSyncService {
 
     public static void initialize() {
         PlayerBlockBreakEvents.AFTER.register((world, player, pos, state, blockEntity) -> {
-            if (!world.isClientSide()) {
-                markDirtyAt(world.dimension(), pos);
+            if (world instanceof ServerLevel serverLevel) {
+                markDirtyAt(serverLevel, pos);
             }
         });
 
         UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
-            if (!world.isClientSide()) {
-                markDirtyAt(world.dimension(), hitResult.getBlockPos());
-                markDirtyAt(world.dimension(), hitResult.getBlockPos().relative(hitResult.getDirection()));
+            if (world instanceof ServerLevel serverLevel) {
+                markDirtyAt(serverLevel, hitResult.getBlockPos());
+                markDirtyAt(serverLevel, hitResult.getBlockPos().relative(hitResult.getDirection()));
             }
             return InteractionResult.PASS;
         });
@@ -110,7 +113,7 @@ public final class PortalStreamSyncService {
     }
 
     /**
-     * Marks every BOTI footprint chunk column dirty so already-streamed empty samples are re-sent
+     * Marks every BOTI plot chunk column dirty so already-streamed empty samples are re-sent
      * after interior place / rebuild.
      */
     public static void markBotiFootprintDirty(UUID tardisId) {
@@ -119,7 +122,7 @@ public final class PortalStreamSyncService {
         }
         META_DIRTY.add(tardisId);
         BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
-        int[] bounds = BotiInteriorSampler.footprintChunkBounds(origin);
+        int[] bounds = BotiInteriorSampler.plotChunkBounds(origin);
         StreamKey streamKey = new StreamKey(PortalStreamKind.BOTI, tardisId);
         BOTI_LIGHT_DEFER_STARTED.remove(streamKey);
         Set<Long> dirty = DIRTY_CHUNKS.computeIfAbsent(streamKey, id -> ConcurrentHashMap.newKeySet());
@@ -145,17 +148,28 @@ public final class PortalStreamSyncService {
         setMetaChanged(tardisId);
     }
 
+    public static void markDirtyAt(ServerLevel world, BlockPos worldPos) {
+        if (world == null || worldPos == null) {
+            return;
+        }
+        markDirtyAt(world.dimension(), worldPos, PortalSampler.streamRadiusChunks(world));
+    }
+
     public static void markDirtyAt(ResourceKey<Level> worldKey, BlockPos worldPos) {
+        markDirtyAt(worldKey, worldPos, PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+    }
+
+    static void markDirtyAt(ResourceKey<Level> worldKey, BlockPos worldPos, int radiusChunks) {
         if (worldKey == null || worldPos == null) {
             return;
         }
-        UUID sotoId = SotoExteriorIndex.resolve(worldKey, worldPos);
+        UUID sotoId = SotoExteriorIndex.resolve(worldKey, worldPos, radiusChunks);
         if (sotoId != null) {
             META_DIRTY.add(sotoId);
             markChunkDirty(PortalStreamKind.SOTO, sotoId, worldPos);
         }
         if (worldKey.equals(TardisDimensions.TARDIS_WORLD_KEY)) {
-            UUID botiId = BotiPlotIndex.resolve(worldPos);
+            UUID botiId = BotiPlotIndex.resolve(worldPos, radiusChunks);
             if (botiId != null) {
                 META_DIRTY.add(botiId);
                 markChunkDirty(PortalStreamKind.BOTI, botiId, worldPos);
@@ -185,7 +199,10 @@ public final class PortalStreamSyncService {
             return true;
         }
         sendMeta(player, ctx);
-        sendFullChunks(player, ctx);
+        SENT_CHUNKS.computeIfAbsent(viewerKey, k -> ConcurrentHashMap.newKeySet());
+        TRACKED_ENTITIES.computeIfAbsent(viewerKey, k -> ConcurrentHashMap.newKeySet());
+        ensureChunks(player, ctx);
+        syncEntities(player, ctx);
         return true;
     }
 
@@ -432,31 +449,10 @@ public final class PortalStreamSyncService {
         PortalStreamPerfStats.noteMetaPacket();
     }
 
-    private static void sendFullChunks(ServerPlayer player, SceneContext ctx) {
-        int[] bounds = ctx.chunkBounds();
-        ViewerKey key = new ViewerKey(ctx.kind(), ctx.tardisId(), player.getUUID());
-        Set<Long> sent = SENT_CHUNKS.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                PortalStreamSample sample = ctx.sampleChunk(cx, cz);
-                PortalStreamPerfStats.noteChunkSample();
-                ServerPlayNetworking.send(
-                        player,
-                        SyncPortalChunkS2CPayload.fromSample(ctx.kind(), ctx.tardisId(), ctx.footprintOrigin(), sample)
-                );
-                PortalStreamPerfStats.noteChunkPacket();
-                sent.add(ChunkPos.pack(cx, cz));
-            }
-        }
-        PortalStreamPerfStats.noteFullResync();
-        TRACKED_ENTITIES.put(key, ConcurrentHashMap.newKeySet());
-        syncEntities(player, ctx);
-    }
-
     private static void ensureChunks(ServerPlayer player, SceneContext ctx) {
         ViewerKey key = new ViewerKey(ctx.kind(), ctx.tardisId(), player.getUUID());
         Set<Long> sent = SENT_CHUNKS.computeIfAbsent(key, k -> ConcurrentHashMap.newKeySet());
-        int[] bounds = ctx.chunkBounds();
+        int[] bounds = ctx.chunkBounds(player);
         Set<Long> desired = new HashSet<>();
         for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
@@ -471,9 +467,23 @@ public final class PortalStreamSyncService {
                 ));
             }
         }
+        int sentThisTick = 0;
+        int anchorCx = ctx.anchorPos().getX() >> 4;
+        int anchorCz = ctx.anchorPos().getZ() >> 4;
+        List<Long> toSend = new ArrayList<>();
         for (long packed : desired) {
-            if (sent.contains(packed)) {
-                continue;
+            if (!sent.contains(packed)) {
+                toSend.add(packed);
+            }
+        }
+        toSend.sort(Comparator.comparingInt(packed -> {
+            int dx = Math.abs(ChunkPos.getX(packed) - anchorCx);
+            int dz = Math.abs(ChunkPos.getZ(packed) - anchorCz);
+            return Math.max(dx, dz);
+        }));
+        for (long packed : toSend) {
+            if (sentThisTick >= CHUNK_SEND_BUDGET_PER_VIEWER_TICK) {
+                break;
             }
             int cx = ChunkPos.getX(packed);
             int cz = ChunkPos.getZ(packed);
@@ -485,6 +495,7 @@ public final class PortalStreamSyncService {
             );
             PortalStreamPerfStats.noteChunkPacket();
             sent.add(packed);
+            sentThisTick++;
         }
     }
 
@@ -559,8 +570,7 @@ public final class PortalStreamSyncService {
             SotoExteriorSampler.addStreamTickets(ctx.world(), ctx.anchorPos());
             SotoExteriorSampler.keepMobAiActive(ctx.world(), ctx.anchorPos());
         } else {
-            // Ticket-only while streaming; force-load only when sampling entities needs it.
-            BotiInteriorSampler.addFootprintTickets(ctx.world(), ctx.footprintOrigin());
+            BotiInteriorSampler.addStreamTickets(ctx.world(), ctx.footprintOrigin());
             BotiInteriorSampler.keepMobAiActive(ctx.world(), ctx.tardisId());
         }
     }
@@ -618,11 +628,12 @@ public final class PortalStreamSyncService {
             PortalShellState shell,
             PortalAtmosphere atmosphere
     ) {
-        int[] chunkBounds() {
+        int[] chunkBounds(ServerPlayer viewer) {
+            int radius = PortalSampler.streamRadiusChunks(viewer);
             if (kind == PortalStreamKind.SOTO) {
-                return SotoExteriorSampler.streamChunkBounds(anchorPos);
+                return SotoExteriorSampler.streamChunkBounds(anchorPos, radius);
             }
-            return BotiInteriorSampler.footprintChunkBounds(footprintOrigin);
+            return BotiInteriorSampler.streamChunkBounds(footprintOrigin, radius);
         }
 
         PortalStreamSample sampleChunk(int chunkX, int chunkZ) {

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -50,11 +50,14 @@ public final class PortalStreamSyncService {
     private static final int META_FLUSH_INTERVAL_TICKS = 3;
     private static final int ENTITY_UPDATE_INTERVAL_TICKS = 2;
     private static final int VIEWER_LEAVE_GRACE_TICKS = 40;
+    static final int MAX_BOTI_LIGHT_DEFER_TICKS = 40;
+    private static final int LIGHT_GATE_PASSED = -1;
 
     private static final Map<StreamKey, Set<UUID>> SUBSCRIBERS = new ConcurrentHashMap<>();
     private static final Map<ViewerKey, Set<Long>> SENT_CHUNKS = new ConcurrentHashMap<>();
     private static final Map<ViewerKey, Set<UUID>> TRACKED_ENTITIES = new ConcurrentHashMap<>();
     private static final Map<StreamKey, Set<Long>> DIRTY_CHUNKS = new ConcurrentHashMap<>();
+    private static final Map<StreamKey, Integer> BOTI_LIGHT_DEFER_STARTED = new ConcurrentHashMap<>();
     private static final Map<StreamKey, Integer> LEAVE_GRACE = new ConcurrentHashMap<>();
     private static final Set<UUID> META_DIRTY = ConcurrentHashMap.newKeySet();
     private static final Map<UUID, Integer> META_REVISIONS = new ConcurrentHashMap<>();
@@ -88,6 +91,7 @@ public final class PortalStreamSyncService {
         SENT_CHUNKS.clear();
         TRACKED_ENTITIES.clear();
         DIRTY_CHUNKS.clear();
+        BOTI_LIGHT_DEFER_STARTED.clear();
         LEAVE_GRACE.clear();
         META_DIRTY.clear();
         META_REVISIONS.clear();
@@ -117,6 +121,7 @@ public final class PortalStreamSyncService {
         BlockPos origin = TardisPlotAllocator.plotOrigin(tardisId);
         int[] bounds = BotiInteriorSampler.footprintChunkBounds(origin);
         StreamKey streamKey = new StreamKey(PortalStreamKind.BOTI, tardisId);
+        BOTI_LIGHT_DEFER_STARTED.remove(streamKey);
         Set<Long> dirty = DIRTY_CHUNKS.computeIfAbsent(streamKey, id -> ConcurrentHashMap.newKeySet());
         for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
             for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
@@ -299,8 +304,11 @@ public final class PortalStreamSyncService {
                 continue;
             }
             keepAlive(ctx);
-            if (kind == PortalStreamKind.BOTI
-                    && !BotiInteriorSampler.isFootprintLightReady(ctx.world(), ctx.footprintOrigin())) {
+            if (kind == PortalStreamKind.BOTI && shouldDeferBotiStream(
+                    streamKey,
+                    BotiInteriorSampler.isFootprintLightReady(ctx.world(), ctx.footprintOrigin()),
+                    tickCounter
+            )) {
                 continue;
             }
             for (ServerPlayer viewer : viewers) {
@@ -321,6 +329,42 @@ public final class PortalStreamSyncService {
                 key.kind() == kind && !registered.contains(key.tardisId()) && !active.contains(key.tardisId()));
     }
 
+    static boolean shouldDeferBotiStreamForTest(UUID tardisId, boolean lightReady, int currentTick) {
+        return shouldDeferBotiStream(new StreamKey(PortalStreamKind.BOTI, tardisId), lightReady, currentTick);
+    }
+
+    private static boolean shouldDeferBotiStream(StreamKey streamKey, boolean lightReady, int currentTick) {
+        Integer started = BOTI_LIGHT_DEFER_STARTED.get(streamKey);
+        if (started != null && started == LIGHT_GATE_PASSED) {
+            return false;
+        }
+        if (lightReady || (started != null && currentTick - started >= MAX_BOTI_LIGHT_DEFER_TICKS)) {
+            BOTI_LIGHT_DEFER_STARTED.put(streamKey, LIGHT_GATE_PASSED);
+            String reason = lightReady ? "ready" : "timeout";
+            // #region agent log
+            try {
+                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                        "{\"hypothesisId\":\"H,J\",\"location\":\"PortalStreamSyncService.shouldDeferBotiStream:pass\",\"message\":\"BOTI light gate passed\",\"data\":{\"reason\":\"" + reason + "\",\"waitedTicks\":" + (started == null ? 0 : currentTick - started) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+            } catch (java.io.IOException ignored) {
+            }
+            // #endregion
+            return false;
+        }
+        if (started == null) {
+            BOTI_LIGHT_DEFER_STARTED.put(streamKey, currentTick);
+            // #region agent log
+            try {
+                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
+                        "{\"hypothesisId\":\"H,J\",\"location\":\"PortalStreamSyncService.shouldDeferBotiStream:wait\",\"message\":\"BOTI light gate started\",\"data\":{\"maxWaitTicks\":" + MAX_BOTI_LIGHT_DEFER_TICKS + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
+                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
+            } catch (java.io.IOException ignored) {
+            }
+            // #endregion
+        }
+        return true;
+    }
+
     private static void handleNoViewers(MinecraftServer server, StreamKey streamKey) {
         int grace = LEAVE_GRACE.merge(streamKey, 1, Integer::sum);
         if (grace < VIEWER_LEAVE_GRACE_TICKS) {
@@ -329,6 +373,7 @@ public final class PortalStreamSyncService {
         unloadAllViewers(server, streamKey);
         SUBSCRIBERS.remove(streamKey);
         DIRTY_CHUNKS.remove(streamKey);
+        BOTI_LIGHT_DEFER_STARTED.remove(streamKey);
         LEAVE_GRACE.remove(streamKey);
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncService.java
@@ -340,27 +340,10 @@ public final class PortalStreamSyncService {
         }
         if (lightReady || (started != null && currentTick - started >= MAX_BOTI_LIGHT_DEFER_TICKS)) {
             BOTI_LIGHT_DEFER_STARTED.put(streamKey, LIGHT_GATE_PASSED);
-            String reason = lightReady ? "ready" : "timeout";
-            // #region agent log
-            try {
-                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                        "{\"hypothesisId\":\"H,J\",\"location\":\"PortalStreamSyncService.shouldDeferBotiStream:pass\",\"message\":\"BOTI light gate passed\",\"data\":{\"reason\":\"" + reason + "\",\"waitedTicks\":" + (started == null ? 0 : currentTick - started) + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-            } catch (java.io.IOException ignored) {
-            }
-            // #endregion
             return false;
         }
         if (started == null) {
             BOTI_LIGHT_DEFER_STARTED.put(streamKey, currentTick);
-            // #region agent log
-            try {
-                java.nio.file.Files.writeString(java.nio.file.Path.of("/opt/cursor/logs/debug.log"),
-                        "{\"hypothesisId\":\"H,J\",\"location\":\"PortalStreamSyncService.shouldDeferBotiStream:wait\",\"message\":\"BOTI light gate started\",\"data\":{\"maxWaitTicks\":" + MAX_BOTI_LIGHT_DEFER_TICKS + "},\"timestamp\":" + System.currentTimeMillis() + "}\n",
-                        java.nio.file.StandardOpenOption.CREATE, java.nio.file.StandardOpenOption.APPEND);
-            } catch (java.io.IOException ignored) {
-            }
-            // #endregion
         }
         return true;
     }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoAtmosphereColors.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoAtmosphereColors.java
@@ -130,4 +130,46 @@ public final class SotoAtmosphereColors {
         float h = Mth.square(1.0F - (1.0F - Mth.sin(g * (float) Math.PI)) * 0.99F);
         return ARGB.colorFromFloat(h, g * 0.3F + 0.7F, g * g * 0.7F + 0.2F, 0.2F);
     }
+
+    /**
+     * Overworld night floor from {@code minecraft:visual/sky_light_factor} (day timeline).
+     * Nether/End keep factor 0 so packed sky light does not wash out ambient.
+     */
+    public static final float NIGHT_SKY_LIGHT_FACTOR = 0.24F;
+    public static final int OVERWORLD_AMBIENT_LIGHT_COLOR = 0x0A0A0A;
+    public static final int NETHER_AMBIENT_LIGHT_COLOR = 0x302821;
+    public static final int END_AMBIENT_LIGHT_COLOR = 0x3F473F;
+
+    /**
+     * Lightmap {@code skyFactor}: overworld follows sun height with a 0.24 night floor,
+     * weather-blended toward that floor. Nether/End stay unlit by sky.
+     */
+    public static float skyLightFactor(EffectsKind kind, float skyAngle, float rainGradient, float thunderGradient) {
+        if (kind != EffectsKind.OVERWORLD) {
+            return 0.0F;
+        }
+        float factor = NIGHT_SKY_LIGHT_FACTOR + (1.0F - NIGHT_SKY_LIGHT_FACTOR) * sunHeight(skyAngle);
+        float weather = Math.max(clamp01(rainGradient) * 0.3125F, clamp01(thunderGradient) * 0.52734375F);
+        return Mth.lerp(weather, factor, NIGHT_SKY_LIGHT_FACTOR);
+    }
+
+    public static int ambientLightColor(EffectsKind kind) {
+        return switch (kind) {
+            case NETHER -> NETHER_AMBIENT_LIGHT_COLOR;
+            case END -> END_AMBIENT_LIGHT_COLOR;
+            case OVERWORLD -> OVERWORLD_AMBIENT_LIGHT_COLOR;
+        };
+    }
+
+    public static int skyLightColor(EffectsKind kind) {
+        return switch (kind) {
+            case NETHER -> 0x7A7AFF;
+            case END -> 0xAC60CD;
+            case OVERWORLD -> 0xFFFFFF;
+        };
+    }
+
+    private static float clamp01(float value) {
+        return Mth.clamp(value, 0.0F, 1.0F);
+    }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorIndex.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorIndex.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.tardis.soto;
 
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
@@ -85,9 +86,13 @@ public final class SotoExteriorIndex {
     }
 
     /**
-     * Resolves the TARDIS whose exterior footprint contains {@code worldPos} in {@code worldKey}.
+     * Resolves the TARDIS whose exterior stream contains {@code worldPos} in {@code worldKey}.
      */
     public static @Nullable UUID resolve(ResourceKey<Level> worldKey, BlockPos worldPos) {
+        return resolve(worldKey, worldPos, PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+    }
+
+    public static @Nullable UUID resolve(ResourceKey<Level> worldKey, BlockPos worldPos, int radiusChunks) {
         if (worldKey == null || worldPos == null) {
             return null;
         }
@@ -96,8 +101,7 @@ public final class SotoExteriorIndex {
             if (!key.worldKey().equals(worldKey)) {
                 continue;
             }
-            BlockPos footprintOrigin = SotoExteriorSampler.footprintOrigin(key.exteriorPos());
-            if (SotoExteriorSampler.isInsideFootprint(worldPos, footprintOrigin)) {
+            if (SotoExteriorSampler.isInsideStreamRadius(worldPos, key.exteriorPos(), radiusChunks)) {
                 return entry.getKey();
             }
         }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.tardis.soto;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
+import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import java.util.HashMap;
 import java.util.List;
@@ -200,7 +201,9 @@ public final class SotoExteriorSampler {
             int chunkZ
     ) {
         StreamChunkSample sample = sampleStreamChunk(exteriorWorld, exteriorPos, chunkX, chunkZ);
-        return new PortalStreamSample(sample.chunkX(), sample.chunkZ(), sample.blocks(), sample.blockEntities());
+        return new PortalStreamSample(
+                sample.chunkX(), sample.chunkZ(), sample.blocks(), sample.blockEntities(), sample.lightData()
+        );
     }
 
     /**
@@ -219,6 +222,8 @@ public final class SotoExteriorSampler {
         exteriorWorld.getChunk(chunkX, chunkZ);
         Map<BlockPos, BlockState> blocks = new HashMap<>();
         Map<BlockPos, CompoundTag> blockEntities = new HashMap<>();
+        int lowestVisibleY = Integer.MAX_VALUE;
+        int highestVisibleY = Integer.MIN_VALUE;
         HolderLookup.Provider registries = exteriorWorld.registryAccess();
         int minY = Math.max(exteriorWorld.getMinY(), exteriorPos.getY() - STREAM_Y_RADIUS);
         int maxY = Math.min(exteriorWorld.getMinY() + exteriorWorld.getHeight() - 1, exteriorPos.getY() + STREAM_Y_RADIUS);
@@ -235,6 +240,8 @@ public final class SotoExteriorSampler {
                     }
                     BlockPos immutable = mutable.immutable();
                     blocks.put(immutable, state);
+                    lowestVisibleY = Math.min(lowestVisibleY, y);
+                    highestVisibleY = Math.max(highestVisibleY, y);
                     BlockEntity blockEntity = exteriorWorld.getBlockEntity(mutable);
                     if (blockEntity != null) {
                         blockEntities.put(immutable, BotiInteriorSampler.captureSyncNbt(blockEntity, registries));
@@ -242,7 +249,17 @@ public final class SotoExteriorSampler {
                 }
             }
         }
-        return new StreamChunkSample(chunkX, chunkZ, blocks, blockEntities);
+        PortalLightData lightData = PortalLightData.EMPTY;
+        if (!blocks.isEmpty()) {
+            int lightMinY = Math.max(minY, lowestVisibleY - 1);
+            int lightMaxY = Math.min(maxY, highestVisibleY + 1);
+            lightData = PortalLightData.sample(
+                    exteriorWorld,
+                    new BlockPos(baseX, lightMinY, baseZ),
+                    new BlockPos(baseX + 15, lightMaxY, baseZ + 15)
+            );
+        }
+        return new StreamChunkSample(chunkX, chunkZ, blocks, blockEntities, lightData);
     }
 
     public static List<Entity> collectStreamEntities(ServerLevel exteriorWorld, BlockPos exteriorPos) {
@@ -258,15 +275,26 @@ public final class SotoExteriorSampler {
             int chunkX,
             int chunkZ,
             Map<BlockPos, BlockState> blocks,
-            Map<BlockPos, CompoundTag> blockEntities
+            Map<BlockPos, CompoundTag> blockEntities,
+            PortalLightData lightData
     ) {
+        public StreamChunkSample(
+                int chunkX,
+                int chunkZ,
+                Map<BlockPos, BlockState> blocks,
+                Map<BlockPos, CompoundTag> blockEntities
+        ) {
+            this(chunkX, chunkZ, blocks, blockEntities, PortalLightData.EMPTY);
+        }
+
         public StreamChunkSample {
             blocks = blocks == null ? Map.of() : Map.copyOf(blocks);
             blockEntities = blockEntities == null ? Map.of() : Map.copyOf(blockEntities);
+            lightData = lightData == null ? PortalLightData.EMPTY : lightData;
         }
 
         public static StreamChunkSample empty(int chunkX, int chunkZ) {
-            return new StreamChunkSample(chunkX, chunkZ, Map.of(), Map.of());
+            return new StreamChunkSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
         }
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
@@ -171,6 +171,11 @@ public final class SotoExteriorSampler extends PortalSampler {
     }
 
     @Override
+    protected boolean useSurfaceSkin() {
+        return true;
+    }
+
+    @Override
     protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
         addStreamTickets(world, anchor);
     }
@@ -189,14 +194,16 @@ public final class SotoExteriorSampler extends PortalSampler {
         if (blocks.isEmpty()) {
             return PortalLightData.EMPTY;
         }
+        YRange lightY = lightYRange(yRange, lowestVisibleY, highestVisibleY);
+        if (lightY.min() > lightY.max()) {
+            return PortalLightData.EMPTY;
+        }
         int baseX = chunkX << 4;
         int baseZ = chunkZ << 4;
-        int lightMinY = Math.max(yRange.min(), lowestVisibleY - 1);
-        int lightMaxY = Math.min(yRange.max(), highestVisibleY + 1);
         return PortalLightData.sample(
                 world.getLightEngine(),
-                new BlockPos(baseX, lightMinY, baseZ),
-                new BlockPos(baseX + 15, lightMaxY, baseZ + 15)
+                new BlockPos(baseX, lightY.min(), baseZ),
+                new BlockPos(baseX + 15, lightY.max(), baseZ + 15)
         );
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
@@ -9,18 +9,18 @@ import java.util.List;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.TicketType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
+import org.jetbrains.annotations.Nullable;
 
 /**
- * Exterior sampling helpers for SOTO: atmosphere, ghost stream geometry, and chunk samples.
- * Relative footprint coords: min corner = {@code exteriorPos + (-5, -1, -5)}; TARDIS at (5, 1, 5).
+ * Exterior sampling helpers for SOTO: atmosphere, hitch geometry, and chunk samples.
+ * Relative hitch coords: min corner = {@code exteriorPos + (-5, -1, -5)}; TARDIS at (5, 1, 5).
  *
- * <p>Ghost streaming uses a Chebyshev box sized from Minecraft view distance, ticketed at the
- * exterior chunk.
+ * <p>Ghost streaming uses a Chebyshev box sized from Minecraft view distance. LOADING tickets
+ * cover that radius; SIMULATION tickets use server simulation distance.
  */
 public final class SotoExteriorSampler extends PortalSampler {
     public static final int SIZE_X = 11;
@@ -33,12 +33,9 @@ public final class SotoExteriorSampler extends PortalSampler {
     /** Offset from exterior block pos to hitch footprint min corner. */
     public static final BlockPos FOOTPRINT_MIN_OFFSET = new BlockPos(-5, -1, -5);
 
-    private static final TicketType SOTO_TICKET = new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION);
-
     static final SotoExteriorSampler INSTANCE = new SotoExteriorSampler();
 
     private SotoExteriorSampler() {
-        super(SIZE_X, SIZE_Y, SIZE_Z, SOTO_TICKET);
     }
 
     public static BlockPos footprintOrigin(BlockPos exteriorPos) {
@@ -120,20 +117,20 @@ public final class SotoExteriorSampler extends PortalSampler {
     }
 
     /**
-     * Cheap probe: queries already-loaded entities in the stream box without force-loading chunks.
+     * Cheap probe: queries already-loaded entities in the simulation box without force-loading chunks.
      */
     public static boolean hasEntities(ServerLevel exteriorWorld, BlockPos exteriorPos) {
         return INSTANCE.hasLoadedEntities(exteriorWorld, exteriorPos);
     }
 
     /**
-     * Resets mob despawn counters in the stream box. Tickets only — no per-tick {@code getChunk}.
+     * Resets mob despawn counters in the simulation box. Tickets only — no per-tick {@code getChunk}.
      */
     public static void keepMobAiActive(ServerLevel exteriorWorld, BlockPos exteriorPos) {
         INSTANCE.resetMobAi(exteriorWorld, exteriorPos);
     }
 
-    public static PortalStreamSample samplePortalStreamChunk(
+    public static @Nullable PortalStreamSample samplePortalStreamChunk(
             ServerLevel exteriorWorld,
             BlockPos exteriorPos,
             int chunkX,
@@ -145,8 +142,10 @@ public final class SotoExteriorSampler extends PortalSampler {
     /**
      * Collects non-air visible block states (+ BE NBT) for one chunk column within stream Y range.
      * Positions in the returned maps are world-absolute.
+     *
+     * @return the sample, or {@code null} when the column is not yet {@code FULL}
      */
-    public static PortalStreamSample sampleStreamChunk(
+    public static @Nullable PortalStreamSample sampleStreamChunk(
             ServerLevel exteriorWorld,
             BlockPos exteriorPos,
             int chunkX,
@@ -160,25 +159,20 @@ public final class SotoExteriorSampler extends PortalSampler {
     }
 
     public static boolean isInsideFootprint(BlockPos worldPos, BlockPos footprintOrigin) {
-        return INSTANCE.inFootprint(worldPos, footprintOrigin);
+        if (worldPos == null || footprintOrigin == null) {
+            return false;
+        }
+        int localX = worldPos.getX() - footprintOrigin.getX();
+        int localY = worldPos.getY() - footprintOrigin.getY();
+        int localZ = worldPos.getZ() - footprintOrigin.getZ();
+        return localX >= 0 && localX < SIZE_X
+                && localY >= 0 && localY < SIZE_Y
+                && localZ >= 0 && localZ < SIZE_Z;
     }
 
     @Override
     protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
         addStreamTickets(world, anchor);
-    }
-
-    @Override
-    protected AABB entityBox(ServerLevel world, BlockPos anchor) {
-        return streamBox(anchor, PortalSampler.streamRadiusChunks(world));
-    }
-
-    @Override
-    protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
-        int yRadius = PortalSampler.streamYRadiusBlocks(PortalSampler.streamRadiusChunks(world));
-        int minY = Math.max(world.getMinY(), anchor.getY() - yRadius);
-        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + yRadius);
-        return yRange(minY, maxY);
     }
 
     @Override
@@ -200,7 +194,7 @@ public final class SotoExteriorSampler extends PortalSampler {
         int lightMinY = Math.max(yRange.min(), lowestVisibleY - 1);
         int lightMaxY = Math.min(yRange.max(), highestVisibleY + 1);
         return PortalLightData.sample(
-                world,
+                world.getLightEngine(),
                 new BlockPos(baseX, lightMinY, baseZ),
                 new BlockPos(baseX + 15, lightMaxY, baseZ + 15)
         );

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
@@ -1,29 +1,19 @@
 package com.adamkali.dwm.tardis.soto;
 
 import com.adamkali.dwm.block.DWMBlocks;
-import com.adamkali.dwm.tardis.boti.BotiInteriorSampler;
 import com.adamkali.dwm.tardis.portal.PortalAtmosphere;
 import com.adamkali.dwm.tardis.portal.PortalLightData;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.HolderLookup;
 import net.minecraft.core.SectionPos;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.resources.Identifier;
-import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
-import net.minecraft.world.attribute.EnvironmentAttributes;
 import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.Mob;
-import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
 import net.minecraft.world.phys.AABB;
 
 /**
@@ -33,7 +23,7 @@ import net.minecraft.world.phys.AABB;
  * <p>Phase 1 ghost streaming uses a separate {@link #STREAM_RADIUS_CHUNKS} ticketed box
  * for live entity keep-alive.
  */
-public final class SotoExteriorSampler {
+public final class SotoExteriorSampler extends PortalSampler {
     public static final int SIZE_X = 11;
     public static final int SIZE_Y = 7;
     public static final int SIZE_Z = 11;
@@ -52,7 +42,10 @@ public final class SotoExteriorSampler {
 
     private static final TicketType SOTO_TICKET = new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION);
 
+    static final SotoExteriorSampler INSTANCE = new SotoExteriorSampler();
+
     private SotoExteriorSampler() {
+        super(SIZE_X, SIZE_Y, SIZE_Z, SOTO_TICKET);
     }
 
     public static BlockPos footprintOrigin(BlockPos exteriorPos) {
@@ -65,6 +58,11 @@ public final class SotoExteriorSampler {
      * portal terrain comes from the ghost stream, which also skips the TARDIS block).
      */
     public static boolean isSotoVisible(BlockState state) {
+        return INSTANCE.isVisible(state);
+    }
+
+    @Override
+    public boolean isVisible(BlockState state) {
         return state != null
                 && !state.isAir()
                 && !state.is(Blocks.LIGHT)
@@ -72,35 +70,14 @@ public final class SotoExteriorSampler {
     }
 
     public static Map<BlockPos, BlockState> filterVisible(Map<BlockPos, BlockState> placements) {
-        Map<BlockPos, BlockState> visible = new HashMap<>();
-        for (Map.Entry<BlockPos, BlockState> entry : placements.entrySet()) {
-            if (isSotoVisible(entry.getValue())) {
-                visible.put(entry.getKey(), entry.getValue());
-            }
-        }
-        return visible;
+        return INSTANCE.filterVisibleBlocks(placements);
     }
 
     /**
      * Samples exterior sky/fog atmosphere at the TARDIS block (single biome point).
      */
     public static PortalAtmosphere sampleAtmosphere(ServerLevel exteriorWorld, BlockPos exteriorPos) {
-        Identifier effectsId = exteriorWorld.dimensionTypeRegistration()
-                .unwrapKey()
-                .map(ResourceKey::identifier)
-                .orElseGet(BuiltinDimensionTypes.OVERWORLD::identifier);
-        long timeOfDay = exteriorWorld.getOverworldClockTime();
-        float rain = exteriorWorld.getRainLevel(0.0f);
-        float thunder = exteriorWorld.getThunderLevel(0.0f);
-        var attrs = exteriorWorld.environmentAttributes();
-        return new PortalAtmosphere(
-                effectsId,
-                timeOfDay,
-                rain,
-                thunder,
-                attrs.getValue(EnvironmentAttributes.SKY_COLOR, exteriorPos),
-                attrs.getValue(EnvironmentAttributes.FOG_COLOR, exteriorPos)
-        );
+        return PortalSampler.sampleAtmosphere(exteriorWorld, exteriorPos);
     }
 
     /**
@@ -156,42 +133,21 @@ public final class SotoExteriorSampler {
         if (world == null || exteriorPos == null) {
             return;
         }
-        int[] bounds = streamChunkBounds(exteriorPos);
-        var chunkManager = world.getChunkSource();
-        for (int cx = bounds[0]; cx <= bounds[1]; cx++) {
-            for (int cz = bounds[2]; cz <= bounds[3]; cz++) {
-                ChunkPos chunkPos = new ChunkPos(cx, cz);
-                chunkManager.addTicketWithRadius(SOTO_TICKET, chunkPos, 2);
-            }
-        }
+        INSTANCE.addTickets(world, streamChunkBounds(exteriorPos));
     }
 
     /**
      * Cheap probe: queries already-loaded entities in the stream box without force-loading chunks.
      */
     public static boolean hasEntities(ServerLevel exteriorWorld, BlockPos exteriorPos) {
-        if (exteriorWorld == null || exteriorPos == null) {
-            return false;
-        }
-        return !exteriorWorld.getEntities((Entity) null, streamBox(exteriorPos), entity -> !entity.isRemoved()).isEmpty();
+        return INSTANCE.hasLoadedEntities(exteriorWorld, exteriorPos);
     }
 
     /**
      * Resets mob despawn counters in the stream box. Tickets only — no per-tick {@code getChunk}.
      */
     public static void keepMobAiActive(ServerLevel exteriorWorld, BlockPos exteriorPos) {
-        if (exteriorWorld == null || exteriorPos == null) {
-            return;
-        }
-        if (!exteriorWorld.players().isEmpty()) {
-            return;
-        }
-        addStreamTickets(exteriorWorld, exteriorPos);
-        for (Entity entity : exteriorWorld.getEntities((Entity) null, streamBox(exteriorPos), e -> !e.isRemoved())) {
-            if (entity instanceof Mob mob && mob.getNoActionTime() != 0) {
-                mob.setNoActionTime(0);
-            }
-        }
+        INSTANCE.resetMobAi(exteriorWorld, exteriorPos);
     }
 
     public static PortalStreamSample samplePortalStreamChunk(
@@ -200,110 +156,69 @@ public final class SotoExteriorSampler {
             int chunkX,
             int chunkZ
     ) {
-        StreamChunkSample sample = sampleStreamChunk(exteriorWorld, exteriorPos, chunkX, chunkZ);
-        return new PortalStreamSample(
-                sample.chunkX(), sample.chunkZ(), sample.blocks(), sample.blockEntities(), sample.lightData()
-        );
+        return sampleStreamChunk(exteriorWorld, exteriorPos, chunkX, chunkZ);
     }
 
     /**
      * Collects non-air visible block states (+ BE NBT) for one chunk column within stream Y range.
      * Positions in the returned maps are world-absolute.
      */
-    public static StreamChunkSample sampleStreamChunk(
+    public static PortalStreamSample sampleStreamChunk(
             ServerLevel exteriorWorld,
             BlockPos exteriorPos,
             int chunkX,
             int chunkZ
     ) {
-        if (exteriorWorld == null || exteriorPos == null) {
-            return StreamChunkSample.empty(chunkX, chunkZ);
-        }
-        exteriorWorld.getChunk(chunkX, chunkZ);
-        Map<BlockPos, BlockState> blocks = new HashMap<>();
-        Map<BlockPos, CompoundTag> blockEntities = new HashMap<>();
-        int lowestVisibleY = Integer.MAX_VALUE;
-        int highestVisibleY = Integer.MIN_VALUE;
-        HolderLookup.Provider registries = exteriorWorld.registryAccess();
-        int minY = Math.max(exteriorWorld.getMinY(), exteriorPos.getY() - STREAM_Y_RADIUS);
-        int maxY = Math.min(exteriorWorld.getMinY() + exteriorWorld.getHeight() - 1, exteriorPos.getY() + STREAM_Y_RADIUS);
-        BlockPos.MutableBlockPos mutable = new BlockPos.MutableBlockPos();
-        int baseX = chunkX << 4;
-        int baseZ = chunkZ << 4;
-        for (int lx = 0; lx < 16; lx++) {
-            for (int lz = 0; lz < 16; lz++) {
-                for (int y = minY; y <= maxY; y++) {
-                    mutable.set(baseX + lx, y, baseZ + lz);
-                    BlockState state = exteriorWorld.getBlockState(mutable);
-                    if (!isSotoVisible(state)) {
-                        continue;
-                    }
-                    BlockPos immutable = mutable.immutable();
-                    blocks.put(immutable, state);
-                    lowestVisibleY = Math.min(lowestVisibleY, y);
-                    highestVisibleY = Math.max(highestVisibleY, y);
-                    BlockEntity blockEntity = exteriorWorld.getBlockEntity(mutable);
-                    if (blockEntity != null) {
-                        blockEntities.put(immutable, BotiInteriorSampler.captureSyncNbt(blockEntity, registries));
-                    }
-                }
-            }
-        }
-        PortalLightData lightData = PortalLightData.EMPTY;
-        if (!blocks.isEmpty()) {
-            int lightMinY = Math.max(minY, lowestVisibleY - 1);
-            int lightMaxY = Math.min(maxY, highestVisibleY + 1);
-            lightData = PortalLightData.sample(
-                    exteriorWorld,
-                    new BlockPos(baseX, lightMinY, baseZ),
-                    new BlockPos(baseX + 15, lightMaxY, baseZ + 15)
-            );
-        }
-        return new StreamChunkSample(chunkX, chunkZ, blocks, blockEntities, lightData);
+        return INSTANCE.sampleChunkColumn(exteriorWorld, exteriorPos, chunkX, chunkZ);
     }
 
     public static List<Entity> collectStreamEntities(ServerLevel exteriorWorld, BlockPos exteriorPos) {
-        if (exteriorWorld == null || exteriorPos == null) {
-            return List.of();
-        }
-        addStreamTickets(exteriorWorld, exteriorPos);
-        return List.copyOf(exteriorWorld.getEntities((Entity) null, streamBox(exteriorPos), entity -> !entity.isRemoved()));
-    }
-
-    /** One streamed chunk column for ghost sync. */
-    public record StreamChunkSample(
-            int chunkX,
-            int chunkZ,
-            Map<BlockPos, BlockState> blocks,
-            Map<BlockPos, CompoundTag> blockEntities,
-            PortalLightData lightData
-    ) {
-        public StreamChunkSample(
-                int chunkX,
-                int chunkZ,
-                Map<BlockPos, BlockState> blocks,
-                Map<BlockPos, CompoundTag> blockEntities
-        ) {
-            this(chunkX, chunkZ, blocks, blockEntities, PortalLightData.EMPTY);
-        }
-
-        public StreamChunkSample {
-            blocks = blocks == null ? Map.of() : Map.copyOf(blocks);
-            blockEntities = blockEntities == null ? Map.of() : Map.copyOf(blockEntities);
-            lightData = lightData == null ? PortalLightData.EMPTY : lightData;
-        }
-
-        public static StreamChunkSample empty(int chunkX, int chunkZ) {
-            return new StreamChunkSample(chunkX, chunkZ, Map.of(), Map.of(), PortalLightData.EMPTY);
-        }
+        return INSTANCE.collectEntities(exteriorWorld, exteriorPos);
     }
 
     public static boolean isInsideFootprint(BlockPos worldPos, BlockPos footprintOrigin) {
-        int localX = worldPos.getX() - footprintOrigin.getX();
-        int localY = worldPos.getY() - footprintOrigin.getY();
-        int localZ = worldPos.getZ() - footprintOrigin.getZ();
-        return localX >= 0 && localX < SIZE_X
-                && localY >= 0 && localY < SIZE_Y
-                && localZ >= 0 && localZ < SIZE_Z;
+        return INSTANCE.inFootprint(worldPos, footprintOrigin);
+    }
+
+    @Override
+    protected void ensureLoaded(ServerLevel world, BlockPos anchor) {
+        addStreamTickets(world, anchor);
+    }
+
+    @Override
+    protected AABB entityBox(BlockPos anchor) {
+        return streamBox(anchor);
+    }
+
+    @Override
+    protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
+        int minY = Math.max(world.getMinY(), anchor.getY() - STREAM_Y_RADIUS);
+        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + STREAM_Y_RADIUS);
+        return yRange(minY, maxY);
+    }
+
+    @Override
+    protected PortalLightData sampleLight(
+            ServerLevel world,
+            BlockPos anchor,
+            int chunkX,
+            int chunkZ,
+            YRange yRange,
+            Map<BlockPos, BlockState> blocks,
+            int lowestVisibleY,
+            int highestVisibleY
+    ) {
+        if (blocks.isEmpty()) {
+            return PortalLightData.EMPTY;
+        }
+        int baseX = chunkX << 4;
+        int baseZ = chunkZ << 4;
+        int lightMinY = Math.max(yRange.min(), lowestVisibleY - 1);
+        int lightMaxY = Math.min(yRange.max(), highestVisibleY + 1);
+        return PortalLightData.sample(
+                world,
+                new BlockPos(baseX, lightMinY, baseZ),
+                new BlockPos(baseX + 15, lightMaxY, baseZ + 15)
+        );
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/soto/SotoExteriorSampler.java
@@ -8,7 +8,6 @@ import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import java.util.List;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
-import net.minecraft.core.SectionPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.world.entity.Entity;
@@ -20,24 +19,18 @@ import net.minecraft.world.phys.AABB;
  * Exterior sampling helpers for SOTO: atmosphere, ghost stream geometry, and chunk samples.
  * Relative footprint coords: min corner = {@code exteriorPos + (-5, -1, -5)}; TARDIS at (5, 1, 5).
  *
- * <p>Phase 1 ghost streaming uses a separate {@link #STREAM_RADIUS_CHUNKS} ticketed box
- * for live entity keep-alive.
+ * <p>Ghost streaming uses a Chebyshev box sized from Minecraft view distance, ticketed at the
+ * exterior chunk.
  */
 public final class SotoExteriorSampler extends PortalSampler {
     public static final int SIZE_X = 11;
     public static final int SIZE_Y = 7;
     public static final int SIZE_Z = 11;
 
-    /** Half-side of ghost stream radius in chunks (Chebyshev). Cap for Phase 1. */
-    public static final int STREAM_RADIUS_CHUNKS = 2;
-
-    /** Vertical half-extent (blocks) around the exterior for stream sampling / entity AABB. */
-    public static final int STREAM_Y_RADIUS = 48;
-
-    /** Relative position of the exterior TARDIS block within the footprint. */
+    /** Relative position of the exterior TARDIS block within the hitch footprint. */
     public static final BlockPos RELATIVE_TARDIS_POS = new BlockPos(5, 1, 5);
 
-    /** Offset from exterior block pos to footprint min corner. */
+    /** Offset from exterior block pos to hitch footprint min corner. */
     public static final BlockPos FOOTPRINT_MIN_OFFSET = new BlockPos(-5, -1, -5);
 
     private static final TicketType SOTO_TICKET = new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION);
@@ -81,48 +74,38 @@ public final class SotoExteriorSampler extends PortalSampler {
     }
 
     /**
-     * Chunk bounds for ghost streaming: Chebyshev radius {@link #STREAM_RADIUS_CHUNKS}
-     * around the exterior block's chunk. Returns {@code [minCX, maxCX, minCZ, maxCZ]}.
+     * Chunk bounds for ghost streaming: Chebyshev radius around the exterior block's chunk.
+     * Returns {@code [minCX, maxCX, minCZ, maxCZ]}.
      */
+    public static int[] streamChunkBounds(BlockPos exteriorPos, int radiusChunks) {
+        return PortalSampler.streamChunkBounds(exteriorPos, radiusChunks);
+    }
+
     public static int[] streamChunkBounds(BlockPos exteriorPos) {
-        int cx = SectionPos.blockToSectionCoord(exteriorPos.getX());
-        int cz = SectionPos.blockToSectionCoord(exteriorPos.getZ());
-        return new int[]{
-                cx - STREAM_RADIUS_CHUNKS,
-                cx + STREAM_RADIUS_CHUNKS,
-                cz - STREAM_RADIUS_CHUNKS,
-                cz + STREAM_RADIUS_CHUNKS
-        };
+        return streamChunkBounds(exteriorPos, PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+    }
+
+    public static int[] streamChunkBounds(ServerLevel world, BlockPos exteriorPos) {
+        return streamChunkBounds(exteriorPos, PortalSampler.streamRadiusChunks(world));
     }
 
     /** Axis-aligned box covering the ghost stream radius (horizontal chunks + vertical radius). */
+    public static AABB streamBox(BlockPos exteriorPos, int radiusChunks) {
+        return PortalSampler.streamBox(
+                exteriorPos, radiusChunks, PortalSampler.streamYRadiusBlocks(radiusChunks));
+    }
+
     public static AABB streamBox(BlockPos exteriorPos) {
-        int half = STREAM_RADIUS_CHUNKS * 16;
-        return new AABB(
-                exteriorPos.getX() - half,
-                exteriorPos.getY() - STREAM_Y_RADIUS,
-                exteriorPos.getZ() - half,
-                exteriorPos.getX() + half + 1,
-                exteriorPos.getY() + STREAM_Y_RADIUS + 1,
-                exteriorPos.getZ() + half + 1
-        );
+        return streamBox(exteriorPos, PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+    }
+
+    public static boolean isInsideStreamRadius(BlockPos worldPos, BlockPos exteriorPos, int radiusChunks) {
+        return PortalSampler.isInsideStreamRadius(
+                worldPos, exteriorPos, radiusChunks, PortalSampler.streamYRadiusBlocks(radiusChunks));
     }
 
     public static boolean isInsideStreamRadius(BlockPos worldPos, BlockPos exteriorPos) {
-        if (worldPos == null || exteriorPos == null) {
-            return false;
-        }
-        int cx = SectionPos.blockToSectionCoord(worldPos.getX());
-        int cz = SectionPos.blockToSectionCoord(worldPos.getZ());
-        int ecx = SectionPos.blockToSectionCoord(exteriorPos.getX());
-        int ecz = SectionPos.blockToSectionCoord(exteriorPos.getZ());
-        int dx = Math.abs(cx - ecx);
-        int dz = Math.abs(cz - ecz);
-        if (dx > STREAM_RADIUS_CHUNKS || dz > STREAM_RADIUS_CHUNKS) {
-            return false;
-        }
-        int dy = Math.abs(worldPos.getY() - exteriorPos.getY());
-        return dy <= STREAM_Y_RADIUS;
+        return isInsideStreamRadius(worldPos, exteriorPos, PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
     }
 
     /**
@@ -133,7 +116,7 @@ public final class SotoExteriorSampler extends PortalSampler {
         if (world == null || exteriorPos == null) {
             return;
         }
-        INSTANCE.addTickets(world, streamChunkBounds(exteriorPos));
+        INSTANCE.addStreamTickets(world, exteriorPos, PortalSampler.streamRadiusChunks(world));
     }
 
     /**
@@ -186,14 +169,15 @@ public final class SotoExteriorSampler extends PortalSampler {
     }
 
     @Override
-    protected AABB entityBox(BlockPos anchor) {
-        return streamBox(anchor);
+    protected AABB entityBox(ServerLevel world, BlockPos anchor) {
+        return streamBox(anchor, PortalSampler.streamRadiusChunks(world));
     }
 
     @Override
     protected YRange sampleYRange(ServerLevel world, BlockPos anchor) {
-        int minY = Math.max(world.getMinY(), anchor.getY() - STREAM_Y_RADIUS);
-        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + STREAM_Y_RADIUS);
+        int yRadius = PortalSampler.streamYRadiusBlocks(PortalSampler.streamRadiusChunks(world));
+        int minY = Math.max(world.getMinY(), anchor.getY() - yRadius);
+        int maxY = Math.min(world.getMinY() + world.getHeight() - 1, anchor.getY() + yRadius);
         return yRange(minY, maxY);
     }
 

--- a/dwm/src/main/resources/dwm.accesswidener
+++ b/dwm/src/main/resources/dwm.accesswidener
@@ -3,3 +3,5 @@ accessible	method	net/minecraft/world/level/levelgen/NoiseRouterData	overworld	(
 accessible	method	net/minecraft/client/Camera	setPosition	(DDD)V
 accessible	method	net/minecraft/client/Camera	setPosition	(Lnet/minecraft/world/phys/Vec3;)V
 accessible	method	net/minecraft/client/Camera	setRotation	(FF)V
+accessible	field	net/minecraft/client/renderer/GameRenderer	lightmap	Lnet/minecraft/client/renderer/Lightmap;
+accessible	field	net/minecraft/client/renderer/GameRenderer	gameRenderState	Lnet/minecraft/client/renderer/state/GameRenderState;

--- a/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
+++ b/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
@@ -10,6 +10,7 @@ steps:
       difficulty: peaceful
       seed: "42"
   - closeScreen
+  - runCommand: "/gamerule sendCommandFeedback false"
   - runCommand: "/gamerule doDaylightCycle false"
   - runCommand: "/gamerule doWeatherCycle false"
   - runCommand: "/gamerule doMobSpawning false"
@@ -41,7 +42,7 @@ steps:
       y: "~"
       z: "~"
   - useItem
-  - waitTicks: 80
+  - waitTicks: 200
   - runCommand: "/tp @s ~-3 ~1 ~"
   - lookAt:
       x: "~3"
@@ -51,9 +52,11 @@ steps:
   - captureScreenshot:
       name: portal-lighting-fog-boti
       compare: true
+  # Switch the exterior to day so SOTO exercises streamed sky light as well as the sea-lantern source.
+  - runCommand: "/time set day"
   - walkUntil:
       dimension: dwm:tardis
-  - waitTicks: 80
+  - waitTicks: 160
   - runCommand: "/tp @s ~ ~ ~4"
   - lookAt:
       yaw: 180

--- a/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
+++ b/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
@@ -1,0 +1,64 @@
+---
+name: Portal Lighting and Fog
+type: test
+---
+steps:
+  - launchGame
+  - createWorld:
+      worldType: superflat
+      gameMode: creative
+      difficulty: peaceful
+      seed: "42"
+  - closeScreen
+  - runCommand: "/gamerule doDaylightCycle false"
+  - runCommand: "/gamerule doWeatherCycle false"
+  - runCommand: "/gamerule doMobSpawning false"
+  - runCommand: "/time set midnight"
+  - runCommand: "/weather clear"
+  - runCommand: "/kill @e[type=!minecraft:player]"
+  # Near emissive marker and far pale wall make SOTO light falloff and 20–30 block fog visible.
+  - runCommand: "/fill ~-10 ~ ~-2 ~-10 ~4 ~2 minecraft:deepslate_tiles"
+  - runCommand: "/setblock ~-9 ~2 ~ minecraft:sea_lantern"
+  - runCommand: "/fill ~-29 ~ ~-2 ~-29 ~4 ~2 minecraft:white_concrete"
+  - runCommand: "/give @s dwm:tardis_block"
+  - waitUntil:
+      holding: dwm:tardis_block
+  - selectHotbar: 0
+  - lookAt:
+      x: "~1"
+      y: "~-1"
+      z: "~"
+  - useItem
+  - waitUntil:
+      block:
+        id: dwm:tardis_block
+        x: "~1"
+        y: "~"
+        z: "~"
+  - selectHotbar: 1
+  - lookAt:
+      x: "~1"
+      y: "~"
+      z: "~"
+  - useItem
+  - waitTicks: 80
+  - runCommand: "/tp @s ~-3 ~1 ~"
+  - lookAt:
+      x: "~3"
+      y: "~"
+      z: "~"
+  - waitTicks: 20
+  - captureScreenshot:
+      name: portal-lighting-fog-boti
+      compare: true
+  - walkUntil:
+      dimension: dwm:tardis
+  - waitTicks: 80
+  - runCommand: "/tp @s ~ ~ ~4"
+  - lookAt:
+      yaw: 180
+      pitch: 0
+  - waitTicks: 20
+  - captureScreenshot:
+      name: portal-lighting-fog-soto
+      compare: true

--- a/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
+++ b/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
@@ -42,13 +42,12 @@ steps:
       y: "~"
       z: "~"
   - useItem
-  - waitTicks: 200
   - runCommand: "/tp @s ~-3 ~1 ~"
   - lookAt:
       x: "~3"
       y: "~"
       z: "~"
-  - waitTicks: 20
+  - waitTicks: 200
   - captureScreenshot:
       name: portal-lighting-fog-boti
       compare: true
@@ -56,12 +55,11 @@ steps:
   - runCommand: "/time set day"
   - walkUntil:
       dimension: dwm:tardis
-  - waitTicks: 160
   - runCommand: "/tp @s ~ ~ ~4"
   - lookAt:
       yaw: 180
       pitch: 0
-  - waitTicks: 20
+  - waitTicks: 160
   - captureScreenshot:
       name: portal-lighting-fog-soto
       compare: true

--- a/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
+++ b/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
@@ -59,7 +59,7 @@ steps:
   - lookAt:
       yaw: 180
       pitch: 0
-  - waitTicks: 160
+  - waitTicks: 240
   - captureScreenshot:
       name: portal-lighting-fog-soto
       compare: true

--- a/dwm/src/test/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayloadTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/network/SyncPortalChunkS2CPayloadTest.java
@@ -2,6 +2,7 @@ package com.adamkali.dwm.network;
 
 import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.tardis.boti.BotiRelativePosCodec;
+import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,6 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,7 +33,8 @@ class SyncPortalChunkS2CPayloadTest {
                 worldPos.getX() >> 4,
                 worldPos.getZ() >> 4,
                 Map.of(worldPos, Blocks.STONE.defaultBlockState()),
-                Map.of()
+                Map.of(),
+                new PortalLightData(worldPos, 1, 1, 1, new byte[]{PortalLightData.pack(3, 11)})
         );
 
         for (PortalStreamKind kind : PortalStreamKind.values()) {
@@ -46,6 +49,9 @@ class SyncPortalChunkS2CPayloadTest {
             assertEquals(4, payload.blocks().getFirst().relZ());
             assertEquals(BotiRelativePosCodec.stateId(Blocks.STONE.defaultBlockState()), payload.blocks().getFirst().stateId());
             assertEquals(Blocks.STONE, payload.toBlockMap().get(new BlockPos(3, 2, 4)).getBlock());
+            assertEquals(new BlockPos(3, 2, 4), payload.lightData().min());
+            assertEquals(3, payload.lightData().brightness(LightLayer.BLOCK, new BlockPos(3, 2, 4), -1));
+            assertEquals(11, payload.lightData().brightness(LightLayer.SKY, new BlockPos(3, 2, 4), -1));
             assertEquals(SyncPortalChunkS2CPayload.ID, payload.type());
         }
     }

--- a/dwm/src/test/java/com/adamkali/dwm/render/portal/PortalFogRendererTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/render/portal/PortalFogRendererTest.java
@@ -1,0 +1,33 @@
+package com.adamkali.dwm.render.portal;
+
+import net.minecraft.client.renderer.fog.FogData;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class PortalFogRendererTest {
+    @Test
+    void buildFogData_appliesColorAndDistanceToEveryWorldFogRange() {
+        FogData fog = PortalFogRenderer.buildFogData(7.0F, 17.0F, 0.2F, 0.3F, 0.4F);
+
+        assertEquals(7.0F, fog.environmentalStart);
+        assertEquals(17.0F, fog.environmentalEnd);
+        assertEquals(7.0F, fog.renderDistanceStart);
+        assertEquals(17.0F, fog.renderDistanceEnd);
+        assertEquals(17.0F, fog.skyEnd);
+        assertEquals(17.0F, fog.cloudEnd);
+        assertEquals(0.2F, fog.color.x);
+        assertEquals(0.3F, fog.color.y);
+        assertEquals(0.4F, fog.color.z);
+        assertEquals(1.0F, fog.color.w);
+    }
+
+    @Test
+    void buildFogData_rejectsInvalidRange() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> PortalFogRenderer.buildFogData(10.0F, 10.0F, 0.0F, 0.0F, 0.0F)
+        );
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/render/portal/PortalLightmapTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/render/portal/PortalLightmapTest.java
@@ -1,0 +1,57 @@
+package com.adamkali.dwm.render.portal;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.adamkali.dwm.tardis.soto.SotoAtmosphere;
+import net.minecraft.client.renderer.state.LightmapRenderState;
+import net.minecraft.world.level.dimension.BuiltinDimensionTypes;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PortalLightmapTest {
+
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+    }
+
+    @Test
+    void overlay_overworldDayRaisesSkyFactor() {
+        LightmapRenderState state = new LightmapRenderState();
+        state.skyFactor = 0.0f;
+        SotoAtmosphere atmosphere = new SotoAtmosphere(
+                BuiltinDimensionTypes.OVERWORLD.identifier(),
+                6000L,
+                0.0f,
+                0.0f,
+                0x78A7FF,
+                0xC0D8FF
+        );
+        PortalLightmap.overlay(state, atmosphere);
+        assertTrue(state.needsUpdate);
+        assertTrue(state.skyFactor > 0.9f, "day overlay sky factor was " + state.skyFactor);
+        assertEquals(0x0A / 255.0f, state.ambientColor.x(), 0.01f);
+        assertEquals(0x0A / 255.0f, state.ambientColor.y(), 0.01f);
+        assertEquals(0x0A / 255.0f, state.ambientColor.z(), 0.01f);
+    }
+
+    @Test
+    void overlay_netherKeepsSkyFactorZeroAndSetsAmbient() {
+        LightmapRenderState state = new LightmapRenderState();
+        state.skyFactor = 1.0f;
+        SotoAtmosphere atmosphere = new SotoAtmosphere(
+                BuiltinDimensionTypes.NETHER.identifier(),
+                6000L,
+                0.0f,
+                0.0f,
+                0x330808,
+                0x330808
+        );
+        PortalLightmap.overlay(state, atmosphere);
+        assertEquals(0.0f, state.skyFactor, 1e-4f);
+        assertEquals(0x30 / 255.0f, state.ambientColor.x(), 0.01f);
+        assertEquals(0x28 / 255.0f, state.ambientColor.y(), 0.01f);
+        assertEquals(0x21 / 255.0f, state.ambientColor.z(), 0.01f);
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/render/soto/ghost/SotoGhostExteriorTest.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.render.soto.ghost;
 import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.network.SyncPortalChunkS2CPayload;
 import com.adamkali.dwm.tardis.boti.BotiRelativePosCodec;
+import com.adamkali.dwm.tardis.portal.PortalLightData;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,6 +14,7 @@ import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
@@ -73,10 +75,39 @@ class SotoGhostExteriorTest {
         Map<BlockPos, BlockState> blocksC = Map.of(pos, Blocks.DIRT.defaultBlockState());
         Map<BlockPos, CompoundTag> bes = Map.of(pos, new CompoundTag());
 
-        assertTrue(SotoGhostExterior.chunkContentUnchanged(blocksA, blocksB, null, null));
-        assertTrue(SotoGhostExterior.chunkContentUnchanged(null, Map.of(), null, Map.of()));
-        assertFalse(SotoGhostExterior.chunkContentUnchanged(blocksA, blocksC, null, null));
-        assertFalse(SotoGhostExterior.chunkContentUnchanged(blocksA, blocksB, null, bes));
+        assertTrue(SotoGhostExterior.chunkContentUnchanged(
+                blocksA, blocksB, null, null, PortalLightData.EMPTY, PortalLightData.EMPTY));
+        assertTrue(SotoGhostExterior.chunkContentUnchanged(
+                null, Map.of(), null, Map.of(), PortalLightData.EMPTY, PortalLightData.EMPTY));
+        assertFalse(SotoGhostExterior.chunkContentUnchanged(
+                blocksA, blocksC, null, null, PortalLightData.EMPTY, PortalLightData.EMPTY));
+        assertFalse(SotoGhostExterior.chunkContentUnchanged(
+                blocksA, blocksB, null, bes, PortalLightData.EMPTY, PortalLightData.EMPTY));
+    }
+
+    @Test
+    void applyChunk_exposesSampledBlockAndSkyLight() {
+        UUID id = UUID.randomUUID();
+        BlockPos rel = new BlockPos(2, 1, 3);
+        PortalLightData light = new PortalLightData(
+                rel, 1, 1, 1, new byte[]{PortalLightData.pack(5, 9)}
+        );
+        SyncPortalChunkS2CPayload payload = new SyncPortalChunkS2CPayload(
+                PortalStreamKind.BOTI, id, 6, 12, 100, 64, 200,
+                List.of(new SyncPortalChunkS2CPayload.BlockEntry(
+                        rel.getX(), rel.getY(), rel.getZ(),
+                        BotiRelativePosCodec.stateId(Blocks.STONE.defaultBlockState())
+                )),
+                List.of(),
+                light
+        );
+
+        SotoGhostExterior.applyChunk(PortalStreamKind.BOTI, payload);
+
+        SotoGhostExterior ghost = SotoGhostExterior.get(PortalStreamKind.BOTI, id);
+        assertNotNull(ghost);
+        assertEquals(5, ghost.getBrightness(LightLayer.BLOCK, rel));
+        assertEquals(9, ghost.getBrightness(LightLayer.SKY, rel));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
@@ -105,6 +105,37 @@ class BotiInteriorSamplerTest {
     }
 
     @Test
+    void streamChunkBounds_clipsViewDistanceToPlot() {
+        BlockPos origin = new BlockPos(0, 64, 0);
+        int[] plot = BotiInteriorSampler.plotChunkBounds(origin);
+        int[] clipped = BotiInteriorSampler.streamChunkBounds(origin, 12);
+        assertEquals(plot[0], clipped[0]);
+        assertEquals(plot[1], clipped[1]);
+        assertEquals(plot[2], clipped[2]);
+        assertEquals(plot[3], clipped[3]);
+        assertTrue(clipped[1] - clipped[0] < 12);
+    }
+
+    @Test
+    void clipStreamRadiusChunks_capsToPlot() {
+        assertEquals(0, BotiInteriorSampler.clipStreamRadiusChunks(0));
+        assertEquals(2, BotiInteriorSampler.clipStreamRadiusChunks(2));
+        assertTrue(BotiInteriorSampler.clipStreamRadiusChunks(12) <= 3);
+        assertEquals(
+                BotiInteriorSampler.clipStreamRadiusChunks(3),
+                BotiInteriorSampler.clipStreamRadiusChunks(32)
+        );
+    }
+
+    @Test
+    void isInsidePlotStream_rejectsNeighborPlot() {
+        BlockPos origin = new BlockPos(0, 64, 0);
+        assertTrue(BotiInteriorSampler.isInsidePlotStream(origin, origin, 2));
+        assertFalse(BotiInteriorSampler.isInsidePlotStream(
+                origin.offset(TardisPlotAllocator.PLOT_SPACING, 0, 0), origin, 12));
+    }
+
+    @Test
     void isFootprintLightReady_waitsForStampedSourceBrightness() {
         ServerLevel world = Mockito.mock(ServerLevel.class);
         BlockPos origin = new BlockPos(15, 64, 15);

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
@@ -18,10 +18,9 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EntityTypes;
-import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.phys.AABB;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -106,17 +105,20 @@ class BotiInteriorSamplerTest {
     }
 
     @Test
-    void isFootprintLightReady_waitsForEveryChunkColumn() {
+    void isFootprintLightReady_waitsForStampedSourceBrightness() {
         ServerLevel world = Mockito.mock(ServerLevel.class);
-        LevelLightEngine lightEngine = Mockito.mock(LevelLightEngine.class);
-        BlockPos origin = new BlockPos(15, 64, 15); // four footprint columns
-        Mockito.when(world.getLightEngine()).thenReturn(lightEngine);
-        Mockito.when(lightEngine.lightOnInColumn(Mockito.anyLong())).thenReturn(true);
+        BlockPos origin = new BlockPos(15, 64, 15);
+        BlockPos sourcePos = origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3));
+        Mockito.when(world.getBlockState(sourcePos)).thenReturn(Blocks.AIR.defaultBlockState());
 
-        assertTrue(BotiInteriorSampler.isFootprintLightReady(world, origin));
-
-        Mockito.when(lightEngine.lightOnInColumn(ChunkPos.pack(1, 1))).thenReturn(false);
         assertFalse(BotiInteriorSampler.isFootprintLightReady(world, origin));
+
+        Mockito.when(world.getBlockState(sourcePos)).thenReturn(Blocks.LIGHT.defaultBlockState());
+        Mockito.when(world.getBrightness(LightLayer.BLOCK, sourcePos)).thenReturn(0);
+        assertFalse(BotiInteriorSampler.isFootprintLightReady(world, origin));
+
+        Mockito.when(world.getBrightness(LightLayer.BLOCK, sourcePos)).thenReturn(15);
+        assertTrue(BotiInteriorSampler.isFootprintLightReady(world, origin));
         assertFalse(BotiInteriorSampler.isFootprintLightReady(null, origin));
         assertFalse(BotiInteriorSampler.isFootprintLightReady(world, null));
     }

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
@@ -15,10 +15,13 @@ import java.util.Map;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.EntityTypes;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.lighting.LevelLightEngine;
 import net.minecraft.world.phys.AABB;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -100,6 +103,22 @@ class BotiInteriorSamplerTest {
         assertEquals(1, bounds[1]);
         assertEquals(0, bounds[2]);
         assertEquals(1, bounds[3]);
+    }
+
+    @Test
+    void isFootprintLightReady_waitsForEveryChunkColumn() {
+        ServerLevel world = Mockito.mock(ServerLevel.class);
+        LevelLightEngine lightEngine = Mockito.mock(LevelLightEngine.class);
+        BlockPos origin = new BlockPos(15, 64, 15); // four footprint columns
+        Mockito.when(world.getLightEngine()).thenReturn(lightEngine);
+        Mockito.when(lightEngine.lightOnInColumn(Mockito.anyLong())).thenReturn(true);
+
+        assertTrue(BotiInteriorSampler.isFootprintLightReady(world, origin));
+
+        Mockito.when(lightEngine.lightOnInColumn(ChunkPos.pack(1, 1))).thenReturn(false);
+        assertFalse(BotiInteriorSampler.isFootprintLightReady(world, origin));
+        assertFalse(BotiInteriorSampler.isFootprintLightReady(null, origin));
+        assertFalse(BotiInteriorSampler.isFootprintLightReady(world, null));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiInteriorSamplerTest.java
@@ -12,7 +12,6 @@ import org.mockito.Mockito;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerLevel;
@@ -21,7 +20,6 @@ import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.phys.AABB;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -62,46 +60,11 @@ class BotiInteriorSamplerTest {
     }
 
     @Test
-    void isInsideFootprint_respectsRoomBounds() {
-        UUID id = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
-        BlockPos origin = TardisPlotAllocator.plotOrigin(id);
-
-        assertTrue(BotiInteriorSampler.isInsideFootprint(origin, origin));
-        assertTrue(BotiInteriorSampler.isInsideFootprint(
-                origin.offset(BotiInteriorSampler.SIZE_X - 1, BotiInteriorSampler.SIZE_Y - 1, BotiInteriorSampler.SIZE_Z - 1),
-                origin));
-        assertFalse(BotiInteriorSampler.isInsideFootprint(origin.offset(BotiInteriorSampler.SIZE_X, 0, 0), origin));
-        assertFalse(BotiInteriorSampler.isInsideFootprint(origin.offset(0, -1, 0), origin));
-    }
-
-    @Test
     void isBotiVisible_excludesInteriorDoorIncludesConsoleAndChest() {
         assertFalse(BotiInteriorSampler.isBotiVisible(DWMBlocks.TARDIS_INTERIOR_DOOR.defaultBlockState()));
         assertTrue(BotiInteriorSampler.isBotiVisible(DWMBlocks.FIRST_DOCTOR_CONSOLE.defaultBlockState()));
         assertTrue(BotiInteriorSampler.isBotiVisible(Blocks.CHEST.defaultBlockState()));
         assertFalse(BotiInteriorSampler.isBotiVisible(Blocks.LIGHT.defaultBlockState()));
-    }
-
-    @Test
-    void footprintBox_matchesRoomDimensions() {
-        BlockPos origin = new BlockPos(64, 64, 128);
-        AABB box = BotiInteriorSampler.footprintBox(origin);
-        assertEquals(origin.getX(), box.minX);
-        assertEquals(origin.getY(), box.minY);
-        assertEquals(origin.getZ(), box.minZ);
-        assertEquals(origin.getX() + BotiInteriorSampler.SIZE_X, box.maxX);
-        assertEquals(origin.getY() + BotiInteriorSampler.SIZE_Y, box.maxY);
-        assertEquals(origin.getZ() + BotiInteriorSampler.SIZE_Z, box.maxZ);
-    }
-
-    @Test
-    void footprintChunkBounds_coversFullFootprint() {
-        BlockPos origin = new BlockPos(15, 64, 15); // straddles chunk boundary for 11-wide room
-        int[] bounds = BotiInteriorSampler.footprintChunkBounds(origin);
-        assertEquals(0, bounds[0]);
-        assertEquals(1, bounds[1]);
-        assertEquals(0, bounds[2]);
-        assertEquals(1, bounds[3]);
     }
 
     @Test
@@ -155,15 +118,15 @@ class BotiInteriorSamplerTest {
     }
 
     @Test
-    void captureEntity_NullEntityReturnsNull() {
-        assertNull(BotiInteriorSampler.captureEntity(null, BlockPos.ZERO));
+    void captureEntityNbt_NullEntityReturnsNull() {
+        assertNull(BotiInteriorSampler.captureEntityNbt(null));
     }
 
     @Test
-    void captureEntity_skipsConsoleControlInteraction() {
+    void captureEntityNbt_skipsConsoleControlInteraction() {
         ConsoleControlInteractionEntity entity = Mockito.mock(ConsoleControlInteractionEntity.class);
         Mockito.when(entity.isRemoved()).thenReturn(false);
-        assertNull(BotiInteriorSampler.captureEntity(entity, BlockPos.ZERO));
+        assertNull(BotiInteriorSampler.captureEntityNbt(entity));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiPlotIndexTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiPlotIndexTest.java
@@ -2,6 +2,7 @@ package com.adamkali.dwm.tardis.boti;
 
 import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.interior.TardisPlotAllocator;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -26,16 +27,18 @@ class BotiPlotIndexTest {
         assertTrue(BotiPlotIndex.isRegistered(id));
         assertEquals(origin, BotiPlotIndex.getOrigin(id));
         assertEquals(id, BotiPlotIndex.resolve(origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE)));
+        assertEquals(id, BotiPlotIndex.resolve(origin.offset(8, 2, 8)));
     }
 
     @Test
-    void resolve_OutsideFootprintReturnsNull() {
+    void resolve_OutsideStreamReturnsNull() {
         UUID id = UUID.fromString("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
         BotiPlotIndex.register(id);
         BlockPos origin = TardisPlotAllocator.plotOrigin(id);
 
-        assertNull(BotiPlotIndex.resolve(origin.offset(TardisPlotAllocator.PLOT_SPACING / 2, 0, 0)));
-        assertNull(BotiPlotIndex.resolve(origin.offset(0, BotiInteriorSampler.SIZE_Y + 2, 0)));
+        assertNull(BotiPlotIndex.resolve(origin.offset(TardisPlotAllocator.PLOT_SPACING, 0, 0)));
+        int yRadius = PortalSampler.streamYRadiusBlocks(PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+        assertNull(BotiPlotIndex.resolve(origin.offset(0, yRadius + 1, 0)));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiRelativePosCodecTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/boti/BotiRelativePosCodecTest.java
@@ -4,6 +4,7 @@ import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.network.SyncPortalChunkS2CPayload;
 import com.adamkali.dwm.network.SyncPortalEntitySpawnS2CPayload;
+import com.adamkali.dwm.tardis.interior.FirstDoctorConsoleRoomLayout;
 import com.adamkali.dwm.tardis.portal.PortalStreamKind;
 import com.adamkali.dwm.tardis.portal.PortalStreamSample;
 import org.junit.jupiter.api.BeforeAll;
@@ -36,9 +37,9 @@ class BotiRelativePosCodecTest {
 
     @Test
     void packUnpack_RoundTripsFootprintCoords() {
-        for (int x = 0; x < BotiInteriorSampler.SIZE_X; x++) {
-            for (int y = 0; y < BotiInteriorSampler.SIZE_Y; y++) {
-                for (int z = 0; z < BotiInteriorSampler.SIZE_Z; z++) {
+        for (int x = 0; x < FirstDoctorConsoleRoomLayout.SIZE_X; x++) {
+            for (int y = 0; y < FirstDoctorConsoleRoomLayout.SIZE_Y; y++) {
+                for (int z = 0; z < FirstDoctorConsoleRoomLayout.SIZE_Z; z++) {
                     BlockPos original = new BlockPos(x, y, z);
                     assertEquals(original, BotiRelativePosCodec.unpack(BotiRelativePosCodec.pack(original)));
                 }

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorPreloadServiceTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorPreloadServiceTest.java
@@ -140,7 +140,7 @@ class TardisInteriorPreloadServiceTest {
     void markBotiFootprintDirty_MarksExpectedColumnCount() {
         PortalStreamSyncService.markBotiFootprintDirty(TARDIS_ID);
         BlockPos origin = TardisPlotAllocator.plotOrigin(TARDIS_ID);
-        int[] bounds = BotiInteriorSampler.footprintChunkBounds(origin);
+        int[] bounds = BotiInteriorSampler.plotChunkBounds(origin);
         int expected = (bounds[1] - bounds[0] + 1) * (bounds[3] - bounds[2] + 1);
         assertEquals(expected, PortalStreamSyncService.botiDirtyChunkCountForTest(TARDIS_ID));
         assertTrue(expected > 0);

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
@@ -17,13 +17,10 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 class TardisInteriorUnitTest {
 
@@ -126,12 +123,8 @@ class TardisInteriorUnitTest {
 
     @Test
     void consoleRoomPlacer_StampsFullStrengthInvisibleLightAboveConsole() {
-        ServerLevel world = mock(ServerLevel.class, RETURNS_DEEP_STUBS);
+        ServerLevel world = mock(ServerLevel.class);
         BlockPos origin = new BlockPos(100, 64, 200);
-        when(world.getBlockState(any(BlockPos.class))).thenReturn(
-                Blocks.AIR.defaultBlockState(),
-                Blocks.LIGHT.defaultBlockState()
-        );
 
         FirstDoctorConsoleRoomPlacer.placeInteriorLight(world, origin);
 

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
@@ -17,10 +17,13 @@ import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class TardisInteriorUnitTest {
 
@@ -123,8 +126,12 @@ class TardisInteriorUnitTest {
 
     @Test
     void consoleRoomPlacer_StampsFullStrengthInvisibleLightAboveConsole() {
-        ServerLevel world = mock(ServerLevel.class);
+        ServerLevel world = mock(ServerLevel.class, RETURNS_DEEP_STUBS);
         BlockPos origin = new BlockPos(100, 64, 200);
+        when(world.getBlockState(any(BlockPos.class))).thenReturn(
+                Blocks.AIR.defaultBlockState(),
+                Blocks.LIGHT.defaultBlockState()
+        );
 
         FirstDoctorConsoleRoomPlacer.placeInteriorLight(world, origin);
 

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
@@ -11,9 +11,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 class TardisInteriorUnitTest {
 
@@ -112,6 +119,20 @@ class TardisInteriorUnitTest {
         Map<BlockPos, BlockState> boti = FirstDoctorConsoleRoomLayout.botiVisiblePlacements();
         assertEquals(DWMBlocks.FIRST_DOCTOR_CONSOLE, boti.get(consolePos).getBlock(),
                 "console must be included in BOTI so its BER can draw");
+    }
+
+    @Test
+    void consoleRoomPlacer_StampsFullStrengthInvisibleLightAboveConsole() {
+        ServerLevel world = mock(ServerLevel.class);
+        BlockPos origin = new BlockPos(100, 64, 200);
+
+        FirstDoctorConsoleRoomPlacer.placeInteriorLight(world, origin);
+
+        verify(world).setBlock(
+                eq(origin.offset(FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE.above(3))),
+                argThat(state -> state.is(Blocks.LIGHT) && state.getLightEmission() == 15),
+                eq(Block.UPDATE_CLIENTS)
+        );
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/interior/TardisInteriorUnitTest.java
@@ -110,6 +110,16 @@ class TardisInteriorUnitTest {
     }
 
     @Test
+    void roomChunkBounds_coversFullRoomIncludingChunkBoundary() {
+        BlockPos origin = new BlockPos(15, 64, 15);
+        int[] bounds = FirstDoctorConsoleRoomPlacer.roomChunkBounds(origin);
+        assertEquals(0, bounds[0]);
+        assertEquals(1, bounds[1]);
+        assertEquals(0, bounds[2]);
+        assertEquals(1, bounds[3]);
+    }
+
+    @Test
     void consoleRoomLayout_PlacesFirstDoctorConsoleWithoutStackedRoundel() {
         Map<BlockPos, BlockState> placements = FirstDoctorConsoleRoomLayout.placements();
         BlockPos consolePos = FirstDoctorConsoleRoomLayout.LOCAL_CONSOLE;

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalLightDataTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalLightDataTest.java
@@ -67,6 +67,37 @@ class PortalLightDataTest {
     }
 
     @Test
+    void sample_fromDataLayersCopiesAcrossSectionBoundary() {
+        DataLayer blockLow = new DataLayer();
+        DataLayer skyLow = new DataLayer();
+        DataLayer blockHigh = new DataLayer();
+        DataLayer skyHigh = new DataLayer();
+        blockLow.set(15, 15, 15, 3);
+        skyLow.set(15, 15, 15, 4);
+        blockHigh.set(0, 0, 0, 9);
+        skyHigh.set(0, 0, 0, 10);
+        LayerLightEventListener blockLight = Mockito.mock(LayerLightEventListener.class);
+        LayerLightEventListener skyLight = Mockito.mock(LayerLightEventListener.class);
+        Mockito.when(blockLight.getDataLayerData(any())).thenAnswer(invocation -> {
+            net.minecraft.core.SectionPos section = invocation.getArgument(0);
+            return section.y() < 1 ? blockLow : blockHigh;
+        });
+        Mockito.when(skyLight.getDataLayerData(any())).thenAnswer(invocation -> {
+            net.minecraft.core.SectionPos section = invocation.getArgument(0);
+            return section.y() < 1 ? skyLow : skyHigh;
+        });
+
+        PortalLightData data = PortalLightData.sample(
+                blockLight, skyLight, new BlockPos(15, 15, 15), new BlockPos(16, 16, 16));
+
+        assertEquals(3, data.brightness(LightLayer.BLOCK, new BlockPos(15, 15, 15), -1));
+        assertEquals(4, data.brightness(LightLayer.SKY, new BlockPos(15, 15, 15), -1));
+        assertEquals(9, data.brightness(LightLayer.BLOCK, new BlockPos(16, 16, 16), -1));
+        assertEquals(10, data.brightness(LightLayer.SKY, new BlockPos(16, 16, 16), -1));
+        assertEquals(0, data.brightness(LightLayer.BLOCK, new BlockPos(16, 15, 15), -1));
+    }
+
+    @Test
     void translated_preservesValuesInNewCoordinateSpace() {
         PortalLightData data = new PortalLightData(
                 new BlockPos(10, 20, 30), 1, 1, 1, new byte[]{PortalLightData.pack(4, 12)}

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalLightDataTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalLightDataTest.java
@@ -1,0 +1,51 @@
+package com.adamkali.dwm.tardis.portal;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LightLayer;
+import net.minecraft.world.level.LevelReader;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+class PortalLightDataTest {
+    @Test
+    void sample_packsBothLayersAcrossBoundedVolume() {
+        LevelReader level = Mockito.mock(LevelReader.class);
+        Mockito.when(level.getBrightness(eq(LightLayer.BLOCK), any(BlockPos.class)))
+                .thenAnswer(invocation -> invocation.<BlockPos>getArgument(1).getX() & 15);
+        Mockito.when(level.getBrightness(eq(LightLayer.SKY), any(BlockPos.class)))
+                .thenAnswer(invocation -> invocation.<BlockPos>getArgument(1).getY() & 15);
+
+        PortalLightData data = PortalLightData.sample(
+                level, new BlockPos(3, 5, 7), new BlockPos(4, 6, 8)
+        );
+
+        assertEquals(2, data.sizeX());
+        assertEquals(2, data.sizeY());
+        assertEquals(2, data.sizeZ());
+        assertEquals(4, data.brightness(LightLayer.BLOCK, new BlockPos(4, 6, 8), -1));
+        assertEquals(6, data.brightness(LightLayer.SKY, new BlockPos(4, 6, 8), -1));
+        assertEquals(-1, data.brightness(LightLayer.SKY, new BlockPos(5, 6, 8), -1));
+    }
+
+    @Test
+    void translated_preservesValuesInNewCoordinateSpace() {
+        PortalLightData data = new PortalLightData(
+                new BlockPos(10, 20, 30), 1, 1, 1, new byte[]{PortalLightData.pack(4, 12)}
+        ).translated(new BlockPos(-10, -20, -30));
+
+        assertEquals(BlockPos.ZERO, data.min());
+        assertEquals(4, data.brightness(LightLayer.BLOCK, BlockPos.ZERO, -1));
+        assertEquals(12, data.brightness(LightLayer.SKY, BlockPos.ZERO, -1));
+    }
+
+    @Test
+    void pack_rejectsValuesOutsideNibbleRange() {
+        assertThrows(IllegalArgumentException.class, () -> PortalLightData.pack(-1, 0));
+        assertThrows(IllegalArgumentException.class, () -> PortalLightData.pack(0, 16));
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalLightDataTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalLightDataTest.java
@@ -3,6 +3,8 @@ package com.adamkali.dwm.tardis.portal;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.LightLayer;
 import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.chunk.DataLayer;
+import net.minecraft.world.level.lighting.LayerLightEventListener;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -30,6 +32,38 @@ class PortalLightDataTest {
         assertEquals(4, data.brightness(LightLayer.BLOCK, new BlockPos(4, 6, 8), -1));
         assertEquals(6, data.brightness(LightLayer.SKY, new BlockPos(4, 6, 8), -1));
         assertEquals(-1, data.brightness(LightLayer.SKY, new BlockPos(5, 6, 8), -1));
+    }
+
+    @Test
+    void sample_fromDataLayersPacksNibbleValues() {
+        DataLayer blockLayer = new DataLayer();
+        DataLayer skyLayer = new DataLayer();
+        blockLayer.set(1, 2, 3, 7);
+        skyLayer.set(1, 2, 3, 12);
+        LayerLightEventListener blockLight = Mockito.mock(LayerLightEventListener.class);
+        LayerLightEventListener skyLight = Mockito.mock(LayerLightEventListener.class);
+        Mockito.when(blockLight.getDataLayerData(any())).thenReturn(blockLayer);
+        Mockito.when(skyLight.getDataLayerData(any())).thenReturn(skyLayer);
+
+        PortalLightData data = PortalLightData.sample(
+                blockLight, skyLight, new BlockPos(1, 2, 3), new BlockPos(1, 2, 3));
+
+        assertEquals(7, data.brightness(LightLayer.BLOCK, new BlockPos(1, 2, 3), -1));
+        assertEquals(12, data.brightness(LightLayer.SKY, new BlockPos(1, 2, 3), -1));
+    }
+
+    @Test
+    void sample_nullLayersReadAsZero() {
+        LayerLightEventListener blockLight = Mockito.mock(LayerLightEventListener.class);
+        LayerLightEventListener skyLight = Mockito.mock(LayerLightEventListener.class);
+        Mockito.when(blockLight.getDataLayerData(any())).thenReturn(null);
+        Mockito.when(skyLight.getDataLayerData(any())).thenReturn(null);
+
+        PortalLightData data = PortalLightData.sample(
+                blockLight, skyLight, BlockPos.ZERO, BlockPos.ZERO);
+
+        assertEquals(0, data.brightness(LightLayer.BLOCK, BlockPos.ZERO, -1));
+        assertEquals(0, data.brightness(LightLayer.SKY, BlockPos.ZERO, -1));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
@@ -9,9 +9,11 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.LevelChunkSection;
 import net.minecraft.world.phys.AABB;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -137,5 +139,71 @@ class PortalSamplerTest {
         assertEquals(96.0f, PortalSampler.fogStartBlocks(10), 1e-4f);
         assertEquals(160.0f, PortalSampler.fogEndBlocks(10), 1e-4f);
         assertTrue(PortalSampler.fogEndBlocks(0) > PortalSampler.fogStartBlocks(0));
+    }
+
+    @Test
+    void lightYRange_padsVisibleSpanAndRejectsEmpty() {
+        PortalSampler.YRange range = new PortalSampler.YRange(0, 128);
+        PortalSampler.YRange padded = PortalSampler.lightYRange(range, 64, 70);
+        assertEquals(63, padded.min());
+        assertEquals(71, padded.max());
+        PortalSampler.YRange empty = PortalSampler.lightYRange(range, Integer.MAX_VALUE, Integer.MIN_VALUE);
+        assertTrue(empty.min() > empty.max());
+    }
+
+    @Test
+    void isHiddenInterior_dropsBuriedSolidKeepsShellAndNonFullBlocks() {
+        BlockState stone = Blocks.STONE.defaultBlockState();
+        BlockState air = Blocks.AIR.defaultBlockState();
+        BlockState chest = Blocks.CHEST.defaultBlockState();
+        BlockState stair = Blocks.OAK_STAIRS.defaultBlockState();
+        assertTrue(PortalSampler.isHiddenInterior(stone, stone, stone, stone, stone, stone, stone));
+        assertFalse(PortalSampler.isHiddenInterior(stone, stone, stone, air, stone, stone, stone));
+        assertFalse(PortalSampler.isHiddenInterior(chest, stone, stone, stone, stone, stone, stone));
+        assertFalse(PortalSampler.isHiddenInterior(stair, stone, stone, stone, stone, stone, stone));
+        assertFalse(PortalSampler.isHiddenInterior(null, stone, stone, stone, stone, stone, stone));
+    }
+
+    @Test
+    void isSolidFilledSection_usesPaletteMaybeHas() {
+        LevelChunkSection solid = Mockito.mock(LevelChunkSection.class);
+        Mockito.when(solid.hasOnlyAir()).thenReturn(false);
+        Mockito.when(solid.maybeHas(Mockito.any())).thenReturn(false);
+        assertTrue(PortalSampler.isSolidFilledSection(solid));
+
+        LevelChunkSection mixed = Mockito.mock(LevelChunkSection.class);
+        Mockito.when(mixed.hasOnlyAir()).thenReturn(false);
+        Mockito.when(mixed.maybeHas(Mockito.any())).thenReturn(true);
+        assertFalse(PortalSampler.isSolidFilledSection(mixed));
+
+        LevelChunkSection air = Mockito.mock(LevelChunkSection.class);
+        Mockito.when(air.hasOnlyAir()).thenReturn(true);
+        assertFalse(PortalSampler.isSolidFilledSection(air));
+    }
+
+    @Test
+    void computeSurfaceSkinBounds_keepsNeighborPadAndEdgeDepth() {
+        int[] heights = new int[256];
+        java.util.Arrays.fill(heights, 70);
+        heights[(3 << 4) | 3] = 90;
+        int[] colMin = new int[256];
+        int[] colMax = new int[256];
+        PortalSampler.computeSurfaceSkinBounds(heights, 0, 128, colMin, colMax);
+
+        int interior = (8 << 4) | 8;
+        assertEquals(70, colMax[interior]);
+        assertEquals(69, colMin[interior]);
+
+        int nextToHill = (3 << 4) | 4;
+        assertEquals(70, colMax[nextToHill]);
+        assertEquals(69, colMin[nextToHill]);
+
+        int hill = (3 << 4) | 3;
+        assertEquals(90, colMax[hill]);
+        assertEquals(69, colMin[hill]);
+
+        int edge = (0 << 4) | 8;
+        assertEquals(70, colMax[edge]);
+        assertEquals(54, colMin[edge]);
     }
 }

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.server.level.TicketType;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
@@ -25,10 +24,7 @@ class PortalSamplerTest {
     @BeforeAll
     static void bootstrap() {
         MinecraftTestBootstrap.ensure();
-        SAMPLER = new PortalSampler(
-                3, 4, 5,
-                new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION)
-        ) {
+        SAMPLER = new PortalSampler() {
             @Override
             public boolean isVisible(BlockState state) {
                 return state != null && !state.isAir() && !state.is(Blocks.LIGHT);
@@ -52,15 +48,12 @@ class PortalSamplerTest {
     }
 
     @Test
-    void isInsideFootprint_respectsConstructorSizes() {
-        BlockPos origin = new BlockPos(10, 20, 30);
-
-        assertTrue(SAMPLER.inFootprint(origin, origin));
-        assertTrue(SAMPLER.inFootprint(origin.offset(2, 3, 4), origin));
-        assertFalse(SAMPLER.inFootprint(origin.offset(3, 0, 0), origin));
-        assertFalse(SAMPLER.inFootprint(origin.offset(0, 4, 0), origin));
-        assertFalse(SAMPLER.inFootprint(origin.offset(0, 0, 5), origin));
-        assertFalse(SAMPLER.inFootprint(origin.offset(0, -1, 0), origin));
+    void simulationRadiusChunks_isAtMostStreamRadius() {
+        assertEquals(
+                PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS,
+                PortalSampler.simulationRadiusChunks(null)
+        );
+        assertTrue(PortalSampler.simulationRadiusChunks(null) <= PortalSampler.streamRadiusChunks((ServerLevel) null));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
@@ -4,9 +4,13 @@ import com.adamkali.dwm.MinecraftTestBootstrap;
 import java.util.HashMap;
 import java.util.Map;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.AABB;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -63,5 +67,82 @@ class PortalSamplerTest {
     void sampleAtmosphere_nullInputsReturnDefault() {
         assertSame(PortalAtmosphere.DEFAULT, PortalSampler.sampleAtmosphere(null, BlockPos.ZERO));
         assertSame(PortalAtmosphere.DEFAULT, PortalSampler.sampleAtmosphere(null, null));
+    }
+
+    @Test
+    void streamRadiusChunks_nullInputsUseDefault() {
+        assertEquals(PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS, PortalSampler.streamRadiusChunks((ServerLevel) null));
+        assertEquals(PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS, PortalSampler.streamRadiusChunks((ServerPlayer) null));
+    }
+
+    @Test
+    void streamYRadiusBlocks_matchesChunkWidth() {
+        assertEquals(0, PortalSampler.streamYRadiusBlocks(0));
+        assertEquals(32, PortalSampler.streamYRadiusBlocks(2));
+        assertEquals(160, PortalSampler.streamYRadiusBlocks(10));
+        assertEquals(0, PortalSampler.streamYRadiusBlocks(-1));
+    }
+
+    @Test
+    void streamChunkBounds_isCenteredChebyshev() {
+        BlockPos anchor = new BlockPos(100, 64, -20);
+        int[] bounds = PortalSampler.streamChunkBounds(anchor, 2);
+        int cx = 100 >> 4;
+        int cz = -20 >> 4;
+        assertEquals(cx - 2, bounds[0]);
+        assertEquals(cx + 2, bounds[1]);
+        assertEquals(cz - 2, bounds[2]);
+        assertEquals(cz + 2, bounds[3]);
+    }
+
+    @Test
+    void clipChunkBounds_intersectsViewAndPlot() {
+        int[] view = new int[]{-10, 10, -10, 10};
+        int[] clipped = PortalSampler.clipChunkBounds(view, 0, 3, 0, 3);
+        assertEquals(0, clipped[0]);
+        assertEquals(3, clipped[1]);
+        assertEquals(0, clipped[2]);
+        assertEquals(3, clipped[3]);
+    }
+
+    @Test
+    void isInsideStreamRadius_respectsChebyshevAndY() {
+        BlockPos anchor = new BlockPos(16, 70, 16);
+        int radius = 2;
+        int yRadius = PortalSampler.streamYRadiusBlocks(radius);
+        assertTrue(PortalSampler.isInsideStreamRadius(anchor, anchor, radius, yRadius));
+        assertTrue(PortalSampler.isInsideStreamRadius(anchor.offset(32, 0, 0), anchor, radius, yRadius));
+        assertFalse(PortalSampler.isInsideStreamRadius(anchor.offset(48, 0, 0), anchor, radius, yRadius));
+        assertFalse(PortalSampler.isInsideStreamRadius(anchor.offset(0, yRadius + 1, 0), anchor, radius, yRadius));
+    }
+
+    @Test
+    void streamBox_coversRadius() {
+        BlockPos anchor = new BlockPos(0, 64, 0);
+        int radius = 2;
+        int yRadius = PortalSampler.streamYRadiusBlocks(radius);
+        AABB box = PortalSampler.streamBox(anchor, radius, yRadius);
+        int half = radius * 16;
+        assertEquals(-half, box.minX, 1e-6);
+        assertEquals(half + 1, box.maxX, 1e-6);
+        assertEquals(64 - yRadius, box.minY, 1e-6);
+        assertEquals(64 + yRadius + 1, box.maxY, 1e-6);
+    }
+
+    @Test
+    void streamTicketChunk_isAnchorChunk() {
+        BlockPos anchor = new BlockPos(100, 64, -20);
+        ChunkPos ticket = PortalSampler.streamTicketChunk(anchor);
+        assertEquals(100 >> 4, ticket.x());
+        assertEquals(-20 >> 4, ticket.z());
+    }
+
+    @Test
+    void fogDistances_scaleWithRadius() {
+        assertEquals(19.2f, PortalSampler.fogStartBlocks(2), 1e-4f);
+        assertEquals(32.0f, PortalSampler.fogEndBlocks(2), 1e-4f);
+        assertEquals(96.0f, PortalSampler.fogStartBlocks(10), 1e-4f);
+        assertEquals(160.0f, PortalSampler.fogEndBlocks(10), 1e-4f);
+        assertTrue(PortalSampler.fogEndBlocks(0) > PortalSampler.fogStartBlocks(0));
     }
 }

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalSamplerTest.java
@@ -1,0 +1,67 @@
+package com.adamkali.dwm.tardis.portal;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import java.util.HashMap;
+import java.util.Map;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.TicketType;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalSamplerTest {
+    private static PortalSampler SAMPLER;
+
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+        SAMPLER = new PortalSampler(
+                3, 4, 5,
+                new TicketType(80, TicketType.FLAG_LOADING | TicketType.FLAG_SIMULATION)
+        ) {
+            @Override
+            public boolean isVisible(BlockState state) {
+                return state != null && !state.isAir() && !state.is(Blocks.LIGHT);
+            }
+        };
+    }
+
+    @Test
+    void filterVisible_keepsOnlyVisibleBlocks() {
+        Map<BlockPos, BlockState> input = new HashMap<>();
+        input.put(new BlockPos(0, 0, 0), Blocks.STONE.defaultBlockState());
+        input.put(new BlockPos(1, 0, 0), Blocks.AIR.defaultBlockState());
+        input.put(new BlockPos(2, 0, 0), Blocks.LIGHT.defaultBlockState());
+        input.put(new BlockPos(3, 0, 0), Blocks.CHEST.defaultBlockState());
+
+        Map<BlockPos, BlockState> visible = SAMPLER.filterVisibleBlocks(input);
+
+        assertEquals(2, visible.size());
+        assertTrue(visible.containsKey(new BlockPos(0, 0, 0)));
+        assertTrue(visible.containsKey(new BlockPos(3, 0, 0)));
+    }
+
+    @Test
+    void isInsideFootprint_respectsConstructorSizes() {
+        BlockPos origin = new BlockPos(10, 20, 30);
+
+        assertTrue(SAMPLER.inFootprint(origin, origin));
+        assertTrue(SAMPLER.inFootprint(origin.offset(2, 3, 4), origin));
+        assertFalse(SAMPLER.inFootprint(origin.offset(3, 0, 0), origin));
+        assertFalse(SAMPLER.inFootprint(origin.offset(0, 4, 0), origin));
+        assertFalse(SAMPLER.inFootprint(origin.offset(0, 0, 5), origin));
+        assertFalse(SAMPLER.inFootprint(origin.offset(0, -1, 0), origin));
+    }
+
+    @Test
+    void sampleAtmosphere_nullInputsReturnDefault() {
+        assertSame(PortalAtmosphere.DEFAULT, PortalSampler.sampleAtmosphere(null, BlockPos.ZERO));
+        assertSame(PortalAtmosphere.DEFAULT, PortalSampler.sampleAtmosphere(null, null));
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncServiceTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncServiceTest.java
@@ -3,8 +3,12 @@ package com.adamkali.dwm.tardis.portal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
+import net.minecraft.world.level.ChunkPos;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +33,37 @@ class PortalStreamSyncServiceTest {
         int radius2Columns = 5 * 5;
         assertTrue(PortalStreamSyncService.CHUNK_SEND_BUDGET_PER_VIEWER_TICK < radius2Columns);
         assertTrue(PortalStreamSyncService.CHUNK_SEND_BUDGET_PER_VIEWER_TICK > 0);
+        assertTrue(PortalStreamSyncService.GLOBAL_SAMPLE_BUDGET_PER_TICK >= PortalStreamSyncService.CHUNK_SEND_BUDGET_PER_VIEWER_TICK);
+        assertTrue(PortalStreamSyncService.SAMPLE_TIME_BUDGET_NS > 0);
+    }
+
+    @Test
+    void leftoverDirty_keepsChunksUntilEveryViewerIsUpdated() {
+        long packed = ChunkPos.pack(4, -2);
+        Map<Long, Integer> need = new HashMap<>();
+        Map<Long, Integer> got = new HashMap<>();
+        need.put(packed, 2);
+        got.put(packed, 1);
+        assertTrue(PortalStreamSyncService.leftoverDirty(need, got).contains(packed));
+        got.put(packed, 2);
+        assertTrue(PortalStreamSyncService.leftoverDirty(need, got).isEmpty());
+    }
+
+    @Test
+    void chebyshevDistance_isMaxAxis() {
+        assertEquals(3, PortalStreamSyncService.chebyshevDistance(ChunkPos.pack(3, -2), 0, 0));
+        assertEquals(0, PortalStreamSyncService.chebyshevDistance(ChunkPos.pack(5, 9), 5, 9));
+    }
+
+    @Test
+    void sampleBudget_stopsAfterGlobalCap() {
+        PortalStreamSyncService.SampleBudget budget = PortalStreamSyncService.SampleBudget.start();
+        assertTrue(budget.canSample());
+        for (int i = 0; i < PortalStreamSyncService.GLOBAL_SAMPLE_BUDGET_PER_TICK; i++) {
+            assertTrue(budget.canSample());
+            budget.noteSample();
+        }
+        assertFalse(budget.canSample());
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncServiceTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncServiceTest.java
@@ -1,0 +1,36 @@
+package com.adamkali.dwm.tardis.portal;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PortalStreamSyncServiceTest {
+    private static final UUID TARDIS_ID =
+            UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+    @AfterEach
+    void tearDown() {
+        PortalStreamSyncService.clear();
+    }
+
+    @Test
+    void botiLightGate_passesAsSoonAsLightingIsReady() {
+        assertTrue(PortalStreamSyncService.shouldDeferBotiStreamForTest(TARDIS_ID, false, 10));
+        assertFalse(PortalStreamSyncService.shouldDeferBotiStreamForTest(TARDIS_ID, true, 11));
+        assertFalse(PortalStreamSyncService.shouldDeferBotiStreamForTest(TARDIS_ID, false, 12));
+    }
+
+    @Test
+    void botiLightGate_timesOutAndStaysOpen() {
+        assertTrue(PortalStreamSyncService.shouldDeferBotiStreamForTest(TARDIS_ID, false, 10));
+        assertTrue(PortalStreamSyncService.shouldDeferBotiStreamForTest(
+                TARDIS_ID, false, 10 + PortalStreamSyncService.MAX_BOTI_LIGHT_DEFER_TICKS - 1));
+        assertFalse(PortalStreamSyncService.shouldDeferBotiStreamForTest(
+                TARDIS_ID, false, 10 + PortalStreamSyncService.MAX_BOTI_LIGHT_DEFER_TICKS));
+        assertFalse(PortalStreamSyncService.shouldDeferBotiStreamForTest(TARDIS_ID, false, 1000));
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncServiceTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/portal/PortalStreamSyncServiceTest.java
@@ -25,6 +25,13 @@ class PortalStreamSyncServiceTest {
     }
 
     @Test
+    void chunkSendBudget_isSmallerThanDefaultViewBox() {
+        int radius2Columns = 5 * 5;
+        assertTrue(PortalStreamSyncService.CHUNK_SEND_BUDGET_PER_VIEWER_TICK < radius2Columns);
+        assertTrue(PortalStreamSyncService.CHUNK_SEND_BUDGET_PER_VIEWER_TICK > 0);
+    }
+
+    @Test
     void botiLightGate_timesOutAndStaysOpen() {
         assertTrue(PortalStreamSyncService.shouldDeferBotiStreamForTest(TARDIS_ID, false, 10));
         assertTrue(PortalStreamSyncService.shouldDeferBotiStreamForTest(

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/soto/SotoAtmosphereColorsTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/soto/SotoAtmosphereColorsTest.java
@@ -115,4 +115,39 @@ class SotoAtmosphereColorsTest {
         assertEquals(1, SotoAtmosphereColors.moonPhase(24000L));
         assertEquals(0, SotoAtmosphereColors.moonPhase(8L * 24000L));
     }
+
+    @Test
+    void skyLightFactor_overworldDayNearOneNightNearFloor() {
+        float day = SotoAtmosphereColors.skyLightFactor(
+                SotoAtmosphereColors.EffectsKind.OVERWORLD,
+                SotoAtmosphereColors.skyAngle(6000L),
+                0.0f,
+                0.0f);
+        float night = SotoAtmosphereColors.skyLightFactor(
+                SotoAtmosphereColors.EffectsKind.OVERWORLD,
+                SotoAtmosphereColors.skyAngle(18000L),
+                0.0f,
+                0.0f);
+        assertTrue(day > 0.9f, "day sky factor should be near 1, was " + day);
+        assertEquals(SotoAtmosphereColors.NIGHT_SKY_LIGHT_FACTOR, night, 0.02f);
+    }
+
+    @Test
+    void skyLightFactor_netherAndEndAreZero() {
+        float angle = SotoAtmosphereColors.skyAngle(6000L);
+        assertEquals(0.0f, SotoAtmosphereColors.skyLightFactor(
+                SotoAtmosphereColors.EffectsKind.NETHER, angle, 0.0f, 0.0f));
+        assertEquals(0.0f, SotoAtmosphereColors.skyLightFactor(
+                SotoAtmosphereColors.EffectsKind.END, angle, 0.0f, 0.0f));
+    }
+
+    @Test
+    void ambientLightColor_matchesVanillaDimensionTypes() {
+        assertEquals(SotoAtmosphereColors.OVERWORLD_AMBIENT_LIGHT_COLOR,
+                SotoAtmosphereColors.ambientLightColor(SotoAtmosphereColors.EffectsKind.OVERWORLD));
+        assertEquals(SotoAtmosphereColors.NETHER_AMBIENT_LIGHT_COLOR,
+                SotoAtmosphereColors.ambientLightColor(SotoAtmosphereColors.EffectsKind.NETHER));
+        assertEquals(SotoAtmosphereColors.END_AMBIENT_LIGHT_COLOR,
+                SotoAtmosphereColors.ambientLightColor(SotoAtmosphereColors.EffectsKind.END));
+    }
 }

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/soto/SotoExteriorIndexTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/soto/SotoExteriorIndexTest.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.tardis.soto;
 
 import com.adamkali.dwm.tardis.data.model.TardisDataModel;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +32,11 @@ class SotoExteriorIndexTest {
         assertEquals(exterior, SotoExteriorIndex.getExteriorPos(id));
         assertEquals(id, SotoExteriorIndex.resolve(overworld, exterior));
         assertEquals(id, SotoExteriorIndex.resolve(overworld, exterior.offset(2, 0, -1)));
-        assertNull(SotoExteriorIndex.resolve(overworld, exterior.offset(20, 0, 0)));
+        assertEquals(id, SotoExteriorIndex.resolve(overworld, exterior.offset(20, 0, 0)));
+        int yRadius = PortalSampler.streamYRadiusBlocks(PortalSampler.DEFAULT_STREAM_RADIUS_CHUNKS);
+        assertNull(SotoExteriorIndex.resolve(
+                overworld, exterior.offset(0, yRadius + 1, 0)));
+        assertNull(SotoExteriorIndex.resolve(overworld, exterior.offset(48, 0, 0)));
     }
 
     @Test

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/soto/SotoExteriorSamplerTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/soto/SotoExteriorSamplerTest.java
@@ -3,6 +3,7 @@ package com.adamkali.dwm.tardis.soto;
 import com.adamkali.dwm.MinecraftTestBootstrap;
 import com.adamkali.dwm.block.DWMBlocks;
 import com.adamkali.dwm.tardis.boti.BotiRelativePosCodec;
+import com.adamkali.dwm.tardis.portal.PortalSampler;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -82,32 +83,37 @@ class SotoExteriorSamplerTest {
     @Test
     void streamChunkBounds_usesConfiguredRadius() {
         BlockPos exterior = new BlockPos(100, 64, -20);
-        int[] bounds = SotoExteriorSampler.streamChunkBounds(exterior);
+        int radius = 3;
+        int[] bounds = SotoExteriorSampler.streamChunkBounds(exterior, radius);
         int cx = 100 >> 4;
         int cz = -20 >> 4;
-        assertEquals(cx - SotoExteriorSampler.STREAM_RADIUS_CHUNKS, bounds[0]);
-        assertEquals(cx + SotoExteriorSampler.STREAM_RADIUS_CHUNKS, bounds[1]);
-        assertEquals(cz - SotoExteriorSampler.STREAM_RADIUS_CHUNKS, bounds[2]);
-        assertEquals(cz + SotoExteriorSampler.STREAM_RADIUS_CHUNKS, bounds[3]);
+        assertEquals(cx - radius, bounds[0]);
+        assertEquals(cx + radius, bounds[1]);
+        assertEquals(cz - radius, bounds[2]);
+        assertEquals(cz + radius, bounds[3]);
     }
 
     @Test
     void isInsideStreamRadius_respectsChebyshevAndY() {
         BlockPos exterior = new BlockPos(16, 70, 16);
-        assertTrue(SotoExteriorSampler.isInsideStreamRadius(exterior, exterior));
-        assertTrue(SotoExteriorSampler.isInsideStreamRadius(exterior.offset(32, 0, 0), exterior));
-        assertFalse(SotoExteriorSampler.isInsideStreamRadius(exterior.offset(48, 0, 0), exterior));
+        int radius = 2;
+        assertTrue(SotoExteriorSampler.isInsideStreamRadius(exterior, exterior, radius));
+        assertTrue(SotoExteriorSampler.isInsideStreamRadius(exterior.offset(32, 0, 0), exterior, radius));
+        assertFalse(SotoExteriorSampler.isInsideStreamRadius(exterior.offset(48, 0, 0), exterior, radius));
+        int yRadius = PortalSampler.streamYRadiusBlocks(radius);
         assertFalse(SotoExteriorSampler.isInsideStreamRadius(
-                exterior.offset(0, SotoExteriorSampler.STREAM_Y_RADIUS + 1, 0), exterior));
+                exterior.offset(0, yRadius + 1, 0), exterior, radius));
     }
 
     @Test
     void streamBox_coversRadius() {
         BlockPos exterior = new BlockPos(0, 64, 0);
-        var box = SotoExteriorSampler.streamBox(exterior);
-        int half = SotoExteriorSampler.STREAM_RADIUS_CHUNKS * 16;
+        int radius = 2;
+        var box = SotoExteriorSampler.streamBox(exterior, radius);
+        int half = radius * 16;
+        int yRadius = PortalSampler.streamYRadiusBlocks(radius);
         assertEquals(-half, box.minX, 1e-6);
         assertEquals(half + 1, box.maxX, 1e-6);
-        assertEquals(64 - SotoExteriorSampler.STREAM_Y_RADIUS, box.minY, 1e-6);
+        assertEquals(64 - yRadius, box.minY, 1e-6);
     }
 }

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
@@ -1559,12 +1559,12 @@ class ScenarioCompilerTest {
         ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot))
                 .compile("portalLightingAndFog");
 
-        assertEquals(34, plan.steps().size());
-        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(26).arguments().get("name"));
-        assertEquals(true, plan.steps().get(26).arguments().get("compare"));
-        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(28).displayName());
-        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(33).arguments().get("name"));
-        assertEquals(true, plan.steps().get(33).arguments().get("compare"));
+        assertEquals(32, plan.steps().size());
+        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(25).arguments().get("name"));
+        assertEquals(true, plan.steps().get(25).arguments().get("compare"));
+        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(27).displayName());
+        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(31).arguments().get("name"));
+        assertEquals(true, plan.steps().get(31).arguments().get("compare"));
     }
 
     @Test

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
@@ -1559,12 +1559,12 @@ class ScenarioCompilerTest {
         ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot))
                 .compile("portalLightingAndFog");
 
-        assertEquals(32, plan.steps().size());
-        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(25).arguments().get("name"));
-        assertEquals(true, plan.steps().get(25).arguments().get("compare"));
-        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(26).displayName());
-        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(31).arguments().get("name"));
-        assertEquals(true, plan.steps().get(31).arguments().get("compare"));
+        assertEquals(34, plan.steps().size());
+        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(26).arguments().get("name"));
+        assertEquals(true, plan.steps().get(26).arguments().get("compare"));
+        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(28).displayName());
+        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(33).arguments().get("name"));
+        assertEquals(true, plan.steps().get(33).arguments().get("compare"));
     }
 
     @Test

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
@@ -1553,6 +1553,21 @@ class ScenarioCompilerTest {
     }
 
     @Test
+    void compilesPortalLightingAndFogVisualScenario() {
+        Path scenarioRoot = resolveScreenplayTests();
+
+        ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot))
+                .compile("portalLightingAndFog");
+
+        assertEquals(32, plan.steps().size());
+        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(25).arguments().get("name"));
+        assertEquals(true, plan.steps().get(25).arguments().get("compare"));
+        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(26).displayName());
+        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(31).arguments().get("name"));
+        assertEquals(true, plan.steps().get(31).arguments().get("compare"));
+    }
+
+    @Test
     void compilesSonicFieldModeHudScenarioWithoutScreenshotCompare() {
         Path scenarioRoot = resolveScreenplayTests();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- TARDIS doorway previews rendered streamed scenes fullbright and reused/no-op fog, flattening depth and ignoring real scene illumination.
- At higher view distances the portal sampler could stall the server by force-loading chunks on the game thread.
- Packed SOTO sky/block light was still shaded with the interior lightmap (`sky_light_factor=0`, black ambient), so Overworld day and Nether ambient looked unlit.

## Proposed Implementation

- Stream compact sky/block-light volumes with BOTI and SOTO and use them for terrain ambient occlusion, block entities, and entities.
- Share sampling through `PortalSampler`: size streams from Minecraft view/render distance (clipped to the TARDIS plot for BOTI), ticket async chunk load like vanilla, sample only `FULL` columns on a per-tick budget, and never force-generate on the server thread.
- Skip buried SOTO interiors (world-surface heightmap + occluded-section cull) and clip light copies to the visible Y span, skipping empty data layers.
- Overlay the destination atmosphere on the client lightmap while drawing SOTO so sampled sky/block coords interpret as Overworld/Nether/End rather than `dwm:tardis`.
- Upload atmosphere-colored Minecraft 26.2 fog through a lifecycle-managed portal fog buffer, with start/end derived from streamed radius.
- Stamp and propagate the console room’s intended invisible `minecraft:light`, then gate BOTI chunk sync until brightness is ready (40-tick fail-open).
- Add a Screenplay comparison capture for both portal directions (`portalLightingAndFog`) plus unit/GameTest coverage for codecs, light storage, fog data, room lighting, lightmap overlay, and sampler budgets.

![BOTI sampled interior lighting and fog](https://github.com/user-attachments/assets/3ce99d94-e639-4a1e-be65-2b0564584f1e)
![SOTO sampled exterior lighting and fog](https://github.com/user-attachments/assets/7e9fb3f3-6a27-4975-bf56-ae3c72409f89)

## Problems Encountered / Decisions Made

- The shipped console-room structure omitted its blueprint’s intended `minecraft:light`. Custom-dimension chunks could also reach `FULL` without lighting enabled, so ordinary block-change checks had nowhere to retain brightness. Placement now stamps the source, enables footprint lighting, waits up to 40 ticks for propagated brightness, then fails open so BOTI cannot stall forever.
- High view distance previously force-generated columns on the server thread and hitch-locked MSPT. Streaming now matches vanilla `PlayerChunkSender` policy: tickets request async load, sampling uses `getChunkNow`, and simulation tickets stay within simulation distance.
- Packed sky/block values from the exterior were correct, but the TARDIS dimension lightmap zeroed sky factor and ambient. SOTO now snapshots, overlays, and restores `LightmapRenderState` around the portal pass.
- SOTO used to walk cave layers under the landing site. It now skins from the world-surface heightmap and drops fully occluded sections so buried stone is not streamed.
- BOTI and SOTO duplicated atmosphere, ticket, and column-scan helpers. Those live in `PortalSampler` so the two directions stay in sync without a cross-package NBT dependency.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2323dad8-6024-4598-824d-3221c46f84ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2323dad8-6024-4598-824d-3221c46f84ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>