### PR TITLE
feat(screenplay): add opt-in scenario screen recording

### DIFF
--- a/dwm/src/screenplayTests/AGENTS.md
+++ b/dwm/src/screenplayTests/AGENTS.md
@@ -12,8 +12,8 @@ Also: [`screenplay/README.md`](../../../screenplay/README.md), [`screenplay/meta
 ## Commands
 - Run a scenario or suite: `./dwm/gradlew runScreenplay -Pscreenplay=<yaml-filename-stem>`
 - Run all discovered suites + standalone `type: test` scenarios: `./dwm/gradlew runScreenplayTests`
-- Properties: `-PscreenplayDisplay=display|xvfb`, `-PscreenplayTimeout=<seconds>`, optional `-PscreenplayBaselinesDir=<dir>` for screenshot compare
-- Outputs: `dwm/build/screenplay/report.xml`, `metrics.json`, `diagnostics.txt`, screenshots under `dwm/build/screenplay/run/screenshots/`
+- Properties: `-PscreenplayDisplay=display|xvfb`, `-PscreenplayTimeout=<seconds>`, optional `-PscreenplayBaselinesDir=<dir>` for screenshot compare, optional `-PscreenplayRecord=true|false` (or YAML `record: true`) for ffmpeg screen recording
+- Outputs: `dwm/build/screenplay/report.xml`, `metrics.json`, `diagnostics.txt`, screenshots under `dwm/build/screenplay/run/screenshots/`, recordings under `dwm/build/screenplay/run/recordings/`
 - Per-run archives from `runScreenplayTests`: `dwm/build/screenplay/results/<id>/`
 
 ## Harness unit tests

--- a/dwm/src/screenplayTests/README.md
+++ b/dwm/src/screenplayTests/README.md
@@ -69,8 +69,10 @@ Results are written to:
   (listed in `.gitignore`; CI uploads the file as a workflow artifact)
 - `build/screenplay/diagnostics.txt` — current screen and visible widgets
 - `build/screenplay/run/screenshots/` — PNGs from `captureScreenshot`
+- `build/screenplay/run/recordings/` — MP4s when `-PscreenplayRecord=true` or YAML
+  `record: true` (requires `ffmpeg`)
 - `build/screenplay/results/<id>/` — per-scenario copies of report, metrics,
-  diagnostics, and screenshots written by `runScreenplayTests`
+  diagnostics, screenshots, and recordings written by `runScreenplayTests`
 - `build/screenplay/vanilla-server/` — official dedicated-server run dir from
   `startVanillaServer` (`server-jar.path`, `eula.txt`, `server.properties`,
   `world/`, `logs/harness.log`)

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCatalog.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCatalog.java
@@ -198,13 +198,20 @@ public final class ScenarioCatalog {
             default -> throw new ScenarioException(source + ": unsupported frontmatter type '" + rawType + "'");
         };
 
+        boolean record = optionalBoolean(frontmatter, "record", source);
         if (type == ScenarioDocument.Type.SUITE) {
-            return parseSuite(id, name, body, source);
+            return parseSuite(id, name, record, body, source);
         }
-        return parseTestOrCommand(id, name, type, body, source);
+        return parseTestOrCommand(id, name, type, record, body, source);
     }
 
-    private static ScenarioDocument parseSuite(String id, String name, Map<String, Object> body, String source) {
+    private static ScenarioDocument parseSuite(
+            String id,
+            String name,
+            boolean record,
+            Map<String, Object> body,
+            String source
+    ) {
         if (body.containsKey("parameters")) {
             throw new ScenarioException(source + ": suite documents may not declare parameters");
         }
@@ -227,6 +234,7 @@ public final class ScenarioCatalog {
                 id,
                 name,
                 ScenarioDocument.Type.SUITE,
+                record,
                 List.of(),
                 List.of(),
                 beforeAll,
@@ -242,6 +250,7 @@ public final class ScenarioCatalog {
             String id,
             String name,
             ScenarioDocument.Type type,
+            boolean record,
             Map<String, Object> body,
             String source
     ) {
@@ -257,6 +266,7 @@ public final class ScenarioCatalog {
                 id,
                 name,
                 type,
+                record,
                 parameters,
                 steps,
                 List.of(),
@@ -401,6 +411,17 @@ public final class ScenarioCatalog {
             throw new ScenarioException(context + ": '" + key + "' must be a non-empty string");
         }
         return string;
+    }
+
+    private static boolean optionalBoolean(Map<String, Object> values, String key, String context) {
+        if (!values.containsKey(key)) {
+            return false;
+        }
+        Object value = values.get(key);
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        throw new ScenarioException(context + ": '" + key + "' must be a boolean");
     }
 
     private static boolean isYaml(Path path) {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCompiler.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioCompiler.java
@@ -27,7 +27,7 @@ public final class ScenarioCompiler {
         ScenarioDocument test = catalog.requireTest(testId);
         List<ScenarioPlan.Step> expanded = new ArrayList<>();
         expand(test.steps(), test.source(), Map.of(), new ArrayDeque<>(), expanded);
-        return new ScenarioPlan(test.id(), test.name(), expanded);
+        return new ScenarioPlan(test.id(), test.name(), expanded, test.record());
     }
 
     public SuitePlan compileSuite(String suiteId) {
@@ -57,7 +57,16 @@ public final class ScenarioCompiler {
             }
             members.add(compile(testId));
         }
-        return new SuitePlan(suite.id(), suite.name(), beforeAll, beforeEach, afterEach, afterAll, members);
+        return new SuitePlan(
+                suite.id(),
+                suite.name(),
+                beforeAll,
+                beforeEach,
+                afterEach,
+                afterAll,
+                members,
+                suite.record()
+        );
     }
 
     private List<ScenarioPlan.Step> expandHook(List<ScenarioDocument.Invocation> invocations, String source) {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioDocument.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioDocument.java
@@ -7,6 +7,7 @@ public record ScenarioDocument(
         String id,
         String name,
         Type type,
+        boolean record,
         List<Parameter> parameters,
         List<Invocation> steps,
         List<Invocation> beforeAll,

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioPlan.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioPlan.java
@@ -3,7 +3,7 @@ package com.adamkali.screenplay;
 import java.util.List;
 import java.util.Map;
 
-public record ScenarioPlan(String id, String name, List<Step> steps) {
+public record ScenarioPlan(String id, String name, List<Step> steps, boolean record) {
     public ScenarioPlan {
         steps = List.copyOf(steps);
     }

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioReportWriter.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioReportWriter.java
@@ -36,7 +36,7 @@ final class ScenarioReportWriter {
     }
 
     void writeBootstrapFailure(String scenarioId, Throwable failure) {
-        ScenarioPlan plan = new ScenarioPlan(scenarioId, scenarioId, List.of());
+        ScenarioPlan plan = new ScenarioPlan(scenarioId, scenarioId, List.of(), false);
         write(plan, List.of(), message(failure), message(failure) + "\n");
     }
 
@@ -57,7 +57,7 @@ final class ScenarioReportWriter {
             );
             String metrics = suite
                     ? suiteMetricsJson(id, name, cases)
-                    : metricsJson(new ScenarioPlan(id, name, List.of()), cases.getFirst().steps(), cases.getFirst().failure());
+                    : metricsJson(new ScenarioPlan(id, name, List.of(), false), cases.getFirst().steps(), cases.getFirst().failure());
             Files.writeString(metricsFile(), metrics, StandardCharsets.UTF_8);
         } catch (IOException exception) {
             throw new ScenarioException("Could not write scenario report to " + reportFile, exception);

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioRunner.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScenarioRunner.java
@@ -30,6 +30,7 @@ final class ScenarioRunner {
     private final ScreenshotCapture screenshotCapture;
     private final VanillaServerProcess vanillaServer;
     private final CreateWorldProcess createWorld;
+    private final ScreenRecorder screenRecorder;
     private final Logger logger;
 
     private final List<ScenarioReportWriter.CaseResult> cases = new ArrayList<>();
@@ -51,7 +52,8 @@ final class ScenarioRunner {
             ScenarioPlan plan,
             ScenarioReportWriter reportWriter,
             Duration stepTimeout,
-            Logger logger
+            Logger logger,
+            boolean record
     ) {
         this.singlePlan = plan;
         this.suite = null;
@@ -62,6 +64,7 @@ final class ScenarioRunner {
         this.screenshotCapture = new ScreenshotCapture(logger);
         this.vanillaServer = new VanillaServerProcess(logger);
         this.createWorld = new CreateWorldProcess(logger);
+        this.screenRecorder = new ScreenRecorder(logger, record);
         this.phase = Phase.TEST;
         beginCase(plan.id());
     }
@@ -70,7 +73,8 @@ final class ScenarioRunner {
             SuitePlan suite,
             ScenarioReportWriter reportWriter,
             Duration stepTimeout,
-            Logger logger
+            Logger logger,
+            boolean record
     ) {
         this.singlePlan = null;
         this.suite = suite;
@@ -81,6 +85,7 @@ final class ScenarioRunner {
         this.screenshotCapture = new ScreenshotCapture(logger);
         this.vanillaServer = new VanillaServerProcess(logger);
         this.createWorld = new CreateWorldProcess(logger);
+        this.screenRecorder = new ScreenRecorder(logger, record);
         this.memberIndex = 0;
         if (!suite.beforeAll().isEmpty()) {
             this.phase = Phase.BEFORE_ALL;
@@ -98,6 +103,8 @@ final class ScenarioRunner {
         if (finished || executing || phase == Phase.DONE) {
             return;
         }
+
+        screenRecorder.ensureStarted(client, executableId());
 
         List<ScenarioPlan.Step> steps = currentPhaseSteps();
         if (stepIndex >= steps.size()) {
@@ -311,6 +318,7 @@ final class ScenarioRunner {
         finished = true;
         phase = Phase.DONE;
         vanillaServer.stop();
+        screenRecorder.stop();
         String failureMessage = firstFailure == null ? null
                 : firstFailure.getMessage() == null
                 ? firstFailure.getClass().getName()
@@ -344,6 +352,10 @@ final class ScenarioRunner {
             logger.error("Scenario '{}' failed: {}", singlePlan.id(), failureMessage, firstFailure);
         }
         System.exit(exitCode);
+    }
+
+    private String executableId() {
+        return isSuite ? suite.id() : singlePlan.id();
     }
 
     private String failurePrefix() {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenRecorder.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenRecorder.java
@@ -152,9 +152,9 @@ public final class ScreenRecorder {
         outputPath = recordingsDir.resolve(sanitizeFileName(scenarioId) + ".mp4");
         logFile = recordingsDir.resolve(sanitizeFileName(scenarioId) + ".ffmpeg.log");
 
-        int width = evenPositive(client.getWindow().getWidth(), 1280);
-        int height = evenPositive(client.getWindow().getHeight(), 720);
-        List<String> command = buildFfmpegCommand(display, width, height, outputPath);
+        // Capture the full X display. Using the Minecraft window size at +0,0 misframes
+        // when the GLFW window is not at the display origin (common under xvfb).
+        List<String> command = buildFfmpegCommand(display, outputPath);
 
         ProcessBuilder builder = new ProcessBuilder(command);
         builder.redirectErrorStream(true);
@@ -173,17 +173,15 @@ public final class ScreenRecorder {
         shutdownHook = new Thread(this::stop, "screenplay-screen-recorder-shutdown");
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         logger.info(
-                "Started screen recording pid {} -> {} ({}x{} @ {}fps on DISPLAY={})",
+                "Started screen recording pid {} -> {} ({}fps on DISPLAY={})",
                 process.pid(),
                 outputPath.toAbsolutePath(),
-                width,
-                height,
                 DEFAULT_FPS,
                 display
         );
     }
 
-    static List<String> buildFfmpegCommand(String display, int width, int height, Path outputPath) {
+    static List<String> buildFfmpegCommand(String display, Path outputPath) {
         List<String> command = new ArrayList<>();
         command.add("ffmpeg");
         command.add("-y");
@@ -191,8 +189,6 @@ public final class ScreenRecorder {
         command.add("x11grab");
         command.add("-framerate");
         command.add(Integer.toString(DEFAULT_FPS));
-        command.add("-video_size");
-        command.add(width + "x" + height);
         command.add("-i");
         command.add(display);
         command.add("-c:v");
@@ -214,14 +210,6 @@ public final class ScreenRecorder {
             throw new ScenarioException("Screen recording id must not contain path separators: '" + id + "'");
         }
         return trimmed;
-    }
-
-    static int evenPositive(int value, int fallback) {
-        int resolved = value > 0 ? value : fallback;
-        if ((resolved & 1) != 0) {
-            resolved -= 1;
-        }
-        return Math.max(resolved, 2);
     }
 
     private static boolean ffmpegAvailable() {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenRecorder.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenRecorder.java
@@ -152,9 +152,12 @@ public final class ScreenRecorder {
         outputPath = recordingsDir.resolve(sanitizeFileName(scenarioId) + ".mp4");
         logFile = recordingsDir.resolve(sanitizeFileName(scenarioId) + ".ffmpeg.log");
 
-        // Capture the full X display. Using the Minecraft window size at +0,0 misframes
-        // when the GLFW window is not at the display origin (common under xvfb).
-        List<String> command = buildFfmpegCommand(display, outputPath);
+        var window = client.getWindow();
+        int width = evenPositive(window.getWidth(), 1280);
+        int height = evenPositive(window.getHeight(), 720);
+        int x = Math.max(0, window.getX());
+        int y = Math.max(0, window.getY());
+        List<String> command = buildFfmpegCommand(display, x, y, width, height, outputPath);
 
         ProcessBuilder builder = new ProcessBuilder(command);
         builder.redirectErrorStream(true);
@@ -173,15 +176,26 @@ public final class ScreenRecorder {
         shutdownHook = new Thread(this::stop, "screenplay-screen-recorder-shutdown");
         Runtime.getRuntime().addShutdownHook(shutdownHook);
         logger.info(
-                "Started screen recording pid {} -> {} ({}fps on DISPLAY={})",
+                "Started screen recording pid {} -> {} ({}x{}+{}+{} @ {}fps on DISPLAY={})",
                 process.pid(),
                 outputPath.toAbsolutePath(),
+                width,
+                height,
+                x,
+                y,
                 DEFAULT_FPS,
                 display
         );
     }
 
-    static List<String> buildFfmpegCommand(String display, Path outputPath) {
+    static List<String> buildFfmpegCommand(
+            String display,
+            int x,
+            int y,
+            int width,
+            int height,
+            Path outputPath
+    ) {
         List<String> command = new ArrayList<>();
         command.add("ffmpeg");
         command.add("-y");
@@ -189,8 +203,10 @@ public final class ScreenRecorder {
         command.add("x11grab");
         command.add("-framerate");
         command.add(Integer.toString(DEFAULT_FPS));
+        command.add("-video_size");
+        command.add(width + "x" + height);
         command.add("-i");
-        command.add(display);
+        command.add(display + "+" + x + "," + y);
         command.add("-c:v");
         command.add("libx264");
         command.add("-pix_fmt");
@@ -210,6 +226,14 @@ public final class ScreenRecorder {
             throw new ScenarioException("Screen recording id must not contain path separators: '" + id + "'");
         }
         return trimmed;
+    }
+
+    static int evenPositive(int value, int fallback) {
+        int resolved = value > 0 ? value : fallback;
+        if ((resolved & 1) != 0) {
+            resolved -= 1;
+        }
+        return Math.max(resolved, 2);
     }
 
     private static boolean ffmpegAvailable() {

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenRecorder.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenRecorder.java
@@ -1,0 +1,254 @@
+package com.adamkali.screenplay;
+
+import net.minecraft.client.Minecraft;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Captures the Minecraft client display via ffmpeg x11grab into an MP4 under
+ * {@code {gameDirectory}/recordings/{id}.mp4}.
+ */
+public final class ScreenRecorder {
+    public static final String RECORD_PROPERTY = "screenplay.record";
+
+    private static final int STOP_WAIT_SECONDS = 8;
+    private static final int DESTROY_WAIT_SECONDS = 3;
+    private static final int DEFAULT_FPS = 30;
+
+    private final Logger logger;
+    private final boolean enabled;
+    private final Object lock = new Object();
+
+    private Process process;
+    private Path outputPath;
+    private Path logFile;
+    private Thread shutdownHook;
+    private boolean started;
+    private boolean stopped;
+
+    ScreenRecorder(Logger logger, boolean enabled) {
+        this.logger = logger;
+        this.enabled = enabled;
+    }
+
+    /**
+     * Reads the optional CLI override from {@link #RECORD_PROPERTY}.
+     *
+     * @return {@code true}/{@code false} when set, or {@code null} when unset
+     */
+    public static Boolean readCliOverride() {
+        String value = System.getProperty(RECORD_PROPERTY);
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if ("true".equalsIgnoreCase(trimmed)) {
+            return true;
+        }
+        if ("false".equalsIgnoreCase(trimmed)) {
+            return false;
+        }
+        throw new ScenarioException("System property '" + RECORD_PROPERTY
+                + "' must be true or false, but was '" + value + "'");
+    }
+
+    /**
+     * Explicit CLI override wins; otherwise use the YAML frontmatter flag.
+     */
+    public static boolean resolveRecord(Boolean cliOverride, boolean yamlRecord) {
+        if (cliOverride != null) {
+            return cliOverride;
+        }
+        return yamlRecord;
+    }
+
+    void ensureStarted(Minecraft client, String scenarioId) {
+        if (!enabled) {
+            return;
+        }
+        synchronized (lock) {
+            if (started || stopped) {
+                return;
+            }
+            start(client, scenarioId);
+            started = true;
+        }
+    }
+
+    void stop() {
+        synchronized (lock) {
+            if (stopped) {
+                return;
+            }
+            stopped = true;
+            if (process == null) {
+                removeShutdownHook();
+                return;
+            }
+            try {
+                if (process.isAlive()) {
+                    try {
+                        OutputStream stdin = process.getOutputStream();
+                        stdin.write('q');
+                        stdin.flush();
+                    } catch (IOException ignored) {
+                        // Fall through to destroy if stdin is closed.
+                    }
+                    if (!process.waitFor(STOP_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                        process.destroy();
+                        if (!process.waitFor(DESTROY_WAIT_SECONDS, TimeUnit.SECONDS)) {
+                            process.destroyForcibly();
+                            process.waitFor(DESTROY_WAIT_SECONDS, TimeUnit.SECONDS);
+                        }
+                    }
+                }
+                if (outputPath != null && Files.isRegularFile(outputPath)) {
+                    logger.info("Screen recording saved {}", outputPath.toAbsolutePath());
+                } else if (started) {
+                    logger.warn("Screen recording did not produce an output file"
+                            + (logFile == null ? "" : "; see " + logFile.toAbsolutePath()));
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                process.destroyForcibly();
+            } finally {
+                process = null;
+                removeShutdownHook();
+            }
+        }
+    }
+
+    private void start(Minecraft client, String scenarioId) {
+        if (scenarioId == null || scenarioId.isBlank()) {
+            throw new ScenarioException("Screen recording requires a non-empty scenario id");
+        }
+        String display = System.getenv("DISPLAY");
+        if (display == null || display.isBlank()) {
+            throw new ScenarioException(
+                    "Screen recording requires $DISPLAY (use -PscreenplayDisplay=display or xvfb)");
+        }
+        if (!ffmpegAvailable()) {
+            throw new ScenarioException(
+                    "Screen recording requires ffmpeg on PATH. Install with: apt install ffmpeg");
+        }
+
+        Path recordingsDir = client.gameDirectory.toPath().resolve("recordings");
+        try {
+            Files.createDirectories(recordingsDir);
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not create recordings directory " + recordingsDir, exception);
+        }
+        outputPath = recordingsDir.resolve(sanitizeFileName(scenarioId) + ".mp4");
+        logFile = recordingsDir.resolve(sanitizeFileName(scenarioId) + ".ffmpeg.log");
+
+        int width = evenPositive(client.getWindow().getWidth(), 1280);
+        int height = evenPositive(client.getWindow().getHeight(), 720);
+        List<String> command = buildFfmpegCommand(display, width, height, outputPath);
+
+        ProcessBuilder builder = new ProcessBuilder(command);
+        builder.redirectErrorStream(true);
+        builder.redirectOutput(ProcessBuilder.Redirect.to(logFile.toFile()));
+
+        try {
+            process = builder.start();
+        } catch (IOException exception) {
+            throw new ScenarioException("Could not start ffmpeg screen recording", exception);
+        }
+        if (!process.isAlive()) {
+            throw new ScenarioException("ffmpeg exited immediately while starting screen recording"
+                    + (logFile == null ? "" : ". See " + logFile.toAbsolutePath()));
+        }
+
+        shutdownHook = new Thread(this::stop, "screenplay-screen-recorder-shutdown");
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        logger.info(
+                "Started screen recording pid {} -> {} ({}x{} @ {}fps on DISPLAY={})",
+                process.pid(),
+                outputPath.toAbsolutePath(),
+                width,
+                height,
+                DEFAULT_FPS,
+                display
+        );
+    }
+
+    static List<String> buildFfmpegCommand(String display, int width, int height, Path outputPath) {
+        List<String> command = new ArrayList<>();
+        command.add("ffmpeg");
+        command.add("-y");
+        command.add("-f");
+        command.add("x11grab");
+        command.add("-framerate");
+        command.add(Integer.toString(DEFAULT_FPS));
+        command.add("-video_size");
+        command.add(width + "x" + height);
+        command.add("-i");
+        command.add(display);
+        command.add("-c:v");
+        command.add("libx264");
+        command.add("-pix_fmt");
+        command.add("yuv420p");
+        command.add("-preset");
+        command.add("ultrafast");
+        command.add(outputPath.toAbsolutePath().toString());
+        return command;
+    }
+
+    static String sanitizeFileName(String id) {
+        String trimmed = id.trim();
+        if (trimmed.isEmpty()) {
+            throw new ScenarioException("Screen recording id must be non-empty");
+        }
+        if (trimmed.contains("/") || trimmed.contains("\\") || trimmed.contains("..")) {
+            throw new ScenarioException("Screen recording id must not contain path separators: '" + id + "'");
+        }
+        return trimmed;
+    }
+
+    static int evenPositive(int value, int fallback) {
+        int resolved = value > 0 ? value : fallback;
+        if ((resolved & 1) != 0) {
+            resolved -= 1;
+        }
+        return Math.max(resolved, 2);
+    }
+
+    private static boolean ffmpegAvailable() {
+        try {
+            Process which = new ProcessBuilder("which", "ffmpeg").redirectErrorStream(true).start();
+            if (!which.waitFor(5, TimeUnit.SECONDS)) {
+                which.destroyForcibly();
+                return false;
+            }
+            return which.exitValue() == 0;
+        } catch (IOException | InterruptedException exception) {
+            if (exception instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            return false;
+        }
+    }
+
+    private void removeShutdownHook() {
+        if (shutdownHook == null) {
+            return;
+        }
+        try {
+            Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } catch (IllegalStateException ignored) {
+            // JVM is already shutting down.
+        }
+        shutdownHook = null;
+    }
+}

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenplayBootstrap.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/ScreenplayBootstrap.java
@@ -33,25 +33,34 @@ public final class ScreenplayBootstrap {
         try {
             ScenarioCatalog catalog = ScenarioCatalog.loadFromResources(ScreenplayBootstrap.class.getClassLoader());
             Duration timeout = Duration.ofSeconds(readPositiveLong(TIMEOUT_PROPERTY, 30L));
+            Boolean recordOverride = ScreenRecorder.readCliOverride();
             ScenarioDocument.Type type = catalog.resolveExecutableType(scenarioId);
             if (type == ScenarioDocument.Type.SUITE) {
                 SuitePlan suite = new ScenarioCompiler(catalog).compileSuite(scenarioId);
-                ScenarioRunner runner = new ScenarioRunner(suite, reportWriter, timeout, LOGGER);
+                boolean record = ScreenRecorder.resolveRecord(recordOverride, suite.record());
+                ScenarioRunner runner = new ScenarioRunner(suite, reportWriter, timeout, LOGGER, record);
                 platform.registerEndClientTick(runner::tick);
                 LOGGER.info(
-                        "Loaded suite '{}' with {} tests (before-all={}, before-each={}, after-each={}, after-all={})",
+                        "Loaded suite '{}' with {} tests (before-all={}, before-each={}, after-each={}, after-all={}, record={})",
                         suite.id(),
                         suite.tests().size(),
                         suite.beforeAll().size(),
                         suite.beforeEach().size(),
                         suite.afterEach().size(),
-                        suite.afterAll().size()
+                        suite.afterAll().size(),
+                        record
                 );
             } else {
                 ScenarioPlan plan = new ScenarioCompiler(catalog).compile(scenarioId);
-                ScenarioRunner runner = new ScenarioRunner(plan, reportWriter, timeout, LOGGER);
+                boolean record = ScreenRecorder.resolveRecord(recordOverride, plan.record());
+                ScenarioRunner runner = new ScenarioRunner(plan, reportWriter, timeout, LOGGER, record);
                 platform.registerEndClientTick(runner::tick);
-                LOGGER.info("Loaded scenario '{}' with {} primitive steps", plan.id(), plan.steps().size());
+                LOGGER.info(
+                        "Loaded scenario '{}' with {} primitive steps (record={})",
+                        plan.id(),
+                        plan.steps().size(),
+                        record
+                );
             }
         } catch (RuntimeException exception) {
             LOGGER.error("Could not start scenario '{}'", scenarioId, exception);

--- a/screenplay/common/src/main/java/com/adamkali/screenplay/SuitePlan.java
+++ b/screenplay/common/src/main/java/com/adamkali/screenplay/SuitePlan.java
@@ -9,7 +9,8 @@ public record SuitePlan(
         List<ScenarioPlan.Step> beforeEach,
         List<ScenarioPlan.Step> afterEach,
         List<ScenarioPlan.Step> afterAll,
-        List<ScenarioPlan> tests
+        List<ScenarioPlan> tests,
+        boolean record
 ) {
     public SuitePlan {
         beforeAll = List.copyOf(beforeAll);

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioReportWriterTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioReportWriterTest.java
@@ -19,7 +19,7 @@ class ScenarioReportWriterTest {
 
     @Test
     void metricsJson_includesSchemaScenarioTotalsAndSteps() {
-        ScenarioPlan plan = new ScenarioPlan("placeBlock", "Place Block", List.of());
+        ScenarioPlan plan = new ScenarioPlan("placeBlock", "Place Block", List.of(), false);
         List<ScenarioReportWriter.StepResult> results = List.of(
                 new ScenarioReportWriter.StepResult("useItem", 12_300_000L, true),
                 new ScenarioReportWriter.StepResult("waitUntil block \"minecraft:dirt\"", 48_000_000L, true)
@@ -43,7 +43,7 @@ class ScenarioReportWriterTest {
 
     @Test
     void metricsJson_marksFailedWhenFailurePresent() {
-        ScenarioPlan plan = new ScenarioPlan("createWorld", "Create World", List.of());
+        ScenarioPlan plan = new ScenarioPlan("createWorld", "Create World", List.of(), false);
         String json = ScenarioReportWriter.metricsJson(
                 plan,
                 List.of(new ScenarioReportWriter.StepResult("launchGame", 1_000_000L, false)),
@@ -58,7 +58,7 @@ class ScenarioReportWriterTest {
 
     @Test
     void metricsJson_bootstrapFailureHasEmptySteps() {
-        ScenarioPlan plan = new ScenarioPlan("broken", "broken", List.of());
+        ScenarioPlan plan = new ScenarioPlan("broken", "broken", List.of(), false);
         JSONObject json = new JSONObject(ScenarioReportWriter.metricsJson(plan, List.of(), "boom"));
 
         assertFalse(json.getBoolean("passed"));
@@ -77,7 +77,8 @@ class ScenarioReportWriterTest {
                 List.of(),
                 List.of(),
                 List.of(),
-                List.of(new ScenarioPlan("memberA", "Member A", List.of()))
+                List.of(new ScenarioPlan("memberA", "Member A", List.of(), false)),
+                false
         );
         List<ScenarioReportWriter.CaseResult> cases = List.of(
                 new ScenarioReportWriter.CaseResult(
@@ -123,7 +124,7 @@ class ScenarioReportWriterTest {
     void write_emitsMetricsBesideReport() throws Exception {
         Path reportFile = tempDir.resolve("report.xml");
         ScenarioReportWriter writer = new ScenarioReportWriter(reportFile);
-        ScenarioPlan plan = new ScenarioPlan("placeBlock", "Place Block", List.of());
+        ScenarioPlan plan = new ScenarioPlan("placeBlock", "Place Block", List.of(), false);
         List<ScenarioReportWriter.StepResult> results = List.of(
                 new ScenarioReportWriter.StepResult("useItem", 5_000_000L, true)
         );

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenRecorderTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenRecorderTest.java
@@ -44,6 +44,14 @@ class ScreenRecorderTest {
     }
 
     @Test
+    void evenPositive_roundsDownOddSizes() {
+        assertEquals(1280, ScreenRecorder.evenPositive(1280, 800));
+        assertEquals(720, ScreenRecorder.evenPositive(721, 800));
+        assertEquals(800, ScreenRecorder.evenPositive(0, 800));
+        assertEquals(2, ScreenRecorder.evenPositive(1, 1));
+    }
+
+    @Test
     void sanitizeFileName_rejectsPathSeparators() {
         assertEquals("createWorld", ScreenRecorder.sanitizeFileName("createWorld"));
         assertThrows(ScenarioException.class, () -> ScreenRecorder.sanitizeFileName("../escape"));
@@ -51,14 +59,14 @@ class ScreenRecorderTest {
     }
 
     @Test
-    void buildFfmpegCommand_includesX11grabAndOutput(@TempDir Path tempDir) {
+    void buildFfmpegCommand_includesX11grabWindowRegion(@TempDir Path tempDir) {
         Path output = tempDir.resolve("createWorld.mp4");
-        List<String> command = ScreenRecorder.buildFfmpegCommand(":99", output);
+        List<String> command = ScreenRecorder.buildFfmpegCommand(":99", 213, 272, 854, 480, output);
 
         assertEquals("ffmpeg", command.get(0));
         assertTrue(command.contains("x11grab"));
-        assertTrue(command.contains(":99"));
-        assertFalse(command.contains("-video_size"));
+        assertTrue(command.contains("854x480"));
+        assertTrue(command.contains(":99+213,272"));
         assertEquals(output.toAbsolutePath().toString(), command.getLast());
     }
 

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenRecorderTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenRecorderTest.java
@@ -44,14 +44,6 @@ class ScreenRecorderTest {
     }
 
     @Test
-    void evenPositive_roundsDownOddSizes() {
-        assertEquals(1280, ScreenRecorder.evenPositive(1280, 800));
-        assertEquals(720, ScreenRecorder.evenPositive(721, 800));
-        assertEquals(800, ScreenRecorder.evenPositive(0, 800));
-        assertEquals(2, ScreenRecorder.evenPositive(1, 1));
-    }
-
-    @Test
     void sanitizeFileName_rejectsPathSeparators() {
         assertEquals("createWorld", ScreenRecorder.sanitizeFileName("createWorld"));
         assertThrows(ScenarioException.class, () -> ScreenRecorder.sanitizeFileName("../escape"));
@@ -61,12 +53,12 @@ class ScreenRecorderTest {
     @Test
     void buildFfmpegCommand_includesX11grabAndOutput(@TempDir Path tempDir) {
         Path output = tempDir.resolve("createWorld.mp4");
-        List<String> command = ScreenRecorder.buildFfmpegCommand(":99", 854, 480, output);
+        List<String> command = ScreenRecorder.buildFfmpegCommand(":99", output);
 
         assertEquals("ffmpeg", command.get(0));
         assertTrue(command.contains("x11grab"));
-        assertTrue(command.contains("854x480"));
         assertTrue(command.contains(":99"));
+        assertFalse(command.contains("-video_size"));
         assertEquals(output.toAbsolutePath().toString(), command.getLast());
     }
 

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenRecorderTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenRecorderTest.java
@@ -1,0 +1,129 @@
+package com.adamkali.screenplay;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ScreenRecorderTest {
+    @AfterEach
+    void clearProperties() {
+        System.clearProperty(ScreenRecorder.RECORD_PROPERTY);
+    }
+
+    @Test
+    void resolveRecord_cliOverridesYaml() {
+        assertTrue(ScreenRecorder.resolveRecord(true, false));
+        assertFalse(ScreenRecorder.resolveRecord(false, true));
+        assertTrue(ScreenRecorder.resolveRecord(null, true));
+        assertFalse(ScreenRecorder.resolveRecord(null, false));
+    }
+
+    @Test
+    void readCliOverride_parsesTrueFalseAndUnset() {
+        assertNull(ScreenRecorder.readCliOverride());
+
+        System.setProperty(ScreenRecorder.RECORD_PROPERTY, "true");
+        assertEquals(true, ScreenRecorder.readCliOverride());
+
+        System.setProperty(ScreenRecorder.RECORD_PROPERTY, "FALSE");
+        assertEquals(false, ScreenRecorder.readCliOverride());
+
+        System.setProperty(ScreenRecorder.RECORD_PROPERTY, "maybe");
+        ScenarioException exception = assertThrows(ScenarioException.class, ScreenRecorder::readCliOverride);
+        assertTrue(exception.getMessage().contains("must be true or false"));
+    }
+
+    @Test
+    void evenPositive_roundsDownOddSizes() {
+        assertEquals(1280, ScreenRecorder.evenPositive(1280, 800));
+        assertEquals(720, ScreenRecorder.evenPositive(721, 800));
+        assertEquals(800, ScreenRecorder.evenPositive(0, 800));
+        assertEquals(2, ScreenRecorder.evenPositive(1, 1));
+    }
+
+    @Test
+    void sanitizeFileName_rejectsPathSeparators() {
+        assertEquals("createWorld", ScreenRecorder.sanitizeFileName("createWorld"));
+        assertThrows(ScenarioException.class, () -> ScreenRecorder.sanitizeFileName("../escape"));
+        assertThrows(ScenarioException.class, () -> ScreenRecorder.sanitizeFileName("a/b"));
+    }
+
+    @Test
+    void buildFfmpegCommand_includesX11grabAndOutput(@TempDir Path tempDir) {
+        Path output = tempDir.resolve("createWorld.mp4");
+        List<String> command = ScreenRecorder.buildFfmpegCommand(":99", 854, 480, output);
+
+        assertEquals("ffmpeg", command.get(0));
+        assertTrue(command.contains("x11grab"));
+        assertTrue(command.contains("854x480"));
+        assertTrue(command.contains(":99"));
+        assertEquals(output.toAbsolutePath().toString(), command.getLast());
+    }
+
+    @Test
+    void catalogParsesRecordFrontmatter(@TempDir Path root) throws Exception {
+        Files.writeString(root.resolve("recorded.yaml"), """
+                ---
+                name: Recorded
+                type: test
+                record: true
+                ---
+                steps:
+                  - launchGame
+                """);
+        Files.writeString(root.resolve("plain.yaml"), """
+                ---
+                name: Plain
+                type: test
+                ---
+                steps:
+                  - launchGame
+                """);
+        Files.writeString(root.resolve("recordedSuite.yaml"), """
+                ---
+                name: Recorded Suite
+                type: suite
+                record: true
+                ---
+                tests:
+                  - plain
+                """);
+
+        ScenarioCatalog catalog = ScenarioCatalog.load(root);
+        assertTrue(catalog.requireTest("recorded").record());
+        assertFalse(catalog.requireTest("plain").record());
+        assertTrue(catalog.requireSuite("recordedSuite").record());
+
+        ScenarioPlan recordedPlan = new ScenarioCompiler(catalog).compile("recorded");
+        assertTrue(recordedPlan.record());
+        SuitePlan suitePlan = new ScenarioCompiler(catalog).compileSuite("recordedSuite");
+        assertTrue(suitePlan.record());
+        assertFalse(suitePlan.tests().getFirst().record());
+    }
+
+    @Test
+    void catalogRejectsNonBooleanRecord(@TempDir Path root) throws Exception {
+        Files.writeString(root.resolve("invalid.yaml"), """
+                ---
+                name: Invalid
+                type: test
+                record: maybe
+                ---
+                steps:
+                  - launchGame
+                """);
+
+        ScenarioException exception = assertThrows(ScenarioException.class, () -> ScenarioCatalog.load(root));
+        assertTrue(exception.getMessage().contains("'record' must be a boolean"));
+    }
+}

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenplayBootstrapTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScreenplayBootstrapTest.java
@@ -16,6 +16,7 @@ class ScreenplayBootstrapTest {
         System.clearProperty(ScreenplayBootstrap.SCENARIO_PROPERTY);
         System.clearProperty(ScreenplayBootstrap.REPORT_PROPERTY);
         System.clearProperty(ScreenplayBootstrap.TIMEOUT_PROPERTY);
+        System.clearProperty(ScreenRecorder.RECORD_PROPERTY);
     }
 
     @Test

--- a/screenplay/docs/docs/quickstart.md
+++ b/screenplay/docs/docs/quickstart.md
@@ -57,8 +57,9 @@ On a machine with a real display, omit `-PscreenplayDisplay` or use `display`.
 | `-Pscreenplay=<id>` | YAML filename stem to run |
 | `-PscreenplayDisplay=display\|xvfb` | Framebuffer strategy (default `display`) |
 | `-PscreenplayTimeout=<seconds>` | Per-step timeout (default 30) |
+| `-PscreenplayRecord=true\|false` | Screen-record the client (requires `ffmpeg`) |
 
-Results land under `build/screenplay/` (JUnit XML, metrics, diagnostics, screenshots). Details: [Running tests](running-tests.md).
+Results land under `build/screenplay/` (JUnit XML, metrics, diagnostics, screenshots, optional recordings). Details: [Running tests](running-tests.md).
 
 ## 4. Next steps
 

--- a/screenplay/docs/docs/reference/gradle-plugin.md
+++ b/screenplay/docs/docs/reference/gradle-plugin.md
@@ -42,6 +42,8 @@ run standalone.
 | `-Pscreenplay=<id>` | Scenario filename stem |
 | `-PscreenplayTimeout=<seconds>` | Per-step timeout (default 30) |
 | `-PscreenplayDisplay=display\|xvfb` | Framebuffer strategy (default `display`) |
+| `-PscreenplayRecord=true\|false` | Override screen recording (requires `ffmpeg`) |
+| `-PscreenplayBaselinesDir=<dir>` | Baseline PNGs for `captureScreenshot` compare |
 
 ## Dependencies
 

--- a/screenplay/docs/docs/running-tests.md
+++ b/screenplay/docs/docs/running-tests.md
@@ -60,6 +60,25 @@ slow soft-GL CI:
 second** timeout floor; `-PscreenplayTimeout` still raises that floor when set
 higher.
 
+## Screen recording
+
+Opt in to capture the client display as an MP4 via ffmpeg x11grab (Linux/X11,
+including `xvfb`):
+
+```bash
+./screenplay/gradlew runScreenplay -Pscreenplay=createWorld \
+  -PscreenplayDisplay=xvfb \
+  -PscreenplayRecord=true
+```
+
+| Source | Behavior |
+| --- | --- |
+| `-PscreenplayRecord=true\|false` | Explicit CLI override (sets `screenplay.record`) |
+| YAML frontmatter `record: true` | Per-scenario/suite default when the Gradle property is unset |
+
+Requires `ffmpeg` on `PATH` (`apt install ffmpeg`). One recording is written per
+client session as `build/screenplay/run/recordings/<id>.mp4`.
+
 ## Outputs
 
 | Path | Contents |
@@ -68,6 +87,7 @@ higher.
 | `build/screenplay/metrics.json` | Wall-clock step timings |
 | `build/screenplay/diagnostics.txt` | Current screen and visible widgets |
 | `build/screenplay/run/screenshots/` | PNGs from `captureScreenshot` (and `{stem}-diff.png` on compare failures) |
+| `build/screenplay/run/recordings/` | MP4s when recording is enabled |
 | `build/screenplay/results/<id>/` | Per-scenario copies from `runScreenplayTests` |
 | `build/screenplay/vanilla-server/` | Official dedicated-server dir from `startVanillaServer` |
 
@@ -95,11 +115,13 @@ The plugin sets (among others):
 - `screenplay.report-file`
 - `screenplay.vanilla-server-dir`
 - `screenplay.baselines-dir` — when `-PscreenplayBaselinesDir` is set
+- `screenplay.record` — when `-PscreenplayRecord` is set
 
 ## CI tips
 
 - Prefer `-PscreenplayDisplay=xvfb` on headless Linux runners.
-- Upload `report.xml`, `metrics.json`, diagnostics, and screenshots as workflow
+- Upload `report.xml`, `metrics.json`, diagnostics, screenshots, and recordings as workflow
   artifacts for agent and human review (and as the next `main` screenshot baseline).
 - On PRs, prepare baselines with `.github/scripts/prepare-screenplay-baselines.sh`
   before `runScreenplayTests`.
+- Screen recording needs `ffmpeg` in addition to `xvfb`.

--- a/screenplay/docs/docs/writing-scenarios.md
+++ b/screenplay/docs/docs/writing-scenarios.md
@@ -10,10 +10,17 @@ role; the frontmatter `type` does.
 ---
 name: Create World
 type: test
+record: true
 ---
 steps:
   - launchGame
 ```
+
+| Field | Required | Role |
+| --- | --- | --- |
+| `name` | yes | Display name in reports |
+| `type` | yes | `test`, `command`, or `suite` |
+| `record` | no | When `true`, record the client display to an MP4 for this run (default `false`). Overridden by `-PscreenplayRecord`. |
 
 | `type` | Role |
 | --- | --- |
@@ -25,6 +32,10 @@ The **filename stem** is the stable ID. For example,
 `subflows/assertAndClick.yaml` defines `assertAndClick`. Duplicate test,
 command, or suite IDs are rejected even when files live in different
 directories.
+
+For `type: suite`, `record: true` records the **entire suite session** as one
+video. Member-test `record` flags are ignored when those tests run under the
+suite.
 
 ## Suites
 

--- a/screenplay/gradle-plugin/src/main/groovy/com/adamkali/screenplay/gradle/ScreenplayPlugin.groovy
+++ b/screenplay/gradle-plugin/src/main/groovy/com/adamkali/screenplay/gradle/ScreenplayPlugin.groovy
@@ -109,12 +109,14 @@ guiScale:1
         def scenarioId = project.providers.gradleProperty('screenplay').orElse('createWorld')
         def timeout = project.providers.gradleProperty('screenplayTimeout').orElse('30')
         def baselinesDirProperty = project.providers.gradleProperty('screenplayBaselinesDir')
+        def recordProperty = project.providers.gradleProperty('screenplayRecord')
         def reportFile = project.layout.buildDirectory.file("${extension.outputDir}/report.xml").get().asFile.absolutePath
         def vanillaServerDir = project.layout.buildDirectory.dir("${extension.outputDir}/vanilla-server").get().asFile.absolutePath
         def runDir = extension.runDir
         def baselinesDir = baselinesDirProperty.isPresent()
                 ? project.file(baselinesDirProperty.get()).absolutePath
                 : null
+        def recordValue = recordProperty.isPresent() ? normalizeRecordProperty(recordProperty.get()) : null
 
         if (loader == 'fabric') {
             def loom = project.extensions.findByName('loom')
@@ -137,6 +139,9 @@ guiScale:1
             run.property 'screenplay.vanilla-server-dir', vanillaServerDir
             if (baselinesDir != null) {
                 run.property 'screenplay.baselines-dir', baselinesDir
+            }
+            if (recordValue != null) {
+                run.property 'screenplay.record', recordValue
             }
             run.runDir runDir
 
@@ -183,14 +188,27 @@ guiScale:1
                 if (baselinesDir != null) {
                     run.systemProperty 'screenplay.baselines-dir', baselinesDir
                 }
+                if (recordValue != null) {
+                    run.systemProperty 'screenplay.record', recordValue
+                }
             }
         } catch (Throwable ex) {
             project.logger.warn("Screenplay could not fully configure ${loader} run: ${ex.message}")
         }
     }
 
