### PR TITLE
fix(screenplay): wait for door click before TARDIS walk-in

### DIFF
--- a/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
+++ b/dwm/src/screenplayTests/resources/tests/portalLightingAndFog.yaml
@@ -42,6 +42,9 @@ steps:
       y: "~"
       z: "~"
   - useItem
+  # Server validates use-item reach when the packet is applied. Teleporting in the
+  # same tick drops the door toggle; wait like placeAndOpenTardis so the click lands.
+  - waitTicks: 25
   - runCommand: "/tp @s ~-3 ~1 ~"
   - lookAt:
       x: "~3"
@@ -53,6 +56,12 @@ steps:
       compare: true
   # Switch the exterior to day so SOTO exercises streamed sky light as well as the sea-lantern source.
   - runCommand: "/time set day"
+  # Dimension walkUntil holds forward without re-aiming; look at the exterior again
+  # after the long BOTI wait so we walk into the open door, not past it.
+  - lookAt:
+      x: "~4"
+      y: "~1"
+      z: "~"
   - walkUntil:
       dimension: dwm:tardis
   - runCommand: "/tp @s ~ ~ ~4"

--- a/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
+++ b/screenplay/common/src/test/java/com/adamkali/screenplay/ScenarioCompilerTest.java
@@ -1559,12 +1559,12 @@ class ScenarioCompilerTest {
         ScenarioPlan plan = new ScenarioCompiler(ScenarioCatalog.load(scenarioRoot))
                 .compile("portalLightingAndFog");
 
-        assertEquals(32, plan.steps().size());
-        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(25).arguments().get("name"));
-        assertEquals(true, plan.steps().get(25).arguments().get("compare"));
-        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(27).displayName());
-        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(31).arguments().get("name"));
-        assertEquals(true, plan.steps().get(31).arguments().get("compare"));
+        assertEquals(34, plan.steps().size());
+        assertEquals("portal-lighting-fog-boti.png", plan.steps().get(26).arguments().get("name"));
+        assertEquals(true, plan.steps().get(26).arguments().get("compare"));
+        assertEquals("walkUntil dimension \"dwm:tardis\"", plan.steps().get(29).displayName());
+        assertEquals("portal-lighting-fog-soto.png", plan.steps().get(33).arguments().get("name"));
+        assertEquals(true, plan.steps().get(33).arguments().get("compare"));
     }
 
     @Test


### PR DESCRIPTION
## Why this matters

- `portalLightingAndFog` is failing CI on `main`: the player never enters the TARDIS, so the SOTO lighting screenshot never runs and the Screenplay job fails the merge gate.

## Proposed Implementation

- Wait 25 ticks after the door `useItem` (same pattern as `placeAndOpenTardis`) so the server applies the toggle while the player is still in reach.
- Re-aim at the exterior before `walkUntil`, because dimension-mode walking holds forward without updating look direction.
- Update `ScenarioCompilerTest` step counts for the extra primitives.

## Problems Encountered / Decisions Made

- CI artifact `portal-lighting-fog-boti.png` showed a closed box; the passing `placeAndOpenTardis` shot showed an open interior. Root cause was teleporting in the same tick as `useItem`, which drops the door click on the server reach check — not a `walkUntil` or lighting bug.

Made with [Cursor](https://cursor.com)