### PR TITLE
feat(gallifrey): add villages remapped from vanilla plains layouts

### DIFF
--- a/dwm/docs/feature-gallifrey-building.md
+++ b/dwm/docs/feature-gallifrey-building.md
@@ -44,4 +44,4 @@ Give players a Gallifrey-themed terrain and builder kit—stone, woods, and Cita
 - Soul wood family (fourth Gallifrey wood set).
 - Krubella / plutarch plants once proper cross (or intentional cube) sprites exist.
 - Wire archive colormaps for tinted grass/foliage if plants need biome tinting (grass block uses pre-colored deep-red textures).
-- Richer Gallifrey destination content (mobs, villages) on top of the shipped dimension.
+- Richer Gallifrey destination content (mobs) on top of the shipped dimension and villages.

--- a/dwm/docs/feature-gallifrey-dimension.md
+++ b/dwm/docs/feature-gallifrey-dimension.md
@@ -21,6 +21,7 @@ Give TARDIS travel a unique destination world built from Gallifrey builder block
 - Gallifrey-textured coal, iron, gold, and diamond ores in Gallifrey stone (all biomes; drop vanilla items; Overworld-like vein distribution).
 - Archive colormap and cloud textures imported under `assets/dwm/textures/` for future tinting/sky work; grass block uses pre-colored deep-red textures.
 - TARDIS `BiomeSelectorLogic` maps `dwm:gallifrey` to `#dwm:is_gallifrey`.
+- Jigsaw villages (`dwm:gallifrey_village`) in plains and forest: vanilla plains layouts retextured to Ash wood and Gallifrey stone via pool aliases (no copied NBT). Wastes/badlands have no villages yet.
 - Gallifrey fauna: Broakir and Flutterwing on plains/forest; **Mewing Dog** (striped, mewing, wolf-like tame/sit/follow/breed) in **forest only**; **Time Lord** NPCs (four robe variants, villager-like wander; no trades yet) on plains/forest.
 
 ## How It Works In-Game
@@ -28,12 +29,14 @@ Give TARDIS travel a unique destination world built from Gallifrey builder block
 2. Cycle the biome dial among plains / forest / wastes / badlands.
 3. Pull the materialisation lever to dematerialise, then again in flight to land in Gallifrey.
 4. Debug without a TARDIS: `/execute in dwm:gallifrey run tp @s ~ 128 ~`.
+5. Find a village: `/execute in dwm:gallifrey run locate structure dwm:gallifrey_village` (plains/forest only).
 
 ## Known Constraints
 - Cloud texture is imported but not wired through custom dimension effects; sky/fog use biome colors and overworld dimension effects.
-- Villages remain a follow-on ticket; Time Lord trades/professions and more Gallifrey fauna may still land later.
+- Time Lord trades/professions and more Gallifrey fauna may still land later. After datagen/build, smoke villages with `/execute in dwm:gallifrey run locate structure dwm:gallifrey_village`.
 
 ## Future Opportunities (Planned)
 - Wire colormaps for tinted grass/foliage if decorative plants need biome tinting.
 - Custom dimension effects for Gallifrey clouds/sky.
-- Villages and Time Lord trades/professions; additional fauna.
+- Desert-style villages for wastes/badlands.
+- Time Lord trades/professions; additional fauna.

--- a/dwm/src/client/java/com/adamkali/dwm/DWMClientDataGenerator.java
+++ b/dwm/src/client/java/com/adamkali/dwm/DWMClientDataGenerator.java
@@ -14,6 +14,10 @@ import com.adamkali.dwm.world.DWMBiomeBootstrap;
 import com.adamkali.dwm.world.DWMChunkGeneratorSettingsBootstrap;
 import com.adamkali.dwm.world.DWMConfiguredFeatureBootstrap;
 import com.adamkali.dwm.world.DWMPlacedFeatureBootstrap;
+import com.adamkali.dwm.world.DWMProcessorListsBootstrap;
+import com.adamkali.dwm.world.DWMStructureSetsBootstrap;
+import com.adamkali.dwm.world.DWMStructuresBootstrap;
+import com.adamkali.dwm.world.DWMVillagePoolsBootstrap;
 import net.fabricmc.fabric.api.datagen.v1.DataGeneratorEntrypoint;
 import net.fabricmc.fabric.api.datagen.v1.FabricDataGenerator;
 import net.minecraft.core.RegistrySetBuilder;
@@ -46,5 +50,9 @@ public class DWMClientDataGenerator implements DataGeneratorEntrypoint {
         registryBuilder.add(Registries.PLACED_FEATURE, DWMPlacedFeatureBootstrap::bootstrap);
         registryBuilder.add(Registries.BIOME, DWMBiomeBootstrap::bootstrap);
         registryBuilder.add(Registries.NOISE_SETTINGS, DWMChunkGeneratorSettingsBootstrap::bootstrap);
+        registryBuilder.add(Registries.PROCESSOR_LIST, DWMProcessorListsBootstrap::bootstrap);
+        registryBuilder.add(Registries.TEMPLATE_POOL, DWMVillagePoolsBootstrap::bootstrap);
+        registryBuilder.add(Registries.STRUCTURE, DWMStructuresBootstrap::bootstrap);
+        registryBuilder.add(Registries.STRUCTURE_SET, DWMStructureSetsBootstrap::bootstrap);
     }
 }

--- a/dwm/src/main/generated/assets/dwm/lang/en_us.json
+++ b/dwm/src/main/generated/assets/dwm/lang/en_us.json
@@ -693,6 +693,7 @@
   "key.category.dwm.dwm": "Doctor Who Mod",
   "key.dwm.field_guide": "Open Field Guide",
   "stat.dwm.sonic_screwdriver_use": "Uses of Sonic Screwdriver",
+  "structure.dwm.gallifrey_village": "Gallifrey Village",
   "tag.item.dwm.azbantium_ores": "Azbantium Ores",
   "tag.item.dwm.gallifrey_plants": "Gallifrey Plants",
   "tag.item.dwm.repairs_azbantium_equipment": "Azbantium Equipment Repair Materials",

