### PR TITLE
chore(dwm): cut v26.2-1.6.0 release notes

### DIFF
--- a/dwm/gradle.properties
+++ b/dwm/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version=26.2
 loader_version=0.19.3
 loom_version=1.17-SNAPSHOT
 # Mod Properties
-mod_version=1.5.0
+mod_version=1.6.0
 maven_group=com.adamkali.dwm
 archives_base_name=dwm
 # Dependencies

--- a/dwm/metadata/modrinth-body.md
+++ b/dwm/metadata/modrinth-body.md
@@ -5,34 +5,44 @@ Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — 
 ## Fly the TARDIS
 
 - Search the overworld for a TARDIS, open the doors, and walk into a First Doctor–style console room
+- Found Type 40s start unfinished: same-world hops only, a short artron reserve, and broken console circuits until you craft and install matching spare parts
 - Look through open exterior doors for a bigger-on-the-inside preview of the console room
 - Look back out through open interior doors to see the world outside
 - Bind a TARDIS Key to lock and unlock the doors
-- Sneak-use a Stattenheim Remote to summon your TARDIS to a clicked block
-- Set a destination at the First Doctor console with biome/planet dials, saved waypoints, an online player, fast return through previous landings, or the telepathic circuit (home bed or world spawn)
+- Sneak-use a Stattenheim Remote to summon your TARDIS to a clicked block (install the Remote Summon Circuit first on a found ship)
+- Only the owner pilots the console; visitors can still read atmosphere instruments and feed the artron tank
+- Set a destination with biome/planet dials, saved waypoints, an online player, fast return through previous landings, or the telepathic circuit (home bed or world spawn)
 - Cloak the exterior shell, lock the doors, pin X/Y/Z with coordinate lock, toggle stabilisers for precise vs scattered landing, and read exterior atmosphere and artron reserves
-- Pull the materialisation lever to dematerialise, fly, and land.
+- Pull the materialisation lever to dematerialise, fly, and land (10 artron same-world, 30 to change dimension). Refuel with Zeiton Crystals
 - Use the chameleon circuit dial to pick First–Seventh Doctor boxes or the TT Capsule, with a spinning shell hologram
+- Open the Field Guide (G, the first-join book, or Mod Menu) for Quick Start, sonic, circuit, and console-room recipes
 
 ## Explore Gallifrey
 
-- Travel to the Gallifrey destination dimension from the console planet locator
+- Travel to the Gallifrey destination dimension from the console planet locator (fit that circuit on a found ship first)
 - Choose among Gallifrey Plains, Forest, Wastes, and Badlands before you materialise
 - Explore deep-red grass, orange sand and badlands, Gallifrey stone, and themed woods
 - Meet Time Lord wanderers on plains and forest, in four robe variants
 - Spot Broakir on plains and forest, and Flutterwings in four species (Blue Crystal, Madrigal, Silverband, Wild Endeavour)
 - Tame Mewing Dogs in the forest with a bone — they sit, follow, take a dyed collar, and breed
 - Find Flower of Remembrance and Moonlight Bloom on plains and forest, and Saccharine Cane on wastes and badlands
-- Mine Azbantium veins and Gallifrey-textured coal, iron, gold, and diamond ores
+- Mine Azbantium veins, Zeiton, and Gallifrey-textured coal, iron, gold, and diamond ores
 
 ## Build
 
 - Ash, Dark Ash, and Cardinal wood families (logs through doors, boats, and more)
-- Gallifrey stone, sandstone, dirt, grass, and Citadel wall / panel / tile / glass
+- Gallifrey stone, cobblestone and stone-brick stairs / slabs / walls, smooth stone slab, sandstone, dirt, grass, and Citadel wall / panel / tile / glass
 - Orange sand and orange sandstone (stairs, slabs, walls, cut, chiseled, and smooth)
 - Flower of Remembrance, Moonlight Bloom, and Saccharine Cane
 - Chronoplasm powder, colored TARDIS walls, and roundels for console-room builds
 - Craftable decor: sittable chairs, Decorational Column, TARDIS Globe, Compact and Full TARDIS Scanners, and TARDIS Ceiling Vent
+
+## Zeiton
+
+- Mine Zeiton Ore in Gallifrey stone (iron pickaxe) and occasionally in Overworld caves
+- Smelt silk-touched ore, or drop crystals; shapeless convert crystals ↔ powder
+- Craft Ferrite Powder from iron and redstone for early console circuits
+- Use Zeiton Crystals on the console refueler to add artron; Zeiton powder is a cheaper late-circuit ingredient
 
 ## Azbantium
 
@@ -41,16 +51,18 @@ Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — 
 
 ## Sonic Screwdrivers
 
