### PR TITLE
fix(gallifrey): suppress structure-placed village mobs

### DIFF
--- a/dwm/docs/feature-gallifrey-dimension.md
+++ b/dwm/docs/feature-gallifrey-dimension.md
@@ -21,7 +21,7 @@ Give TARDIS travel a unique destination world built from Gallifrey builder block
 - Gallifrey-textured coal, iron, gold, and diamond ores in Gallifrey stone (all biomes; drop vanilla items; Overworld-like vein distribution).
 - Archive colormap and cloud textures imported under `assets/dwm/textures/` for future tinting/sky work; grass block uses pre-colored deep-red textures.
 - TARDIS `BiomeSelectorLogic` maps `dwm:gallifrey` to `#dwm:is_gallifrey`.
-- Jigsaw villages (`dwm:gallifrey_village`) in plains and forest: vanilla plains layouts retextured to Ash wood and Gallifrey stone via pool aliases (no copied NBT). Wastes/badlands have no villages yet.
+- Jigsaw villages (`dwm:gallifrey_village`) in plains and forest: vanilla plains layouts retextured to Ash wood and Gallifrey stone via pool aliases (no copied NBT). Structure-placed villagers, cats, iron golems, and pen animals are aliased to empty (no village mobs). Wastes/badlands have no villages yet.
 - Gallifrey fauna: Broakir and Flutterwing on plains/forest; **Mewing Dog** (striped, mewing, wolf-like tame/sit/follow/breed) in **forest only**; **Time Lord** NPCs (four robe variants, villager-like wander; no trades yet) on plains/forest.
 
 ## How It Works In-Game

--- a/dwm/src/main/generated/data/dwm/worldgen/structure/gallifrey_village.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/structure/gallifrey_village.json
@@ -27,6 +27,26 @@
       "type": "minecraft:direct",
       "alias": "minecraft:village/plains/trees",
       "target": "dwm:village/gallifrey/trees"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/plains/villagers",
+      "target": "minecraft:empty"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/common/cats",
+      "target": "minecraft:empty"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/common/iron_golem",
+      "target": "minecraft:empty"
+    },
+    {
+      "type": "minecraft:direct",
+      "alias": "minecraft:village/common/animals",
+      "target": "minecraft:empty"
     }
   ],
   "project_start_to_heightmap": "WORLD_SURFACE_WG",

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMVillagePools.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMVillagePools.java
@@ -2,11 +2,12 @@ package com.adamkali.dwm.world;
 
 import com.adamkali.dwm.DWMReference;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.data.worldgen.Pools;
 import net.minecraft.resources.Identifier;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
-import net.minecraft.world.level.levelgen.structure.pools.alias.DirectPoolAlias;
 import net.minecraft.world.level.levelgen.structure.pools.alias.PoolAliasBinding;