--- a/dwm/src/main/generated/data/dwm/worldgen/placed_feature/ash_village.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/placed_feature/ash_village.json
@@ -1,0 +1,17 @@
+{
+  "feature": "dwm:ash",
+  "placement": [
+    {
+      "type": "minecraft:block_predicate_filter",
+      "predicate": {
+        "type": "minecraft:would_survive",
+        "state": {
+          "Name": "dwm:ash_sapling",
+          "Properties": {
+            "stage": "0"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/processor_list/gallifrey_village.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/processor_list/gallifrey_village.json
@@ -1,0 +1,7 @@
+{
+  "processors": [
+    {
+      "processor_type": "dwm:gallifrey_village"
+    }
+  ]
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/structure/gallifrey_village.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/structure/gallifrey_village.json
@@ -1,0 +1,42 @@
+{
+  "type": "minecraft:jigsaw",
+  "biomes": "#dwm:has_structure/gallifrey_village",
+  "max_distance_from_center": 80,
+  "pool_aliases": [
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/plains/streets",
+      "target": "dwm:village/gallifrey/streets"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/plains/houses",
+      "target": "dwm:village/gallifrey/houses"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/plains/terminators",
+      "target": "dwm:village/gallifrey/terminators"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/plains/decor",
+      "target": "dwm:village/gallifrey/decor"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/plains/trees",
+      "target": "dwm:village/gallifrey/trees"
+    }
+  ],
+  "project_start_to_heightmap": "WORLD_SURFACE_WG",
+  "size": 6,
+  "spawn_overrides": {},
+  "start_height": {
+    "absolute": 0
+  },
+  "start_pool": "dwm:village/gallifrey/town_centers",
+  "step": "surface_structures",
+  "terrain_adaptation": "beard_thin",
+  "use_expansion_hack": true
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/structure_set/gallifrey_village.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/structure_set/gallifrey_village.json
@@ -1,0 +1,14 @@
+{
+  "placement": {
+    "type": "minecraft:random_spread",
+    "salt": 29473921,
+    "separation": 8,
+    "spacing": 34
+  },
+  "structures": [
+    {
+      "structure": "dwm:gallifrey_village",
+      "weight": 1
+    }
+  ]
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/decor.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/decor.json
@@ -1,0 +1,44 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/plains_lamp_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:feature_pool_element",
+        "feature": "dwm:ash_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:feature_pool_element",
+        "feature": "minecraft:flower_plain",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:feature_pool_element",
+        "feature": "minecraft:pile_hay",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:empty_pool_element"
+      },
+      "weight": 2
+    }
+  ],
+  "fallback": "minecraft:empty"
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/houses.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/houses.json
@@ -1,0 +1,335 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_3",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_4",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_5",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_6",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_7",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_house_8",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 3
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_medium_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_medium_house_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_big_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_butcher_shop_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_butcher_shop_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_tool_smith_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_fletcher_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_shepherds_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_armorer_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_fisher_cottage_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_tannery_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_cartographer_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_library_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 5
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_library_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_masons_house_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_weaponsmith_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_temple_3",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_temple_4",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_stable_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_stable_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_large_farm_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_small_farm_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_animal_pen_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_animal_pen_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_animal_pen_3",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 5
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_accessory_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_meeting_point_4",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 3
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/houses/plains_meeting_point_5",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:empty_pool_element"
+      },
+      "weight": 10
+    }
+  ],
+  "fallback": "dwm:village/gallifrey/terminators"
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/streets.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/streets.json
@@ -1,0 +1,149 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/corner_01",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/corner_02",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/corner_03",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/straight_01",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/straight_02",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/straight_03",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 7
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/straight_04",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 7
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/straight_05",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 3
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/straight_06",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 4
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/crossroad_01",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/crossroad_02",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/crossroad_03",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/crossroad_04",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/crossroad_05",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/crossroad_06",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 2
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/streets/turn_01",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 3
+    }
+  ],
+  "fallback": "dwm:village/gallifrey/terminators"
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/terminators.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/terminators.json
@@ -1,0 +1,41 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/terminators/terminator_01",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/terminators/terminator_02",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/terminators/terminator_03",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 1
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/terminators/terminator_04",
+        "processors": "dwm:gallifrey_village",
+        "projection": "terrain_matching"
+      },
+      "weight": 1
+    }
+  ],
+  "fallback": "minecraft:empty"
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/town_centers.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/town_centers.json
@@ -1,0 +1,41 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/town_centers/plains_fountain_01",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 50
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/town_centers/plains_meeting_point_1",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 50
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/town_centers/plains_meeting_point_2",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 50
+    },
+    {
+      "element": {
+        "element_type": "minecraft:legacy_single_pool_element",
+        "location": "minecraft:village/plains/town_centers/plains_meeting_point_3",
+        "processors": "dwm:gallifrey_village",
+        "projection": "rigid"
+      },
+      "weight": 50
+    }
+  ],
+  "fallback": "minecraft:empty"
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/trees.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/template_pool/village/gallifrey/trees.json
@@ -1,0 +1,13 @@
+{
+  "elements": [
+    {
+      "element": {
+        "element_type": "minecraft:feature_pool_element",
+        "feature": "dwm:ash_village",
+        "projection": "rigid"
+      },
+      "weight": 1
+    }
+  ],
+  "fallback": "minecraft:empty"
+}

