### PR TITLE
fix(tardis): skip bedrock-ceiling surface landings

### DIFF
--- a/dwm/docs/feature-tardis-block.md
+++ b/dwm/docs/feature-tardis-block.md
@@ -32,6 +32,7 @@ Make the TARDIS a tangible world object that is expressive, interactive, and per
 - Ops `/tardis claim` (permission 2) overwrites ownership to the caller if they do not already own a TARDIS: stand inside an interior, or pass `/tardis claim <uuid>`.
 - Collision entry when the exterior door is open (`doorSwing >= 0.9`); exit via open interior doors.
 - Landing search requires replaceable space in the door-facing column (feet + head), not only the shell cell.
+- Automatic surface landings stay below a dimensional bedrock ceiling (e.g. the Nether roof); exact coordinates on it (waypoint, player, summon, fast return) are unchanged.
 - Single config toggle `enableDoorPortals` (default on) via Mod Menu / Cloth Config; legacy `enableBoti` / `enableSoto` migrate on load.
 - Interior doors use an invisible block + dedicated BER (`TardisClassicInteriorDoorModel`) with swing animation.
 - Materialisation lever travel: first pull dematerialises the exterior; after a short hold the TARDIS enters `IN_FLIGHT`; a second pull materialises at the destination resolved from the active `DestinationMode`.

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/LandingSiteLogic.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/LandingSiteLogic.java
@@ -4,6 +4,7 @@ import com.mojang.datafixers.util.Pair;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.core.Holder;
@@ -11,9 +12,11 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.dimension.DimensionType;
 import net.minecraft.world.level.levelgen.Heightmap;
 
 /**
@@ -70,12 +73,11 @@ public final class LandingSiteLogic {
         BlockPos biomePos = located.getFirst();
         // locateBiome can return coordinates in unloaded chunks; heightmap then reports world bottom.
         world.getChunk(biomePos);
-        int topY = world.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, biomePos.getX(), biomePos.getZ());
-        BlockPos landing = new BlockPos(biomePos.getX(), topY, biomePos.getZ());
-        if (!isValidLanding(world, landing, doorFacing)) {
+        Optional<BlockPos> landing = findSurfaceInColumn(world, biomePos.getX(), biomePos.getZ(), doorFacing);
+        if (landing.isEmpty()) {
             return findNearbyValidLanding(world, biomePos.getX(), biomePos.getZ(), doorFacing);
         }
-        return Optional.of(landing);
+        return landing;
     }
 
     /**
@@ -118,10 +120,9 @@ public final class LandingSiteLogic {
                     int x = originX + dx;
                     int z = originZ + dz;
                     world.getChunk(x >> 4, z >> 4);
-                    int topY = world.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z);
-                    BlockPos candidate = new BlockPos(x, topY, z);
-                    if (isValidLanding(world, candidate, doorFacing)) {
-                        return Optional.of(candidate);
+                    Optional<BlockPos> candidate = findSurfaceInColumn(world, x, z, doorFacing);
+                    if (candidate.isPresent()) {
+                        return candidate;
                     }
                 }
             }
@@ -150,16 +151,85 @@ public final class LandingSiteLogic {
             return Optional.empty();
         }
         world.getChunk(searchOrigin);
-        int topY = world.getHeight(
-                Heightmap.Types.MOTION_BLOCKING_NO_LEAVES,
-                searchOrigin.getX(),
-                searchOrigin.getZ()
-        );
-        BlockPos landing = new BlockPos(searchOrigin.getX(), topY, searchOrigin.getZ());
-        if (isValidLanding(world, landing, doorFacing)) {
-            return Optional.of(landing);
+        Optional<BlockPos> landing = findSurfaceInColumn(
+                world, searchOrigin.getX(), searchOrigin.getZ(), doorFacing);
+        if (landing.isPresent()) {
+            return landing;
         }
         return findNearbyValidLanding(world, searchOrigin.getX(), searchOrigin.getZ(), doorFacing);
+    }
+
+    /**
+     * Exclusive top Y of the playable interior when {@code hasCeiling} is set
+     * (vanilla Nether: {@code minY + logicalHeight} = 128). Empty when there is no ceiling.
+     */
+    public static OptionalInt ceilingExclusiveY(boolean hasCeiling, int minY, int logicalHeight) {
+        if (!hasCeiling) {
+            return OptionalInt.empty();
+        }
+        return OptionalInt.of(minY + logicalHeight);
+    }
+
+    /**
+     * {@link #ceilingExclusiveY(boolean, int, int)} from {@code world}'s dimension type.
+     */
+    public static OptionalInt ceilingExclusiveY(@Nullable LevelReader world) {
+        if (world == null) {
+            return OptionalInt.empty();
+        }
+        DimensionType type = dimensionTypeOf(world);
+        if (type == null) {
+            return OptionalInt.empty();
+        }
+        return ceilingExclusiveY(type.hasCeiling(), world.getMinY(), type.logicalHeight());
+    }
+
+    /**
+     * Heightmap surface, or the highest safe floor below a dimensional ceiling.
+     * Empty when the column has no valid shell cell.
+     */
+    public static Optional<BlockPos> findSurfaceInColumn(
+            LevelReader world,
+            int x,
+            int z,
+            Direction doorFacing
+    ) {
+        return findSurfaceInColumn(world, x, z, doorFacing, ceilingExclusiveY(world));
+    }
+
+    /**
+     * Like {@link #findSurfaceInColumn(LevelReader, int, int, Direction)} with an explicit ceiling cap.
+     */
+    public static Optional<BlockPos> findSurfaceInColumn(
+            LevelReader world,
+            int x,
+            int z,
+            Direction doorFacing,
+            OptionalInt ceilingExclusiveY
+    ) {
+        if (world == null || doorFacing == null) {
+            return Optional.empty();
+        }
+        int heightmapY = world.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z);
+        if (ceilingExclusiveY.isEmpty() || heightmapY < ceilingExclusiveY.getAsInt()) {
+            BlockPos landing = new BlockPos(x, heightmapY, z);
+            if (isValidLanding(world, landing, doorFacing)) {
+                return Optional.of(landing);
+            }
+            return Optional.empty();
+        }
+        int minY = world.getMinY();
+        int startY = ceilingExclusiveY.getAsInt() - 1;
+        for (int y = startY; y > minY; y--) {
+            BlockPos candidate = new BlockPos(x, y, z);
+            if (!isReplaceable(world.getBlockState(candidate))) {
+                continue;
+            }
+            if (isDryValidLanding(world, candidate, doorFacing)) {
+                return Optional.of(candidate);
+            }
+        }
+        return Optional.empty();
     }
 
     /**
@@ -192,7 +262,30 @@ public final class LandingSiteLogic {
         return isReplaceable(doorFeet) && isReplaceable(doorHead);
     }
 
+    private static boolean isDryValidLanding(LevelReader world, BlockPos pos, Direction doorFacing) {
+        if (!isValidLanding(world, pos, doorFacing)) {
+            return false;
+        }
+        BlockPos door = pos.relative(doorFacing);
+        return isDry(world.getBlockState(pos))
+                && isDry(world.getBlockState(pos.above()))
+                && isDry(world.getBlockState(door))
+                && isDry(world.getBlockState(door.above()));
+    }
+
+    private static boolean isDry(BlockState state) {
+        return state.getFluidState().isEmpty();
+    }
+
     private static boolean isReplaceable(BlockState state) {
         return state.isAir() || state.canBeReplaced();
+    }
+
+    @Nullable
+    private static DimensionType dimensionTypeOf(LevelReader world) {
+        if (world instanceof Level level) {
+            return level.dimensionType();
+        }
+        return null;
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/logic/StabiliserLogic.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/logic/StabiliserLogic.java
@@ -8,7 +8,6 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.util.RandomSource;
-import net.minecraft.world.level.levelgen.Heightmap;
 
 /**
  * Stabilisers toggle and unstabilised landing scatter helpers.
@@ -73,10 +72,9 @@ public final class StabiliserLogic {
             lastX = x;
             lastZ = z;
             world.getChunk(x >> 4, z >> 4);
-            int topY = world.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z);
-            BlockPos candidate = new BlockPos(x, topY, z);
-            if (LandingSiteLogic.isValidLanding(world, candidate, doorFacing)) {
-                return Optional.of(candidate);
+            Optional<BlockPos> candidate = LandingSiteLogic.findSurfaceInColumn(world, x, z, doorFacing);
+            if (candidate.isPresent()) {
+                return candidate;
             }
         }
         return LandingSiteLogic.findNearbyValidLanding(world, lastX, lastZ, doorFacing);

--- a/dwm/src/test/java/com/adamkali/dwm/tardis/logic/LandingSiteLogicTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/tardis/logic/LandingSiteLogicTest.java
@@ -1,16 +1,37 @@
 package com.adamkali.dwm.tardis.logic;
 
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.function.IntFunction;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.Heightmap;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 
 class LandingSiteLogicTest {
+    private static final Direction DOOR = Direction.NORTH;
+
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+    }
+
     @Test
     void parseBiome_acceptsValidId() {
         Optional<ResourceKey<Biome>> key = LandingSiteLogic.parseBiome("minecraft:plains");
@@ -24,5 +45,115 @@ class LandingSiteLogicTest {
         assertTrue(LandingSiteLogic.parseBiome("").isEmpty());
         assertTrue(LandingSiteLogic.parseBiome("   ").isEmpty());
         assertTrue(LandingSiteLogic.parseBiome("not a biome").isEmpty());
+    }
+
+    @Test
+    void ceilingExclusiveY_isMinYPlusLogicalHeightWhenHasCeiling() {
+        assertEquals(128, LandingSiteLogic.ceilingExclusiveY(true, 0, 128).orElseThrow());
+        assertEquals(320, LandingSiteLogic.ceilingExclusiveY(true, -64, 384).orElseThrow());
+    }
+
+    @Test
+    void ceilingExclusiveY_emptyWhenNoCeilingOrNullWorld() {
+        assertTrue(LandingSiteLogic.ceilingExclusiveY(false, 0, 128).isEmpty());
+        assertTrue(LandingSiteLogic.ceilingExclusiveY(null).isEmpty());
+    }
+
+    @Test
+    void findSurfaceInColumn_netherLikeSkipsBedrockCeiling() {
+        LevelReader world = column(0, 128, y -> {
+            if (y >= 123 && y <= 127) {
+                return Blocks.BEDROCK.defaultBlockState();
+            }
+            if (y == 69) {
+                return Blocks.NETHERRACK.defaultBlockState();
+            }
+            if (y >= 72 && y <= 122) {
+                return Blocks.NETHERRACK.defaultBlockState();
+            }
+            return Blocks.AIR.defaultBlockState();
+        });
+
+        Optional<BlockPos> landing = LandingSiteLogic.findSurfaceInColumn(
+                world, 8, 8, DOOR, OptionalInt.of(128));
+
+        assertEquals(new BlockPos(8, 70, 8), landing.orElseThrow());
+    }
+
+    @Test
+    void findSurfaceInColumn_overworldUsesHeightmapNotCaveBelow() {
+        LevelReader world = column(-64, 64, y -> {
+            if (y == 63) {
+                return Blocks.GRASS_BLOCK.defaultBlockState();
+            }
+            if (y == 39) {
+                return Blocks.STONE.defaultBlockState();
+            }
+            if (y < 63 && y != 39 && y != 40 && y != 41) {
+                return Blocks.STONE.defaultBlockState();
+            }
+            return Blocks.AIR.defaultBlockState();
+        });
+
+        Optional<BlockPos> landing = LandingSiteLogic.findSurfaceInColumn(
+                world, 0, 0, DOOR, OptionalInt.empty());
+
+        assertEquals(new BlockPos(0, 64, 0), landing.orElseThrow());
+    }
+
+    @Test
+    void findSurfaceInColumn_hasCeilingButHeightmapBelowCapUsesHeightmap() {
+        LevelReader world = column(0, 15, y -> {
+            if (y == 14) {
+                return Blocks.STONE.defaultBlockState();
+            }
+            return Blocks.AIR.defaultBlockState();
+        });
+
+        Optional<BlockPos> landing = LandingSiteLogic.findSurfaceInColumn(
+                world, 4, 4, DOOR, OptionalInt.of(256));
+
+        assertEquals(new BlockPos(4, 15, 4), landing.orElseThrow());
+    }
+
+    @Test
+    void findSurfaceInColumn_lavaSeaUnderCeilingIsNotALanding() {
+        LevelReader world = column(0, 128, y -> {
+            if (y >= 123 && y <= 127) {
+                return Blocks.BEDROCK.defaultBlockState();
+            }
+            if (y <= 31) {
+                return Blocks.NETHERRACK.defaultBlockState();
+            }
+            return Blocks.LAVA.defaultBlockState();
+        });
+
+        assertTrue(LandingSiteLogic.findSurfaceInColumn(
+                world, 3, 3, DOOR, OptionalInt.of(128)).isEmpty());
+    }
+
+    @Test
+    void isValidLanding_acceptsNetherRoofForExactCoords() {
+        LevelReader world = column(0, 128, y -> {
+            if (y <= 127) {
+                return Blocks.BEDROCK.defaultBlockState();
+            }
+            return Blocks.AIR.defaultBlockState();
+        });
+
+        assertTrue(LandingSiteLogic.isValidLanding(world, new BlockPos(0, 128, 0), DOOR));
+    }
+
+    private static LevelReader column(int minY, int heightmapY, IntFunction<BlockState> atY) {
+        LevelReader world = Mockito.mock(LevelReader.class);
+        Mockito.when(world.getMinY()).thenReturn(minY);
+        Mockito.when(world.getHeight(eq(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES), anyInt(), anyInt()))
+                .thenReturn(heightmapY);
+        Mockito.when(world.isOutsideBuildHeight(any(BlockPos.class))).thenReturn(false);
+        Mockito.when(world.getBlockState(any(BlockPos.class))).thenAnswer(invocation -> {
+            BlockPos pos = invocation.getArgument(0);
+            return atY.apply(pos.getY());
+        });
+        return world;
     }
 }


### PR DESCRIPTION
## Why this matters

- Travelling to the Nether (and other ceiling dimensions) was putting the TARDIS on the bedrock roof, which is not a useful automatic landing.

## Proposed Implementation

- Surface search now clamps to `minY + logicalHeight` when the dimension `hasCeiling()`, then scans down for the highest dry valid floor.
- Biome landing, untagged surface search, nearby fallback, and unstabilised scatter all use `findSurfaceInColumn`.
- Exact destinations (waypoint, player locator, summon, fast return) can still land on the roof when that cell is already valid.
- Unit tests cover cap math, a Nether-like column, overworld heightmap (no cave scan), lava seas, and roof validity for exact coords.

## Problems Encountered / Decisions Made

- `isValidLanding` is unchanged so intentional roof landings keep working; only automatic heightmap picks skip the ceiling.
- Downward scan also requires empty fluid at feet/head/door so a lava sea is not treated as a floor.


Made with [Cursor](https://cursor.com)