+    private static String normalizeRecordProperty(String raw) {
+        def value = raw == null ? '' : raw.trim().toLowerCase()
+        if (!(value in ['true', 'false'])) {
+            throw new GradleException(
+                    "Invalid -PscreenplayRecord='${raw}'. Allowed values: true, false.")
+        }
+        return value
+    }
+
     private static void configureDisplayOnRunTask(Project project, ScreenplayExtension extension) {
         def displayMode = project.providers.gradleProperty('screenplayDisplay').orElse('display')
+        def recordProperty = project.providers.gradleProperty('screenplayRecord')
         project.tasks.configureEach { task ->
             if (!(task.name in ['runScreenplay', 'runScreenplayClient'])) {
                 return
@@ -232,6 +250,14 @@ guiScale:1
                                 'screenplayDisplay=xvfb requires xvfb-run on PATH. Install with: apt install xvfb')
                     }
                 }
+                if (recordProperty.isPresent() && normalizeRecordProperty(recordProperty.get()) == 'true') {
+                    def ffmpeg = new ProcessBuilder('which', 'ffmpeg').redirectErrorStream(true).start()
+                    ffmpeg.waitFor()
+                    if (ffmpeg.exitValue() != 0) {
+                        throw new GradleException(
+                                'screenplayRecord=true requires ffmpeg on PATH. Install with: apt install ffmpeg')
+                    }
+                }
             }
         }
     }