-- Craft Second, Third, Fourth, and Fifth Doctor sonic variants
-- Toggle iron doors and trapdoors, prime TNT, break glass cleanly, damage slimes, and shear sheep
+- Craft an early sonic (iron, redstone torch, glass pane) with Open only
+- Craft Shatter, Prime, Disrupt, and Shear settings and install them by using a setting while holding a sonic
+- Sneak-use in air to open the field-mode HUD carousel; transmute casings with colored panes for Second–Fifth Doctor looks
+- Use the sonic on your TARDIS to pair it, then Seal closed doors, Scan the ship, or Ping a cloaked shell
 
 ## Quick start
 
-1. Explore the overworld until you find a TARDIS, then open the doors.
-2. Walk in once the doors are fully open.
-3. At the console, set planet and biome, then pull the materialisation lever.
-4. Pull again in flight to land — try Gallifrey for a first trip.
-5. Craft a TARDIS Key to lock the doors, or a Stattenheim Remote to summon the ship.
+1. Open the Field Guide (G) or use the book given on first join.
+2. Explore the overworld until you find a TARDIS, then open the doors and walk in to claim it.
+3. At the console, take a same-world hop, then craft ferrite circuits (planet locator needs an ender pearl) and mine Zeiton before a Gallifrey trip.
+4. Craft a TARDIS Key to lock the doors, or a Stattenheim Remote plus Remote Summon Circuit to call the ship.
+5. Craft a sonic, install settings, and pair it with your TARDIS.
 
 ## Community
 

--- a/dwm/metadata/modrinth-body.md
+++ b/dwm/metadata/modrinth-body.md
@@ -1,69 +1,26 @@
 # The Doctor Who Mod
 