--- a/dwm/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
+++ b/dwm/src/main/java/com/adamkali/dwm/datagen/DWMLanguageProvider.java
@@ -433,6 +433,7 @@ public class DWMLanguageProvider extends FabricLanguageProvider {
         t.add("tag.item.dwm.repairs_azbantium_equipment", "Azbantium Equipment Repair Materials");
         t.add("biome.dwm.gallifrey_wastes", "Gallifrey Wastes");
         t.add("biome.dwm.gallifrey_badlands", "Gallifrey Badlands");
+        t.add("structure.dwm.gallifrey_village", "Gallifrey Village");
         t.add("dwm.console.biome_selector", "Biome selector");
         t.add("dwm.console.biome_selected", "Biome: %s");
         t.add("dwm.console.biome_unavailable", "No biomes available for this dimension");

--- a/dwm/src/main/java/com/adamkali/dwm/datagen/DWMWorldgenProvider.java
+++ b/dwm/src/main/java/com/adamkali/dwm/datagen/DWMWorldgenProvider.java
@@ -21,6 +21,10 @@ public class DWMWorldgenProvider extends FabricDynamicRegistryProvider {
         addModEntries(registries, entries, Registries.PLACED_FEATURE);
         addModEntries(registries, entries, Registries.BIOME);
         addModEntries(registries, entries, Registries.NOISE_SETTINGS);
+        addModEntries(registries, entries, Registries.PROCESSOR_LIST);
+        addModEntries(registries, entries, Registries.TEMPLATE_POOL);
+        addModEntries(registries, entries, Registries.STRUCTURE);
+        addModEntries(registries, entries, Registries.STRUCTURE_SET);
     }
 
     private static <T> void addModEntries(

--- a/dwm/src/main/java/com/adamkali/dwm/tardis/worldgen/DWMStructureProcessors.java
+++ b/dwm/src/main/java/com/adamkali/dwm/tardis/worldgen/DWMStructureProcessors.java
@@ -1,6 +1,7 @@
 package com.adamkali.dwm.tardis.worldgen;
 
 import com.adamkali.dwm.DWMReference;
+import com.adamkali.dwm.world.village.GallifreyVillageProcessor;
 import com.mojang.serialization.MapCodec;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
@@ -13,6 +14,7 @@ public final class DWMStructureProcessors {
 
     public static void initialize() {
         register("tardis_worldgen_marker", TardisWorldgenMarkerProcessor.MAP_CODEC);
+        register("gallifrey_village", GallifreyVillageProcessor.CODEC);
     }
 
     private static void register(String path, MapCodec<? extends StructureProcessor> codec) {

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMBiomeTags.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMBiomeTags.java
@@ -12,6 +12,11 @@ public final class DWMBiomeTags {
             Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "is_gallifrey")
     );
 
+    public static final TagKey<Biome> HAS_GALLIFREY_VILLAGE = TagKey.create(
+            Registries.BIOME,
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "has_structure/gallifrey_village")
+    );
+
     private DWMBiomeTags() {
     }
 }

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
@@ -46,6 +46,12 @@ public final class DWMPlacedFeatureBootstrap {
                 PlacementUtils.countExtra(4, 0.1F, 1),
                 DWMBlocks.ASH_SAPLING
         );
+        PlacementUtils.register(
+                registerable,
+                DWMPlacedFeatures.ASH_VILLAGE,
+                configured.getOrThrow(DWMConfiguredFeatures.ASH),
+                PlacementUtils.filteredByBlockSurvival(DWMBlocks.ASH_SAPLING)
+        );
         registerTree(
                 registerable,
                 DWMPlacedFeatures.DARK_ASH_FOREST,

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
@@ -9,6 +9,8 @@ import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 public final class DWMPlacedFeatures {
     public static final ResourceKey<PlacedFeature> ASH_PLAINS = key("ash_plains");
     public static final ResourceKey<PlacedFeature> ASH_FOREST = key("ash_forest");
+    /** Village-piece tree: configured Ash tree with sapling survival filter only (no biome rarity). */
+    public static final ResourceKey<PlacedFeature> ASH_VILLAGE = key("ash_village");
     public static final ResourceKey<PlacedFeature> DARK_ASH_FOREST = key("dark_ash_forest");
     public static final ResourceKey<PlacedFeature> CARDINAL_FOREST = key("cardinal_forest");
     public static final ResourceKey<PlacedFeature> GALLIFREY_FLOWERS_PLAINS = key("gallifrey_flowers_plains");

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMProcessorLists.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMProcessorLists.java
@@ -1,0 +1,17 @@
+package com.adamkali.dwm.world;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
+
+public final class DWMProcessorLists {
+    public static final ResourceKey<StructureProcessorList> GALLIFREY_VILLAGE = ResourceKey.create(
+            Registries.PROCESSOR_LIST,
+            Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "gallifrey_village")
+    );
+
+    private DWMProcessorLists() {
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMProcessorListsBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMProcessorListsBootstrap.java
@@ -1,0 +1,19 @@
+package com.adamkali.dwm.world;
+
+import com.adamkali.dwm.world.village.GallifreyVillageProcessor;
+import net.minecraft.data.worldgen.BootstrapContext;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
+
+import java.util.List;
+
+public final class DWMProcessorListsBootstrap {
+    private DWMProcessorListsBootstrap() {
+    }
+
+    public static void bootstrap(BootstrapContext<StructureProcessorList> context) {
+        context.register(
+                DWMProcessorLists.GALLIFREY_VILLAGE,
+                new StructureProcessorList(List.of(GallifreyVillageProcessor.INSTANCE))
+        );
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMStructureSets.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMStructureSets.java
@@ -1,0 +1,21 @@
+package com.adamkali.dwm.world;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.levelgen.structure.StructureSet;
+
+public final class DWMStructureSets {
+    public static final ResourceKey<StructureSet> GALLIFREY_VILLAGE = key("gallifrey_village");
+
+    /** Unique salt; vanilla Overworld villages use 10387312. */
+    public static final int PLACEMENT_SALT = 29473921;
+
+    private static ResourceKey<StructureSet> key(String path) {
+        return ResourceKey.create(Registries.STRUCTURE_SET, Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path));
+    }
+
+    private DWMStructureSets() {
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMStructureSetsBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMStructureSetsBootstrap.java
@@ -1,0 +1,25 @@
+package com.adamkali.dwm.world;
+
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstrapContext;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraft.world.level.levelgen.structure.StructureSet;
+import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadStructurePlacement;
+import net.minecraft.world.level.levelgen.structure.placement.RandomSpreadType;
+
+public final class DWMStructureSetsBootstrap {
+    private DWMStructureSetsBootstrap() {
+    }
+
+    public static void bootstrap(BootstrapContext<StructureSet> context) {
+        HolderGetter<Structure> structures = context.lookup(Registries.STRUCTURE);
+        context.register(
+                DWMStructureSets.GALLIFREY_VILLAGE,
+                new StructureSet(
+                        structures.getOrThrow(DWMStructures.GALLIFREY_VILLAGE),
+                        new RandomSpreadStructurePlacement(34, 8, RandomSpreadType.LINEAR, DWMStructureSets.PLACEMENT_SALT)
+                )
+        );
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMStructures.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMStructures.java
@@ -1,0 +1,18 @@
+package com.adamkali.dwm.world;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.levelgen.structure.Structure;
+
+public final class DWMStructures {
+    public static final ResourceKey<Structure> GALLIFREY_VILLAGE = key("gallifrey_village");
+
+    private static ResourceKey<Structure> key(String path) {
+        return ResourceKey.create(Registries.STRUCTURE, Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path));
+    }
+
+    private DWMStructures() {
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMStructuresBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMStructuresBootstrap.java
@@ -1,0 +1,44 @@
+package com.adamkali.dwm.world;
+
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstrapContext;
+import net.minecraft.world.level.biome.Biome;
+import net.minecraft.world.level.levelgen.Heightmap;
+import net.minecraft.world.level.levelgen.VerticalAnchor;
+import net.minecraft.world.level.levelgen.heightproviders.ConstantHeight;
+import net.minecraft.world.level.levelgen.structure.Structure;
+import net.minecraft.world.level.levelgen.structure.TerrainAdjustment;
+import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
+import net.minecraft.world.level.levelgen.structure.structures.JigsawStructure;
+
+import java.util.Optional;
+
+public final class DWMStructuresBootstrap {
+    private DWMStructuresBootstrap() {
+    }
+
+    public static void bootstrap(BootstrapContext<Structure> context) {
+        HolderGetter<Biome> biomes = context.lookup(Registries.BIOME);
+        HolderGetter<StructureTemplatePool> pools = context.lookup(Registries.TEMPLATE_POOL);
+
+        context.register(
+                DWMStructures.GALLIFREY_VILLAGE,
+                new JigsawStructure(
+                        new Structure.StructureSettings.Builder(biomes.getOrThrow(DWMBiomeTags.HAS_GALLIFREY_VILLAGE))
+                                .terrainAdapation(TerrainAdjustment.BEARD_THIN)
+                                .build(),
+                        pools.getOrThrow(DWMVillagePools.TOWN_CENTERS),
+                        Optional.empty(),
+                        6,
+                        ConstantHeight.of(VerticalAnchor.absolute(0)),
+                        true,
+                        Optional.of(Heightmap.Types.WORLD_SURFACE_WG),
+                        new JigsawStructure.MaxDistance(80),
+                        DWMVillagePools.poolAliases(),
+                        JigsawStructure.DEFAULT_DIMENSION_PADDING,
+                        JigsawStructure.DEFAULT_LIQUID_SETTINGS
+                )
+        );
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMVillagePools.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMVillagePools.java
@@ -1,0 +1,53 @@
+package com.adamkali.dwm.world;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
+import net.minecraft.world.level.levelgen.structure.pools.alias.DirectPoolAlias;
+import net.minecraft.world.level.levelgen.structure.pools.alias.PoolAliasBinding;
+import java.util.List;
+
+public final class DWMVillagePools {
+    public static final ResourceKey<StructureTemplatePool> TOWN_CENTERS = key("village/gallifrey/town_centers");
+    public static final ResourceKey<StructureTemplatePool> STREETS = key("village/gallifrey/streets");
+    public static final ResourceKey<StructureTemplatePool> HOUSES = key("village/gallifrey/houses");
+    public static final ResourceKey<StructureTemplatePool> TERMINATORS = key("village/gallifrey/terminators");
+    public static final ResourceKey<StructureTemplatePool> DECOR = key("village/gallifrey/decor");
+    public static final ResourceKey<StructureTemplatePool> TREES = key("village/gallifrey/trees");
+
+    private DWMVillagePools() {
+    }
+
+    public static List<PoolAliasBinding> poolAliases() {
+        return List.of(
+                alias("streets"),
+                alias("houses"),
+                alias("terminators"),
+                alias("decor"),
+                alias("trees")
+        );
+    }
+
+    public static List<Identifier> plainsAliasSources() {
+        return poolAliases().stream()
+                .map(DirectPoolAlias.class::cast)
+                .map(binding -> binding.alias().identifier())
+                .toList();
+    }
+
+    private static PoolAliasBinding alias(String name) {
+        return PoolAliasBinding.direct(
+                ResourceKey.create(Registries.TEMPLATE_POOL, Identifier.withDefaultNamespace("village/plains/" + name)),
+                key("village/gallifrey/" + name)
+        );
+    }
+
+    private static ResourceKey<StructureTemplatePool> key(String path) {
+        return ResourceKey.create(
+                Registries.TEMPLATE_POOL,
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path)
+        );
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMVillagePoolsBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMVillagePoolsBootstrap.java
@@ -1,0 +1,173 @@
+package com.adamkali.dwm.world;
+
+import com.mojang.datafixers.util.Pair;
+import net.minecraft.core.Holder;
+import net.minecraft.core.HolderGetter;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.BootstrapContext;
+import net.minecraft.data.worldgen.Pools;
+import net.minecraft.data.worldgen.placement.VillagePlacements;
+import net.minecraft.world.level.levelgen.placement.PlacedFeature;
+import net.minecraft.world.level.levelgen.structure.pools.StructurePoolElement;
+import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Clones vanilla plains village template pools, swapping processors to
+ * {@code dwm:gallifrey_village} and trees to the Ash village placed feature.
+ * Piece locations stay vanilla so NBT is not copied.
+ */
+public final class DWMVillagePoolsBootstrap {
+    private DWMVillagePoolsBootstrap() {
+    }
+
+    public static void bootstrap(BootstrapContext<StructureTemplatePool> context) {
+        HolderGetter<StructureProcessorList> processors = context.lookup(Registries.PROCESSOR_LIST);
+        Holder<StructureProcessorList> gallifrey = processors.getOrThrow(DWMProcessorLists.GALLIFREY_VILLAGE);
+
+        HolderGetter<StructureTemplatePool> pools = context.lookup(Registries.TEMPLATE_POOL);
+        Holder<StructureTemplatePool> empty = pools.getOrThrow(Pools.EMPTY);
+
+        HolderGetter<PlacedFeature> placedFeatures = context.lookup(Registries.PLACED_FEATURE);
+        Holder<PlacedFeature> ashVillage = placedFeatures.getOrThrow(DWMPlacedFeatures.ASH_VILLAGE);
+        Holder<PlacedFeature> flowerPlainVillage = placedFeatures.getOrThrow(VillagePlacements.FLOWER_PLAIN_VILLAGE);
+        Holder<PlacedFeature> pileHayVillage = placedFeatures.getOrThrow(VillagePlacements.PILE_HAY_VILLAGE);
+
+        context.register(
+                DWMVillagePools.TERMINATORS,
+                new StructureTemplatePool(
+                        empty,
+                        List.of(
+                                legacy("village/plains/terminators/terminator_01", gallifrey, 1),
+                                legacy("village/plains/terminators/terminator_02", gallifrey, 1),
+                                legacy("village/plains/terminators/terminator_03", gallifrey, 1),
+                                legacy("village/plains/terminators/terminator_04", gallifrey, 1)
+                        ),
+                        StructureTemplatePool.Projection.TERRAIN_MATCHING
+                )
+        );
+
+        Holder<StructureTemplatePool> terminators = pools.getOrThrow(DWMVillagePools.TERMINATORS);
+
+        context.register(
+                DWMVillagePools.TOWN_CENTERS,
+                new StructureTemplatePool(
+                        empty,
+                        List.of(
+                                legacy("village/plains/town_centers/plains_fountain_01", gallifrey, 50),
+                                legacy("village/plains/town_centers/plains_meeting_point_1", gallifrey, 50),
+                                legacy("village/plains/town_centers/plains_meeting_point_2", gallifrey, 50),
+                                legacy("village/plains/town_centers/plains_meeting_point_3", gallifrey, 50)
+                        ),
+                        StructureTemplatePool.Projection.RIGID
+                )
+        );
+
+        context.register(
+                DWMVillagePools.STREETS,
+                new StructureTemplatePool(
+                        terminators,
+                        List.of(
+                                legacy("village/plains/streets/corner_01", gallifrey, 2),
+                                legacy("village/plains/streets/corner_02", gallifrey, 2),
+                                legacy("village/plains/streets/corner_03", gallifrey, 2),
+                                legacy("village/plains/streets/straight_01", gallifrey, 4),
+                                legacy("village/plains/streets/straight_02", gallifrey, 4),
+                                legacy("village/plains/streets/straight_03", gallifrey, 7),
+                                legacy("village/plains/streets/straight_04", gallifrey, 7),
+                                legacy("village/plains/streets/straight_05", gallifrey, 3),
+                                legacy("village/plains/streets/straight_06", gallifrey, 4),
+                                legacy("village/plains/streets/crossroad_01", gallifrey, 2),
+                                legacy("village/plains/streets/crossroad_02", gallifrey, 1),
+                                legacy("village/plains/streets/crossroad_03", gallifrey, 2),
+                                legacy("village/plains/streets/crossroad_04", gallifrey, 2),
+                                legacy("village/plains/streets/crossroad_05", gallifrey, 2),
+                                legacy("village/plains/streets/crossroad_06", gallifrey, 2),
+                                legacy("village/plains/streets/turn_01", gallifrey, 3)
+                        ),
+                        StructureTemplatePool.Projection.TERRAIN_MATCHING
+                )
+        );
+
+        context.register(
+                DWMVillagePools.HOUSES,
+                new StructureTemplatePool(
+                        terminators,
+                        List.of(
+                                legacy("village/plains/houses/plains_small_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_small_house_2", gallifrey, 2),
+                                legacy("village/plains/houses/plains_small_house_3", gallifrey, 2),
+                                legacy("village/plains/houses/plains_small_house_4", gallifrey, 2),
+                                legacy("village/plains/houses/plains_small_house_5", gallifrey, 2),
+                                legacy("village/plains/houses/plains_small_house_6", gallifrey, 1),
+                                legacy("village/plains/houses/plains_small_house_7", gallifrey, 2),
+                                legacy("village/plains/houses/plains_small_house_8", gallifrey, 3),
+                                legacy("village/plains/houses/plains_medium_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_medium_house_2", gallifrey, 2),
+                                legacy("village/plains/houses/plains_big_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_butcher_shop_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_butcher_shop_2", gallifrey, 2),
+                                legacy("village/plains/houses/plains_tool_smith_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_fletcher_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_shepherds_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_armorer_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_fisher_cottage_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_tannery_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_cartographer_1", gallifrey, 1),
+                                legacy("village/plains/houses/plains_library_1", gallifrey, 5),
+                                legacy("village/plains/houses/plains_library_2", gallifrey, 1),
+                                legacy("village/plains/houses/plains_masons_house_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_weaponsmith_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_temple_3", gallifrey, 2),
+                                legacy("village/plains/houses/plains_temple_4", gallifrey, 2),
+                                legacy("village/plains/houses/plains_stable_1", gallifrey, 2),
+                                legacy("village/plains/houses/plains_stable_2", gallifrey, 2),
+                                legacy("village/plains/houses/plains_large_farm_1", gallifrey, 4),
+                                legacy("village/plains/houses/plains_small_farm_1", gallifrey, 4),
+                                legacy("village/plains/houses/plains_animal_pen_1", gallifrey, 1),
+                                legacy("village/plains/houses/plains_animal_pen_2", gallifrey, 1),
+                                legacy("village/plains/houses/plains_animal_pen_3", gallifrey, 5),
+                                legacy("village/plains/houses/plains_accessory_1", gallifrey, 1),
+                                legacy("village/plains/houses/plains_meeting_point_4", gallifrey, 3),
+                                legacy("village/plains/houses/plains_meeting_point_5", gallifrey, 1),
+                                Pair.of(StructurePoolElement.empty(), 10)
+                        ),
+                        StructureTemplatePool.Projection.RIGID
+                )
+        );
+
+        context.register(
+                DWMVillagePools.TREES,
+                new StructureTemplatePool(
+                        empty,
+                        List.of(Pair.of(StructurePoolElement.feature(ashVillage), 1)),
+                        StructureTemplatePool.Projection.RIGID
+                )
+        );
+
+        context.register(
+                DWMVillagePools.DECOR,
+                new StructureTemplatePool(
+                        empty,
+                        List.of(
+                                legacy("village/plains/plains_lamp_1", gallifrey, 2),
+                                Pair.of(StructurePoolElement.feature(ashVillage), 1),
+                                Pair.of(StructurePoolElement.feature(flowerPlainVillage), 1),
+                                Pair.of(StructurePoolElement.feature(pileHayVillage), 1),
+                                Pair.of(StructurePoolElement.empty(), 2)
+                        ),
+                        StructureTemplatePool.Projection.RIGID
+                )
+        );
+    }
+
+    private static Pair<Function<StructureTemplatePool.Projection, ? extends StructurePoolElement>, Integer> legacy(
+            String location,
+            Holder<StructureProcessorList> processors,
+            int weight
+    ) {
+        return Pair.of(StructurePoolElement.legacy(location, processors), weight);
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/village/GallifreyVillagePalette.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/village/GallifreyVillagePalette.java
@@ -1,0 +1,104 @@
+package com.adamkali.dwm.world.village;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.state.BlockState;
+import org.jspecify.annotations.Nullable;
+import java.util.Map;
+
+/**
+ * Maps vanilla plains-village blocks onto Ash wood and Gallifrey stone,
+ * copying blockstate properties via {@link Block#withPropertiesOf(BlockState)}.
+ */
+public final class GallifreyVillagePalette {
+    public static final float MOSSIFY_CHANCE = 0.1F;
+
+    private static final Map<Block, Block> REPLACEMENTS = Map.ofEntries(
+            Map.entry(Blocks.GRASS_BLOCK, DWMBlocks.GALLIFREY_GRASS_BLOCK),
+            Map.entry(Blocks.DIRT, DWMBlocks.GALLIFREY_DIRT),
+            Map.entry(Blocks.DIRT_PATH, DWMBlocks.GALLIFREY_COARSE_DIRT),
+
+            Map.entry(Blocks.OAK_PLANKS, DWMBlocks.ASH_PLANKS),
+            Map.entry(Blocks.OAK_LOG, DWMBlocks.ASH_LOG),
+            Map.entry(Blocks.OAK_WOOD, DWMBlocks.ASH_WOOD),
+            Map.entry(Blocks.STRIPPED_OAK_LOG, DWMBlocks.STRIPPED_ASH_LOG),
+            Map.entry(Blocks.STRIPPED_OAK_WOOD, DWMBlocks.STRIPPED_ASH_WOOD),
+            Map.entry(Blocks.OAK_STAIRS, DWMBlocks.ASH_STAIRS),
+            Map.entry(Blocks.OAK_SLAB, DWMBlocks.ASH_SLAB),
+            Map.entry(Blocks.OAK_FENCE, DWMBlocks.ASH_FENCE),
+            Map.entry(Blocks.OAK_FENCE_GATE, DWMBlocks.ASH_FENCE_GATE),
+            Map.entry(Blocks.OAK_DOOR, DWMBlocks.ASH_DOOR),
+            Map.entry(Blocks.OAK_TRAPDOOR, DWMBlocks.ASH_TRAPDOOR),
+            Map.entry(Blocks.OAK_LEAVES, DWMBlocks.ASH_LEAVES),
+            Map.entry(Blocks.OAK_SAPLING, DWMBlocks.ASH_SAPLING),
+            Map.entry(Blocks.POTTED_OAK_SAPLING, DWMBlocks.POTTED_ASH_SAPLING),
+
+            Map.entry(Blocks.COBBLESTONE, DWMBlocks.GALLIFREY_COBBLESTONE),
+            Map.entry(Blocks.COBBLESTONE_STAIRS, DWMBlocks.GALLIFREY_COBBLESTONE_STAIRS),
+            Map.entry(Blocks.COBBLESTONE_SLAB, DWMBlocks.GALLIFREY_COBBLESTONE_SLAB),
+            Map.entry(Blocks.COBBLESTONE_WALL, DWMBlocks.GALLIFREY_COBBLESTONE_WALL),
+            Map.entry(Blocks.MOSSY_COBBLESTONE, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE),
+            Map.entry(Blocks.MOSSY_COBBLESTONE_STAIRS, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE_STAIRS),
+            Map.entry(Blocks.MOSSY_COBBLESTONE_SLAB, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE_SLAB),
+            Map.entry(Blocks.MOSSY_COBBLESTONE_WALL, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE_WALL),
+
+            Map.entry(Blocks.STONE, DWMBlocks.GALLIFREY_STONE),
+            Map.entry(Blocks.SMOOTH_STONE, DWMBlocks.GALLIFREY_SMOOTH_STONE),
+            Map.entry(Blocks.SMOOTH_STONE_SLAB, DWMBlocks.GALLIFREY_SMOOTH_STONE_SLAB),
+            Map.entry(Blocks.STONE_BRICKS, DWMBlocks.GALLIFREY_STONE_BRICKS),
+            Map.entry(Blocks.STONE_BRICK_STAIRS, DWMBlocks.GALLIFREY_STONE_BRICK_STAIRS),
+            Map.entry(Blocks.STONE_BRICK_SLAB, DWMBlocks.GALLIFREY_STONE_BRICK_SLAB),
+            Map.entry(Blocks.STONE_BRICK_WALL, DWMBlocks.GALLIFREY_STONE_BRICK_WALL),
+            Map.entry(Blocks.MOSSY_STONE_BRICKS, DWMBlocks.MOSSY_GALLIFREY_STONE_BRICKS),
+            Map.entry(Blocks.MOSSY_STONE_BRICK_STAIRS, DWMBlocks.MOSSY_GALLIFREY_STONE_BRICK_STAIRS),
+            Map.entry(Blocks.MOSSY_STONE_BRICK_SLAB, DWMBlocks.MOSSY_GALLIFREY_STONE_BRICK_SLAB),
+            Map.entry(Blocks.MOSSY_STONE_BRICK_WALL, DWMBlocks.MOSSY_GALLIFREY_STONE_BRICK_WALL),
+            Map.entry(Blocks.CRACKED_STONE_BRICKS, DWMBlocks.CRACKED_GALLIFREY_STONE_BRICKS),
+            Map.entry(Blocks.CHISELED_STONE_BRICKS, DWMBlocks.CHISELED_GALLIFREY_STONE_BRICKS),
+
+            Map.entry(Blocks.POTTED_DANDELION, DWMBlocks.POTTED_FLOWER_OF_REMEMBRANCE),
+            Map.entry(Blocks.POTTED_POPPY, DWMBlocks.POTTED_MOONLIGHT_BLOOM),
+
+            Map.entry(Blocks.DYED_TERRACOTTA.white(), DWMBlocks.CITADEL_TILE),
+            Map.entry(Blocks.TERRACOTTA, DWMBlocks.CITADEL_WALL)
+    );
+
+    private static final Map<Block, Block> MOSSY_VARIANTS = Map.of(
+            Blocks.COBBLESTONE, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE,
+            Blocks.COBBLESTONE_STAIRS, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE_STAIRS,
+            Blocks.COBBLESTONE_SLAB, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE_SLAB,
+            Blocks.COBBLESTONE_WALL, DWMBlocks.GALLIFREY_MOSSY_COBBLESTONE_WALL
+    );
+
+    private GallifreyVillagePalette() {
+    }
+
+    public static BlockState replace(BlockState state) {
+        return replace(state, null);
+    }
+
+    public static BlockState replace(BlockState state, @Nullable RandomSource random) {
+        Block block = state.getBlock();
+        if (random != null) {
+            Block mossy = MOSSY_VARIANTS.get(block);
+            if (mossy != null && random.nextFloat() < MOSSIFY_CHANCE) {
+                return mossy.withPropertiesOf(state);
+            }
+        }
+        Block replacement = REPLACEMENTS.get(block);
+        if (replacement == null) {
+            return state;
+        }
+        return replacement.withPropertiesOf(state);
+    }
+
+    public static boolean mapsTo(Block source, Block expected) {
+        return REPLACEMENTS.get(source) == expected;
+    }
+
+    public static boolean usesCardinalDoor() {
+        return REPLACEMENTS.containsValue(DWMBlocks.CARDINAL_DOOR);
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/village/GallifreyVillageProcessor.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/village/GallifreyVillageProcessor.java
@@ -1,0 +1,40 @@
+package com.adamkali.dwm.world.village;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+import org.jspecify.annotations.Nullable;
+
+public final class GallifreyVillageProcessor implements StructureProcessor {
+    public static final GallifreyVillageProcessor INSTANCE = new GallifreyVillageProcessor();
+    public static final MapCodec<GallifreyVillageProcessor> CODEC = MapCodec.unit(() -> INSTANCE);
+
+    private GallifreyVillageProcessor() {
+    }
+
+    @Override
+    public StructureTemplate.@Nullable StructureBlockInfo processBlock(
+            LevelReader level,
+            BlockPos targetPosition,
+            BlockPos referencePos,
+            BlockPos templateRelativePos,
+            StructureTemplate.StructureBlockInfo processedBlockInfo,
+            StructurePlaceSettings settings
+    ) {
+        BlockState original = processedBlockInfo.state();
+        BlockState replaced = GallifreyVillagePalette.replace(original, settings.getRandom(processedBlockInfo.pos()));
+        if (replaced == original) {
+            return processedBlockInfo;
+        }
+        return new StructureTemplate.StructureBlockInfo(processedBlockInfo.pos(), replaced, processedBlockInfo.nbt());
+    }
+
+    @Override
+    public MapCodec<? extends StructureProcessor> codec() {
+        return CODEC;
+    }
+}

--- a/dwm/src/main/resources/data/dwm/tags/worldgen/biome/has_structure/gallifrey_village.json
+++ b/dwm/src/main/resources/data/dwm/tags/worldgen/biome/has_structure/gallifrey_village.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "dwm:gallifrey_plains",
+    "dwm:gallifrey_forest"
+  ]
+}

--- a/dwm/src/test/java/com/adamkali/dwm/ResourceValidationTests.java
+++ b/dwm/src/test/java/com/adamkali/dwm/ResourceValidationTests.java
@@ -893,6 +893,35 @@ public class ResourceValidationTests {
         }
     }
 
+    @Test
+    public void generatedGallifreyVillageWorldgenExists() throws Exception {
+        Path worldgen = Path.of("src/main/generated/data/dwm/worldgen");
+        String[] paths = {
+                "structure/gallifrey_village.json",
+                "structure_set/gallifrey_village.json",
+                "processor_list/gallifrey_village.json",
+                "template_pool/village/gallifrey/town_centers.json",
+                "template_pool/village/gallifrey/streets.json",
+                "template_pool/village/gallifrey/houses.json",
+                "template_pool/village/gallifrey/terminators.json",
+                "template_pool/village/gallifrey/decor.json",
+                "template_pool/village/gallifrey/trees.json",
+                "placed_feature/ash_village.json",
+        };
+        for (String relative : paths) {
+            Path file = worldgen.resolve(relative);
+            assertTrue(
+                    Files.isRegularFile(file) && Files.size(file) > 0,
+                    "Missing generated Gallifrey village worldgen: " + file
+            );
+        }
+        Path biomeTag = Path.of("src/main/resources/data/dwm/tags/worldgen/biome/has_structure/gallifrey_village.json");
+        assertTrue(
+                Files.isRegularFile(biomeTag) && Files.size(biomeTag) > 0,
+                "Missing biome tag: " + biomeTag
+        );
+    }
+
     private static boolean biomeHasCreatureSpawn(String biomeFile, String entityId) throws Exception {
         Path path = Path.of("src/main/generated/data/dwm/worldgen/biome").resolve(biomeFile);
         assertTrue(Files.isRegularFile(path), "Missing generated biome: " + path);

--- a/dwm/src/test/java/com/adamkali/dwm/world/GallifreyDimensionsTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/GallifreyDimensionsTest.java
@@ -23,6 +23,14 @@ class GallifreyDimensionsTest {
     }
 
     @Test
+    void hasGallifreyVillageBiomeTag_usesExpectedId() {
+        assertEquals(
+                Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "has_structure/gallifrey_village"),
+                DWMBiomeTags.HAS_GALLIFREY_VILLAGE.location()
+        );
+    }
+
+    @Test
     void badlandsBiomeKey_usesExpectedId() {
         assertEquals(
                 Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, "gallifrey_badlands"),

--- a/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolAliasTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolAliasTest.java
@@ -1,0 +1,29 @@
+package com.adamkali.dwm.world;
+
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GallifreyVillagePoolAliasTest {
+    @Test
+    void aliasesRewritePlainsPoolsAndLeaveVillagersUnaliased() {
+        List<Identifier> sources = DWMVillagePools.plainsAliasSources();
+        assertEquals(
+                List.of(
+                        Identifier.withDefaultNamespace("village/plains/streets"),
+                        Identifier.withDefaultNamespace("village/plains/houses"),
+                        Identifier.withDefaultNamespace("village/plains/terminators"),
+                        Identifier.withDefaultNamespace("village/plains/decor"),
+                        Identifier.withDefaultNamespace("village/plains/trees")
+                ),
+                sources
+        );
+        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/plains/villagers")));
+        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/common/cats")));
+        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/common/iron_golem")));
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolsTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolsTest.java
@@ -1,0 +1,29 @@
+package com.adamkali.dwm.world;
+
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class GallifreyVillagePoolsTest {
+    @Test
+    void poolAliasesRewritePlainsJigsawTargets() {
+        Set<Identifier> sources = new HashSet<>(DWMVillagePools.plainsAliasSources());
+        assertEquals(
+                Set.of(
+                        Identifier.withDefaultNamespace("village/plains/streets"),
+                        Identifier.withDefaultNamespace("village/plains/houses"),
+                        Identifier.withDefaultNamespace("village/plains/terminators"),
+                        Identifier.withDefaultNamespace("village/plains/decor"),
+                        Identifier.withDefaultNamespace("village/plains/trees")
+                ),
+                sources
+        );
+        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/plains/villagers")));
+        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/common/iron_golem")));
+    }
+}

--- a/dwm/src/test/java/com/adamkali/dwm/world/village/GallifreyVillagePaletteTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/village/GallifreyVillagePaletteTest.java
@@ -1,0 +1,42 @@
+package com.adamkali.dwm.world.village;
+
+import com.adamkali.dwm.MinecraftTestBootstrap;
+import com.adamkali.dwm.block.DWMBlocks;
+import net.minecraft.core.Direction;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.StairBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class GallifreyVillagePaletteTest {
+    @BeforeAll
+    static void bootstrap() {
+        MinecraftTestBootstrap.ensure();
+    }
+
+    @Test
+    void oakStairsKeepFacingWhenMappedToAsh() {
+        BlockState oak = Blocks.OAK_STAIRS.defaultBlockState().setValue(StairBlock.FACING, Direction.EAST);
+        BlockState replaced = GallifreyVillagePalette.replace(oak);
+        assertEquals(DWMBlocks.ASH_STAIRS, replaced.getBlock());
+        assertEquals(Direction.EAST, replaced.getValue(StairBlock.FACING));
+    }
+
+    @Test
+    void unmappedBlocksAreUnchanged() {
+        BlockState pane = Blocks.GLASS_PANE.defaultBlockState();
+        assertSame(pane, GallifreyVillagePalette.replace(pane));
+    }
+
+    @Test
+    void oakDoorMapsToAshNotCardinal() {
+        assertFalse(GallifreyVillagePalette.usesCardinalDoor());
+        assertEquals(DWMBlocks.ASH_DOOR, GallifreyVillagePalette.replace(Blocks.OAK_DOOR.defaultBlockState()).getBlock());
+        assertFalse(GallifreyVillagePalette.mapsTo(Blocks.OAK_DOOR, DWMBlocks.CARDINAL_DOOR));
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Gallifrey plains and forest lacked settlements; villages make the destination feel inhabited and give players Ash/Gallifrey-stone builds to discover without shipping artist MCA world saves.

## Proposed Implementation

- Register `GallifreyVillagePalette` + structure processor that remaps oak/cobble/grass (and related blocks) to Ash wood and Gallifrey stone while preserving block states.
- Bootstrap jigsaw structure `dwm:gallifrey_village` with cloned plains template pools, `pool_aliases` to vanilla NBT pieces, processor list, structure set, and `#dwm:has_structure/gallifrey_village` (plains + forest only).
- Wire PROCESSOR_LIST / TEMPLATE_POOL / STRUCTURE / STRUCTURE_SET into datagen; add unit + resource validation tests; update Gallifrey docs.
- Stacks on stone stairs/slabs/walls (#242).

## Problems Encountered / Decisions Made

- Used vanilla plains layouts + pool aliases instead of the MCA prototype (avoids copying NBT into the mod).
- Left wastes/badlands without villages for a later desert-style pass.
- Did not add the structure to `#minecraft:village` to avoid Overworld raid/map coupling.
- Registered the village processor through existing `DWMStructureProcessors` rather than a standalone register call.
- Ported onto the monorepo `dwm/` layout.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e7c-3944-7a8e-bc41-2b0e81077f49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e7c-3944-7a8e-bc41-2b0e81077f49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

