### PR TITLE
chore(dev): unpack named Minecraft sources for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,10 @@ tickets/
 # Loom / local Fabric tooling caches
 .fabric/
 
+# Generated Minecraft named sources (Mojang EULA — do not commit decompiled .java)
+dwm/minecraft-sources/**
+!dwm/minecraft-sources/README.md
+
 # MkDocs local build output
 screenplay/docs/site/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@
 - `screenplay/docs/`: Screenplay GitHub Pages site (MkDocs Material) — https://adam-k-ali.github.io/DWM/
 - `screenplay/metadata/`: Screenplay Modrinth listing drafts + `version.json`.
 - `.cursor/skills/`: Agent skills for GameTests, asset import, Blockbench models, MCP verify, etc.
+- `dwm/minecraft-sources/`: Generated Fabric Loom named Minecraft sources (gitignored `.java`; run `./dwm/gradlew unpackMinecraftSources`). See **Reading Minecraft sources**.
 
 ## Gradle wrappers (do not use root `./gradlew` for builds)
 
@@ -36,6 +37,7 @@
 | Screenplay client (no DWM) | `./screenplay/gradlew runClient` |
 | DWM YAML scenario | `./dwm/gradlew runScreenplay -Pscreenplay=<id>` |
 | Screenplay library demos | `./screenplay/gradlew runScreenplay -Pscreenplay=createWorld` |
+| Minecraft named sources (Grep) | `./dwm/gradlew unpackMinecraftSources` |
 
 DWM consumes Screenplay via composite `includeBuild('../screenplay')` (Maven coords + dependency substitution), not as a Gradle subproject.
 
@@ -60,6 +62,14 @@ DWM consumes Screenplay via composite `includeBuild('../screenplay')` (Maven coo
 - Favor Fabric API events/hooks/utilities before introducing Mixins.
 - Use Mixins only when needed; keep them minimal and as targeted as possible.
 - Maintain compatibility-minded behavior (avoid fragile assumptions about execution order or side effects).
+
+## Reading Minecraft sources
+DWM and Screenplay Fabric use **Mojang official mappings** for the Minecraft version in [`dwm/gradle.properties`](dwm/gradle.properties) / [`gradle/libs.versions.toml`](gradle/libs.versions.toml). There is no `yarn_mappings` line — do not guess Yarn 1.20/1.21 names.
+
+- Path: [`dwm/minecraft-sources/net/minecraft/...`](dwm/minecraft-sources/) (Grep/Read with that path; the repo index will not contain it).
+- If the tree is missing or [`dwm/minecraft-sources/.version`](dwm/minecraft-sources/.version) does not match `minecraft_version`, run `./dwm/gradlew unpackMinecraftSources`. First run may take several minutes (`genSources`); later unpacks are cheap.
+- **Do not** glob `~/.gradle/caches` for `*.java` — that hits NeoForge `ng_execute` transforms (wrong loader). **Do not** extract jars to the repo root.
+- Before reimplementing chunk streaming, lighting, tickets, or similar: open the vanilla class under `dwm/minecraft-sources` and wrap it. Matching vanilla policy is not the same as copying `PlayerChunkSender` (that class sends whole chunks to a `ServerPlayer`).
 
 ## Networking & Side Safety
 - Treat server as authoritative for gameplay/world state changes.
@@ -110,6 +120,7 @@ DWM consumes Screenplay via composite `includeBuild('../screenplay')` (Maven coo
   - `./dwm/gradlew runGametest` — headless GameTests → `dwm/build/gametest/report.xml`
   - `./dwm/gradlew runScreenplay -Pscreenplay=<yaml-stem>` — DWM client YAML scenarios → `dwm/build/screenplay/report.xml`
   - `./dwm/gradlew syncVersionJson` / `checkVersionSync` — keep `dwm/version.json` aligned with `dwm/gradle.properties`
+  - `./dwm/gradlew unpackMinecraftSources` — explode Fabric named Minecraft sources into `dwm/minecraft-sources/` (local/agent; not CI)
 - If a command fails, surface the failure clearly and fix root causes before handoff where possible.
 
 ## Releases / CI
@@ -180,3 +191,4 @@ These notes are for agents running in the Cursor Cloud VM. The standard build/te
 - `./dwm/gradlew build` also compiles the `client` source set and runs the full JUnit suite.
 - `./dwm/gradlew runDatagen` writes generated resources under `dwm/src/main/generated/` and also leaves an untracked `.cache/` directory — delete that `.cache` dir before committing to avoid stray churn.
 - IDE: open `dwm/` as the Gradle project for mod work (composite pulls Screenplay). Open `screenplay/` when working on the harness alone.
+- `./dwm/gradlew unpackMinecraftSources` is local/agent (not CI); first `genSources` on a cold cache is slow.

--- a/dwm/build.gradle
+++ b/dwm/build.gradle
@@ -326,6 +326,58 @@ tasks.named("runDatagen").configure {
     finalizedBy("pruneDatagenItemModels")
 }
 
+/**
+ * Explodes Loom named Minecraft sources (common + client) into minecraft-sources/
+ * so agents can Grep/Read a stable path instead of ~/.gradle caches.
+ * Not part of build/check — first genSources is slow; unpack after that is cheap.
+ */
+tasks.register("unpackMinecraftSources") {
+    group = "fabric"
+    description = "Unpack Fabric Loom named Minecraft sources into minecraft-sources/"
+    dependsOn "genSources"
+    def dest = file("minecraft-sources")
+    def versionFile = file("minecraft-sources/.version")
+    def mcVersion = provider { project.minecraft_version as String }
+    inputs.property "minecraft_version", mcVersion
+    outputs.dir dest
+    doLast {
+        def jars = tasks.withType(net.fabricmc.loom.task.GenerateSourcesTask).collect { t ->
+            t.sourcesOutputJar.get().asFile
+        }.findAll { it.exists() }.unique()
+        if (jars.isEmpty()) {
+            throw new GradleException(
+                    "No Minecraft sources jars found after genSources. " +
+                            "Expected GenerateSourcesTask.sourcesOutputJar files."
+            )
+        }
+        if (dest.directory) {
+            dest.eachFile { f ->
+                if (f.name == "README.md") {
+                    return
+                }
+                if (f.directory) {
+                    f.deleteDir()
+                } else {
+                    f.delete()
+                }
+            }
+        }
+        dest.mkdirs()
+        jars.each { jar ->
+            copy {
+                from zipTree(jar)
+                into dest
+                include "**/*.java"
+            }
+        }
+        versionFile.text = mcVersion.get() + "\n"
+        logger.lifecycle(
+                "Unpacked ${jars.size()} Minecraft sources jar(s) into ${dest} " +
+                        "(minecraft_version=${mcVersion.get()})"
+        )
+    }
+}
+
 test {
     useJUnitPlatform()
 }