-Fly a working TARDIS, land on Gallifrey, and build with Time Lord materials — a focused Doctor Who toolkit for Fabric survival.
+Fly a working TARDIS, travel the universe, and tinker with Time Lord tools — a focused Doctor Who toolkit for Fabric survival.
+
+<!-- IMAGE: Hero — overworld police-box TARDIS, doors open, player claiming it; hint of bigger-inside through the doorway. Landscape 16:9, no HUD. -->
+![A TARDIS in the overworld, doors open](https://cdn.modrinth.com/data/CY3ponKT/images/2687adc99ad6bcdb1f1fdd77e6a1c1cde3da8549.png)
 
 ## Fly the TARDIS
 
-- Search the overworld for a TARDIS, open the doors, and walk into a First Doctor–style console room
-- Found Type 40s start unfinished: same-world hops only, a short artron reserve, and broken console circuits until you craft and install matching spare parts
-- Look through open exterior doors for a bigger-on-the-inside preview of the console room
-- Look back out through open interior doors to see the world outside
-- Bind a TARDIS Key to lock and unlock the doors
-- Sneak-use a Stattenheim Remote to summon your TARDIS to a clicked block (install the Remote Summon Circuit first on a found ship)
-- Only the owner pilots the console; visitors can still read atmosphere instruments and feed the artron tank
-- Set a destination with biome/planet dials, saved waypoints, an online player, fast return through previous landings, or the telepathic circuit (home bed or world spawn)
-- Cloak the exterior shell, lock the doors, pin X/Y/Z with coordinate lock, toggle stabilisers for precise vs scattered landing, and read exterior atmosphere and artron reserves
-- Pull the materialisation lever to dematerialise, fly, and land (10 artron same-world, 30 to change dimension). Refuel with Zeiton Crystals
-- Use the chameleon circuit dial to pick First–Seventh Doctor boxes or the TT Capsule, with a spinning shell hologram
-- Open the Field Guide (G, the first-join book, or Mod Menu) for Quick Start, sonic, circuit, and console-room recipes
+Find a TARDIS, open the doors, and step into a console room that is bigger on the inside. Found ships start unfinished — you fit the circuits, feed the tank, and pull the lever. Visitors can look. Only you fly.
 
-## Explore Gallifrey
+<!-- IMAGE: First Doctor–style console room, rotor and console in frame, interior doors open onto the world outside. Landscape 16:9, no HUD. -->
+![Inside the TARDIS console room](https://cdn.modrinth.com/data/CY3ponKT/images/595f2d760fe1f0e501c5b5ddf0fed07398a608bc.png)
 
-- Travel to the Gallifrey destination dimension from the console planet locator (fit that circuit on a found ship first)
-- Choose among Gallifrey Plains, Forest, Wastes, and Badlands before you materialise
-- Explore deep-red grass, orange sand and badlands, Gallifrey stone, and themed woods
-- Meet Time Lord wanderers on plains and forest, in four robe variants
-- Spot Broakir on plains and forest, and Flutterwings in four species (Blue Crystal, Madrigal, Silverband, Wild Endeavour)
-- Tame Mewing Dogs in the forest with a bone — they sit, follow, take a dyed collar, and breed
-- Find Flower of Remembrance and Moonlight Bloom on plains and forest, and Saccharine Cane on wastes and badlands
-- Mine Azbantium veins, Zeiton, and Gallifrey-textured coal, iron, gold, and diamond ores
+## Travel the universe
 
-## Build
+Explore alien skies, experience new wildlife, and use new materials that belong there. All available through your TARDIS doors.
 
-- Ash, Dark Ash, and Cardinal wood families (logs through doors, boats, and more)
-- Gallifrey stone, cobblestone and stone-brick stairs / slabs / walls, smooth stone slab, sandstone, dirt, grass, and Citadel wall / panel / tile / glass
-- Orange sand and orange sandstone (stairs, slabs, walls, cut, chiseled, and smooth)
-- Flower of Remembrance, Moonlight Bloom, and Saccharine Cane
-- Chronoplasm powder, colored TARDIS walls, and roundels for console-room builds
-- Craftable decor: sittable chairs, Decorational Column, TARDIS Globe, Compact and Full TARDIS Scanners, and TARDIS Ceiling Vent
+<!-- IMAGE: Current non-overworld destination (today: Gallifrey — red grass or orange badlands) plus at least one living thing. Landscape 16:9, no HUD. Swap when a stronger destination shot exists. -->
+![TARDIS on Gallifrey](https://cdn.modrinth.com/data/CY3ponKT/images/689af627d9bec9edc2d5ebdb9c18d3d019770ba6.png)
 
-## Zeiton
+## A Time Lord toolkit
 
-- Mine Zeiton Ore in Gallifrey stone (iron pickaxe) and occasionally in Overworld caves
-- Smelt silk-touched ore, or drop crystals; shapeless convert crystals ↔ powder
-- Craft Ferrite Powder from iron and redstone for early console circuits
-- Use Zeiton Crystals on the console refueler to add artron; Zeiton powder is a cheaper late-circuit ingredient
+Use sonic screwdrivers, and build your next invention with an array of new blocks and tools.
 
-## Azbantium
-
-- Mine Azbantium ore in Gallifrey stone and smelt it into gems
-- Craft diamond-tier Azbantium tools and armor
-
-## Sonic Screwdrivers
-
-- Craft an early sonic (iron, redstone torch, glass pane) with Open only
-- Craft Shatter, Prime, Disrupt, and Shear settings and install them by using a setting while holding a sonic
-- Sneak-use in air to open the field-mode HUD carousel; transmute casings with colored panes for Second–Fifth Doctor looks
-- Use the sonic on your TARDIS to pair it, then Seal closed doors, Scan the ship, or Ping a cloaked shell
-
-## Quick start
-
-1. Open the Field Guide (G) or use the book given on first join.
-2. Explore the overworld until you find a TARDIS, then open the doors and walk in to claim it.
-3. At the console, take a same-world hop, then craft ferrite circuits (planet locator needs an ender pearl) and mine Zeiton before a Gallifrey trip.
-4. Craft a TARDIS Key to lock the doors, or a Stattenheim Remote plus Remote Summon Circuit to call the ship.
-5. Craft a sonic, install settings, and pair it with your TARDIS.
-
-## Community
-
-Join the Discord for feedback, builds, and updates: https://discord.gg/pGdRYBh
+The Field Guide in-game covers recipes and first steps. Join our community on discord. Share your builds and discoveries, and stay up to date with all the latest releases: https://discord.gg/pGdRYBh

--- a/dwm/version.json
+++ b/dwm/version.json
@@ -1,7 +1,59 @@
 {
   "26.2": {
+    "1.6.0": {
+      "summary": "Repair a found Type 40 — craftable console circuits, a live artron tank, and Zeiton fuel — plus a Field Guide and a setting-based sonic.",
+      "added": [
+        "Block: Zeiton Ore",
+        "Block: Gallifrey Cobblestone Stairs",
+        "Block: Gallifrey Cobblestone Slab",
+        "Block: Gallifrey Cobblestone Wall",
+        "Block: Mossy Gallifrey Cobblestone Stairs",
+        "Block: Mossy Gallifrey Cobblestone Slab",
+        "Block: Mossy Gallifrey Cobblestone Wall",
+        "Block: Gallifrey Smooth Stone Slab",
+        "Block: Gallifrey Stone Brick Stairs",
+        "Block: Gallifrey Stone Brick Slab",
+        "Block: Gallifrey Stone Brick Wall",
+        "Item: Field Guide",
+        "Item: Planet Locator Circuit",
+        "Item: Waypoints Circuit",
+        "Item: Player Locator Circuit",
+        "Item: Telepathic Circuit",
+        "Item: Fast Return Circuit",
+        "Item: Cloak Circuit",
+        "Item: Chameleon Circuit",
+        "Item: Coordinate Locks Circuit",
+        "Item: Stabilisers Circuit",
+        "Item: Remote Summon Circuit",
+        "Item: Shatter Setting",
+        "Item: Prime Setting",
+        "Item: Disrupt Setting",
+        "Item: Shear Setting",
+        "Item: Zeiton Crystals",
+        "Item: Zeiton Powder",
+        "Item: Ferrite Powder",
+        "Misc: Field Guide (G, first-join book, or Mod Menu) with Quick Start, Sonic, Circuits, and Console Room chapters",
+        "Misc: Worldgen Type 40s start unfinished (broken circuits, 30 artron, same-world hops until repaired)",
+        "Misc: Owner-only console piloting (readers and refueler stay public; bound key still unlocks doors)",
+        "Misc: Live artron tank (0–500; Zeiton Crystals add 25; demat and summon spend 10 same-world or 30 to change dimension)",
+        "Misc: Zeiton ore in Gallifrey stone and rare Overworld traces",
+        "Misc: Sonic field-mode HUD carousel; pair with your TARDIS for Seal, Scan, and Ping",
+        "Misc: Doctor Who first-hour and sonic teaching advancement trees"
+      ],
+      "changed": [
+        "Misc: Crafted sonics start with Open only until settings are installed or the TARDIS handshake",
+        "Misc: Found worldgen TARDISes need spare circuits; creative, placed, and existing saves without new flags stay fully fitted and full",
+        "Misc: Only the owner can fly the console",
+        "Misc: Panel 5 refueler is a live artron tank fed with Zeiton Crystals",
+        "Misc: Bigger-on-the-inside and smaller-on-the-outside doorways use streamed lighting and atmosphere fog",
+        "Misc: TARDIS and console inventory icons are 3D; sonic GUI sprites",
+        "Misc: Using a sonic on TARDIS doors no longer opens them",
+        "Misc: Automatic surface landings stay below a dimensional bedrock ceiling"
+      ],
+      "removed": []
+    },
     "1.5.0": {
-      "summary": "Gallifrey comes alive — Time Lord wanderers, Broakir, Flutterwings, and tameable Mewing Dogs, plus smoother TARDIS doorway previews.",
+      "summary": "Gallifrey comes alive \u2014 Time Lord wanderers, Broakir, Flutterwings, and tameable Mewing Dogs, plus smoother TARDIS doorway previews.",
       "added": [
         "Entity: Broakir",
         "Entity: Flutterwing",
@@ -20,10 +72,12 @@
         "Misc: Bigger-on-the-inside doorway preview restored after a rendering regression",
         "Misc: Console room preloads near the exterior so the doorway look-in is ready when doors open"
       ],
-      "removed": []
+      "removed": [
+        
+      ]
     },
     "1.4.0": {
-      "summary": "Claim and summon your TARDIS — key, Stattenheim remote, and a fuller First Doctor console, plus interior decor, lighting, and shell fade.",
+      "summary": "Claim and summon your TARDIS \u2014 key, Stattenheim remote, and a fuller First Doctor console, plus interior decor, lighting, and shell fade.",
       "added": [
         "Block: Decorational Column",
         "Block: TARDIS Ceiling Vent",
@@ -364,7 +418,7 @@
     }
   },
   "promos": {
-    "latest": "26.2-1.5.0",
-    "recommended": "26.2-1.5.0"
+    "latest": "26.2-1.6.0",
+    "recommended": "26.2-1.6.0"
   }
 }


### PR DESCRIPTION
## Why this matters

- Players and storefronts need accurate 1.6.0 notes for the Type 40 repair loop, Field Guide, Zeiton/artron, and sonic toolkit shipped since v26.2-1.5.0.

## Proposed Implementation

- Bump `mod_version` to 1.6.0 in `dwm/gradle.properties`.
- Fill `dwm/version.json` changelog and set `promos.latest` / `recommended` to `26.2-1.6.0`.
- Update `dwm/metadata/modrinth-body.md` to match shipped survival behaviour.
- Validated with `./dwm/gradlew checkVersionSync`. Tagging and storefront publish remain follow-up after merge.

## Problems Encountered / Decisions Made

- Screenplay, CI, and YAML-only work stayed out of the changelog.
- `syncVersionJson` rewrote some older summary dashes as Unicode escapes; left as produced by the task.


Made with [Cursor](https://cursor.com)