@@ -240,6 +266,7 @@ guiScale:1
         def displayMode = project.providers.gradleProperty('screenplayDisplay').orElse('display')
         def timeoutProperty = project.providers.gradleProperty('screenplayTimeout')
         def baselinesDirProperty = project.providers.gradleProperty('screenplayBaselinesDir')
+        def recordProperty = project.providers.gradleProperty('screenplayRecord')
         def projectDirFile = project.layout.projectDirectory.asFile
         def resultsRoot = project.layout.buildDirectory.dir("${extension.outputDir}/results")
         def testsDirs = extension.allTestsDirs()
@@ -283,6 +310,9 @@ guiScale:1
                     if (baselinesDirProperty.isPresent()) {
                         args << "-PscreenplayBaselinesDir=${baselinesDirProperty.get()}"
                     }
+                    if (recordProperty.isPresent()) {
+                        args << "-PscreenplayRecord=${recordProperty.get()}"
+                    }
                     def result = execOps.exec {
                         workingDir projectDirFile
                         commandLine args
@@ -305,6 +335,13 @@ guiScale:1
                         project.copy {
                             from screenshots
                             into new File(archiveDir, 'screenshots')
+                        }
+                    }
+                    def recordings = new File(projectDirFile, "build/${extension.outputDir}/run/recordings")
+                    if (recordings.isDirectory()) {
+                        project.copy {
+                            from recordings
+                            into new File(archiveDir, 'recordings')
                         }
                     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Screenplay scenarios are hard to debug or demo from logs alone; an opt-in MP4 of the client run makes failures and walkthroughs reviewable without a live display.

## Proposed Implementation

- Add `-PscreenplayRecord=true|false` (system property `screenplay.record`) and YAML frontmatter `record: true|false`, with CLI overriding YAML when set.
- Capture the Minecraft GLFW window region with ffmpeg x11grab into `build/screenplay/run/recordings/<id>.mp4`; archive recordings from `runScreenplayTests`.
- Wire start/stop through `ScreenRecorder` + `ScenarioRunner` lifecycle; fail fast when recording is enabled without ffmpeg/`$DISPLAY`.
- Docs and unit tests for precedence, frontmatter parsing, and ffmpeg command construction.

## Problems Encountered / Decisions Made

- Recording is Linux/X11-focused (including xvfb), matching existing display modes; non-X11 platforms are out of scope.
- SnakeYAML treats YAML 1.1 `yes`/`no` as booleans, so invalid-record tests use a non-boolean string (`maybe`).
- Full-display capture letterboxed the GLFW window under xvfb; final approach uses window `x/y/width/height` with ffmpeg `DISPLAY+x,y` offsets.

## Verification

- `./screenplay/gradlew :common:test` — passed
- Smoke: `runScreenplay -Pscreenplay=createWorld -PscreenplayDisplay=xvfb -PscreenplayRecord=true` produced a framed 854x480 MP4
- Smoke: YAML `record: true` without CLI also produced a recording

<a href="https://cursor.com/agents/bc-01a0448a-39e7-7c5b-aac8-943b2f4433a6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenplay-createWorld-recording.mp4"><img src="https://cursor.com/artifacts/c/art-6d2300cc-9bcb-4a79-a2c8-77934045dc81" alt="screenplay-createWorld-recording.mp4" /></a>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0448a-39e7-7c5b-aac8-943b2f4433a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0448a-39e7-7c5b-aac8-943b2f4433a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