+import java.util.ArrayList;
 import java.util.List;
 
 public final class DWMVillagePools {
@@ -17,30 +18,69 @@ public final class DWMVillagePools {
     public static final ResourceKey<StructureTemplatePool> DECOR = key("village/gallifrey/decor");
     public static final ResourceKey<StructureTemplatePool> TREES = key("village/gallifrey/trees");
 
+    /**
+     * Plains piece pools rewritten to Gallifrey pools (vanilla NBT still references these IDs).
+     * Kept as Identifiers so unit tests do not touch {@link PoolAliasBinding} (needs registry bootstrap).
+     */
+    private static final List<String> PIECE_POOL_NAMES = List.of(
+            "streets",
+            "houses",
+            "terminators",
+            "decor",
+            "trees"
+    );
+
+    /** Vanilla jigsaw pools that place villagers / cats / golems / pen animals. */
+    private static final List<String> EMPTY_ENTITY_POOLS = List.of(
+            "village/plains/villagers",
+            "village/common/cats",
+            "village/common/iron_golem",
+            "village/common/animals"
+    );
+
     private DWMVillagePools() {
     }
 
     public static List<PoolAliasBinding> poolAliases() {
-        return List.of(
-                alias("streets"),
-                alias("houses"),
-                alias("terminators"),
-                alias("decor"),
-                alias("trees")
-        );
+        List<PoolAliasBinding> aliases = new ArrayList<>();
+        for (String name : PIECE_POOL_NAMES) {
+            aliases.add(pieceAlias(name));
+        }
+        for (String poolPath : EMPTY_ENTITY_POOLS) {
+            aliases.add(emptyEntityAlias(poolPath));
+        }
+        return List.copyOf(aliases);
     }
 
+    /** Source IDs for plains piece pool rewrites ({@code village/plains/...} → Gallifrey). */
     public static List<Identifier> plainsAliasSources() {
-        return poolAliases().stream()
-                .map(DirectPoolAlias.class::cast)
-                .map(binding -> binding.alias().identifier())
+        return PIECE_POOL_NAMES.stream()
+                .map(name -> Identifier.withDefaultNamespace("village/plains/" + name))
                 .toList();
     }
 
-    private static PoolAliasBinding alias(String name) {
+    /** Source IDs for entity pools rewritten to {@code minecraft:empty}. */
+    public static List<Identifier> emptyEntityAliasSources() {
+        return EMPTY_ENTITY_POOLS.stream()
+                .map(Identifier::withDefaultNamespace)
+                .toList();
+    }
+
+    public static Identifier emptyEntityAliasTarget() {
+        return Pools.EMPTY.identifier();
+    }
+
+    private static PoolAliasBinding pieceAlias(String name) {
         return PoolAliasBinding.direct(
                 ResourceKey.create(Registries.TEMPLATE_POOL, Identifier.withDefaultNamespace("village/plains/" + name)),
                 key("village/gallifrey/" + name)
+        );
+    }
+
+    private static PoolAliasBinding emptyEntityAlias(String poolPath) {
+        return PoolAliasBinding.direct(
+                ResourceKey.create(Registries.TEMPLATE_POOL, Identifier.withDefaultNamespace(poolPath)),
+                Pools.EMPTY
         );
     }
 

--- a/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolAliasTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolAliasTest.java
@@ -6,12 +6,10 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class GallifreyVillagePoolAliasTest {
     @Test
-    void aliasesRewritePlainsPoolsAndLeaveVillagersUnaliased() {
-        List<Identifier> sources = DWMVillagePools.plainsAliasSources();
+    void pieceAliasesRewritePlainsPools() {
         assertEquals(
                 List.of(
                         Identifier.withDefaultNamespace("village/plains/streets"),
@@ -20,10 +18,21 @@ class GallifreyVillagePoolAliasTest {
                         Identifier.withDefaultNamespace("village/plains/decor"),
                         Identifier.withDefaultNamespace("village/plains/trees")
                 ),
-                sources
+                DWMVillagePools.plainsAliasSources()
         );
-        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/plains/villagers")));
-        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/common/cats")));
-        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/common/iron_golem")));
+    }
+
+    @Test
+    void entityPoolsAliasToEmpty() {
+        assertEquals(
+                List.of(
+                        Identifier.withDefaultNamespace("village/plains/villagers"),
+                        Identifier.withDefaultNamespace("village/common/cats"),
+                        Identifier.withDefaultNamespace("village/common/iron_golem"),
+                        Identifier.withDefaultNamespace("village/common/animals")
+                ),
+                DWMVillagePools.emptyEntityAliasSources()
+        );
+        assertEquals(Identifier.withDefaultNamespace("empty"), DWMVillagePools.emptyEntityAliasTarget());
     }
 }

--- a/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolsTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/GallifreyVillagePoolsTest.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class GallifreyVillagePoolsTest {
     @Test
@@ -23,7 +22,20 @@ class GallifreyVillagePoolsTest {
                 ),
                 sources
         );
-        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/plains/villagers")));
-        assertFalse(sources.contains(Identifier.withDefaultNamespace("village/common/iron_golem")));
+    }
+
+    @Test
+    void poolAliasesSuppressStructurePlacedMobs() {
+        Set<Identifier> emptySources = new HashSet<>(DWMVillagePools.emptyEntityAliasSources());
+        assertEquals(
+                Set.of(
+                        Identifier.withDefaultNamespace("village/plains/villagers"),
+                        Identifier.withDefaultNamespace("village/common/cats"),
+                        Identifier.withDefaultNamespace("village/common/iron_golem"),
+                        Identifier.withDefaultNamespace("village/common/animals")
+                ),
+                emptySources
+        );
+        assertEquals(Identifier.withDefaultNamespace("empty"), DWMVillagePools.emptyEntityAliasTarget());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why this matters

- Plains village jigsaw pieces still spawn villagers, cats, iron golems, and pen animals; Gallifrey should not get Overworld village mobs from structure placement.

## Proposed Implementation

- Alias `village/plains/villagers`, `village/common/cats`, `village/common/iron_golem`, and `village/common/animals` to `minecraft:empty` in `DWMVillagePools.poolAliases()`.
- Update unit tests and dimension docs; regenerate structure JSON.

## Problems Encountered / Decisions Made

- Stacks on the villages PR (#243); piece-pool aliases unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a04e7c-3944-7a8e-bc41-2b0e81077f49?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a04e7c-3944-7a8e-bc41-2b0e81077f49&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

