### PR TITLE
fix(soto): raise portal hitch eye height to standing height

### DIFF
--- a/dwm/src/client/java/com/adamkali/dwm/render/soto/TardisSotoRenderer.java
+++ b/dwm/src/client/java/com/adamkali/dwm/render/soto/TardisSotoRenderer.java
@@ -24,10 +24,8 @@ public final class TardisSotoRenderer {
 
     /**
      * Eye height above the TARDIS block base for the exterior hitch.
-     * Matches the classic chameleon BOTI aperture mid-height (~0.75 would be exact center);
-     * kept slightly lower so the look-out sits nearer the threshold than mid-door.
      */
-    public static final double PREVIEW_EYE_HEIGHT = 0.75;
+    public static final double PREVIEW_EYE_HEIGHT = 1.75;
 
     /**
      * Exterior door opening center in footprint-relative coords


### PR DESCRIPTION
## Why this matters

SOTO look-out was hitching the camera at mid-door height (0.75), so the exterior view sat lower than a standing player looking through the doors.

## Proposed Implementation

- Set `TardisSotoRenderer.PREVIEW_EYE_HEIGHT` to 1.75 (standing eye height above the TARDIS block base).

## Problems Encountered / Decisions Made

None

Made with [Cursor](https://cursor.com)