--- a/dwm/minecraft-sources/README.md
+++ b/dwm/minecraft-sources/README.md
@@ -1,0 +1,13 @@
+# Minecraft named sources (generated)
+
+Decompiled Fabric Loom sources for the Minecraft version in `dwm/gradle.properties`. Local only — do not commit `.java` files (Mojang EULA).
+
+Regenerate:
+
+```
+./dwm/gradlew unpackMinecraftSources
+```
+
+That depends on `genSources` (slow the first time). Output is `net/minecraft/...` in this directory. `.version` must match `minecraft_version`.
+
+See the **Reading Minecraft sources** section in the repo-root `AGENTS.md`.

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/AGENTS.md
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/AGENTS.md
@@ -24,6 +24,7 @@ Entry orchestration for doors/travel generally flows: block/BE interaction → `
 - Unit tests: `./dwm/gradlew test --tests "com.adamkali.dwm.tardis.*"`
 - GameTests (door/interior/landing/console): `./dwm/gradlew runGametest`
 - YAML client flows (UI/world creation): `./dwm/gradlew runScreenplay -Pscreenplay=placeAndOpenTardis` (see `src/screenplayTests/AGENTS.md`)
+- Vanilla APIs (portal/BOTI/SOTO): Grep `dwm/minecraft-sources` first; unpack with `./dwm/gradlew unpackMinecraftSources` (see repo-root **Reading Minecraft sources**).
 
 ## Conventions
 - **Server authoritative** — mutate `TardisDataModel` on the server; sync to clients via existing payloads/render state, not client-side persistence.
@@ -38,3 +39,4 @@ Entry orchestration for doors/travel generally flows: block/BE interaction → `
 - Chameleon/SOTO paths are config-gated and off by default — do not assume enabled in tests without setting config.
 - Interior rebuild/plot allocation is order-sensitive — check `TardisInteriorGameTests` before changing placement rules.
 - Travel audio assets may be regenerated via `tools/` scripts — commit resulting OGGs under client resources, not fixture WAVs.
+- Do not glob `~/.gradle/caches` for vanilla sources; portal/chunk/light work must read `dwm/minecraft-sources` (not NeoForge `ng_execute` trees).


### PR DESCRIPTION
## Why this matters

Agents working on portal/chunk/lighting need Mojang-mapped Minecraft sources at a stable path. Grepping `~/.gradle/caches` hits NeoForge transforms and the wrong loader.

## Proposed Implementation

- Add `./dwm/gradlew unpackMinecraftSources` to explode Loom `genSources` jars into `dwm/minecraft-sources/` (`.java` gitignored; README kept).
- Document the workflow in root `AGENTS.md` and TARDIS nested `AGENTS.md`.

## Problems Encountered / Decisions Made

- Not wired into `build`/`check` or CI: first `genSources` is slow and the tree is local-only (Mojang EULA).

Made with [Cursor](https://cursor.com)