### PR TITLE
DWM-068 — Spawn petrified trees in Skaro Petrified Jungle

### DIFF
--- a/dwm/docs/feature-skaro-dimension.md
+++ b/dwm/docs/feature-skaro-dimension.md
@@ -15,9 +15,9 @@ Give TARDIS travel a hostile destination world that is not another recolored Ove
 - Dimension `dwm:skaro` (noise overworld-style generator, overworld-like dimension type). Debug: `/execute in dwm:skaro run tp @s ~ 128 ~`.
 - Biomes (tag `#dwm:is_skaro`): `dwm:skaro_irradiated_wastes`, `dwm:skaro_petrified_jungle`, `dwm:skaro_drammankin_mire`, `dwm:skaro_drammankin_mountains`, `dwm:skaro_thal_plateau`.
 - **Distribution:** Irradiated Wastes dominate multi-noise climate; Petrified Jungle, Drammankin Mire, and Drammankin Mountains occupy wetter/highland niches; Thal Plateau is rare (high climate offset) and reads comparatively safe via a clearer muted sky.
-- **Surface rules** compose the vanilla DWM-064 palette only (no custom Skaro stone/sand/dirt, no grass, no petrified logs — tree placement is DWM-068):
+- **Surface rules** compose the vanilla DWM-064 palette only (no custom Skaro stone/sand/dirt, no grass; petrified logs spawn via flora features, not surface rules):
   - Irradiated Wastes: sand / red sand / terracotta over sand; sickly yellow-green sky, fog, and water.
-  - Petrified Jungle: podzol / rooted dirt / coarse dirt over dirt; ashen grey-brown atmosphere.
+  - Petrified Jungle: podzol / rooted dirt / coarse dirt over dirt; ashen grey-brown atmosphere; dense dead petrified trunks, snags, and fallen logs (no leaves or saplings).
   - Drammankin Mire: mud over dirt; olive fog and murky water.
   - Drammankin Mountains: stone / tuff / gravel over tuff; cold ash-grey atmosphere.
   - Thal Plateau: dirt / coarse dirt / terracotta; muted blue-grey sky.
@@ -28,12 +28,13 @@ Give TARDIS travel a hostile destination world that is not another recolored Ove
   - Building: `stripped_petrified_log`, `stripped_petrified_wood`, `petrified_planks`, `petrified_stairs`, `petrified_slab`, `petrified_wall`.
   - Nonflammable and pickaxe-mineable; axe-strippable; survival craftable (log→planks, stairs/slab/wall, stonecutting).
   - Tags: `#dwm:petrified_blocks`, `#dwm:petrified_logs` (not `#minecraft:logs_that_burn`).
+- **Petrified Jungle flora** (DWM-068 slice): configured features `petrified_tree`, `petrified_snag`, and `fallen_petrified_tree` placed only in `skaro_petrified_jungle` (branching trunks, straight snags, fallen logs — all `petrified_log`, no saplings/leaves).
 - **Vanilla terrain palette (intentional, not placeholder):** stone, tuff, deepslate, gravel, basalt, sand, red sand, terracotta, dirt, coarse dirt, rooted dirt, mud, and podzol. There is no custom Skaro stone, sand, sandstone, dust, or dirt family.
 
 ## Planned (not yet in the jar)
 - Dalek architecture builder family (DWM-065).
 - Radiation, protective suit, and meter (DWM-067).
-- Flora features including petrified tree placement (DWM-068).
+- Remaining Skaro flora (Varga, radiation fungus, mutated reeds, ash scrub, Thal crop) under DWM-068.
 - Structures, Daleks/Thals/fauna population, Kaalann, and related tickets (DWM-069–074).
 
 ## How It Works In-Game
@@ -47,7 +48,7 @@ Give TARDIS travel a hostile destination world that is not another recolored Ove
 - Terrain identity comes from **vanilla composition**, atmosphere, petrified vegetation, and Dalek architecture — not a full custom stone, sand, and dirt palette. That composition choice is product intent for DWM-066, not temporary art.
 - Petrified material is mineralized wood: pickaxe-effective, nonflammable, no saplings or leaves.
 - Sky/fog use biome colors and overworld dimension effects; there is no custom Skaro sky renderer.
-- Dalek architecture, radiation, flora, entities, and structures remain owned by their child tickets under E-007.
+- Dalek architecture, radiation, remaining flora, entities, and structures remain owned by their child tickets under E-007.
 
 ## Future Opportunities
 - Custom dimension effects for Skaro sky, fog, and clouds.

--- a/dwm/docs/index.md
+++ b/dwm/docs/index.md
@@ -20,7 +20,7 @@ This folder documents implemented player-facing features for The Doctor Who Mod 
 - [TARDIS Chameleon System](./feature-chameleon-system.md) (config-gated and disabled by default)
 
 ### Planned Features
-- [Skaro Dimension](./feature-skaro-dimension.md) (destination world; petrified wood and five biomes shipped; radiation/flora/structures still planned)
+- [Skaro Dimension](./feature-skaro-dimension.md) (destination world; petrified wood, five biomes, and Petrified Jungle trees shipped; remaining flora/radiation/structures still planned)
 
 ## Brand and Differentiation
 - [Branding Guidelines](./branding-guidelines.md)

--- a/dwm/src/main/generated/data/dwm/worldgen/biome/skaro_petrified_jungle.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/biome/skaro_petrified_jungle.json
@@ -75,7 +75,10 @@
       "minecraft:spring_lava"
     ],
     [
-      "minecraft:glow_lichen"
+      "minecraft:glow_lichen",
+      "dwm:petrified_jungle_trees",
+      "dwm:petrified_jungle_snags",
+      "dwm:fallen_petrified_jungle_trees"
     ],
     [
       "minecraft:freeze_top_layer"

--- a/dwm/src/main/generated/data/dwm/worldgen/configured_feature/fallen_petrified_tree.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/configured_feature/fallen_petrified_tree.json
@@ -1,0 +1,21 @@
+{
+  "type": "minecraft:fallen_tree",
+  "config": {
+    "log_decorators": [],
+    "log_length": {
+      "type": "minecraft:uniform",
+      "max_inclusive": 11,
+      "min_inclusive": 4
+    },
+    "stump_decorators": [],
+    "trunk_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "dwm:petrified_log",
+        "Properties": {
+          "axis": "y"
+        }
+      }
+    }
+  }
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/configured_feature/petrified_snag.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/configured_feature/petrified_snag.json
@@ -1,0 +1,60 @@
+{
+  "type": "minecraft:tree",
+  "config": {
+    "below_trunk_provider": {
+      "type": "minecraft:rule_based_state_provider",
+      "rules": [
+        {
+          "if_true": {
+            "type": "minecraft:not",
+            "predicate": {
+              "type": "minecraft:matching_block_tag",
+              "tag": "minecraft:cannot_replace_below_tree_trunk"
+            }
+          },
+          "then": {
+            "type": "minecraft:simple_state_provider",
+            "state": {
+              "Name": "minecraft:dirt"
+            }
+          }
+        }
+      ]
+    },
+    "decorators": [],
+    "foliage_placer": {
+      "type": "minecraft:blob_foliage_placer",
+      "height": 1,
+      "offset": 0,
+      "radius": 0
+    },
+    "foliage_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "dwm:petrified_log",
+        "Properties": {
+          "axis": "y"
+        }
+      }
+    },
+    "ignore_vines": true,
+    "minimum_size": {
+      "type": "minecraft:two_layers_feature_size"
+    },
+    "trunk_placer": {
+      "type": "minecraft:straight_trunk_placer",
+      "base_height": 4,
+      "height_rand_a": 2,
+      "height_rand_b": 0
+    },
+    "trunk_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "dwm:petrified_log",
+        "Properties": {
+          "axis": "y"
+        }
+      }
+    }
+  }
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/configured_feature/petrified_tree.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/configured_feature/petrified_tree.json
@@ -1,0 +1,63 @@
+{
+  "type": "minecraft:tree",
+  "config": {
+    "below_trunk_provider": {
+      "type": "minecraft:rule_based_state_provider",
+      "rules": [
+        {
+          "if_true": {
+            "type": "minecraft:not",
+            "predicate": {
+              "type": "minecraft:matching_block_tag",
+              "tag": "minecraft:cannot_replace_below_tree_trunk"
+            }
+          },
+          "then": {
+            "type": "minecraft:simple_state_provider",
+            "state": {
+              "Name": "minecraft:dirt"
+            }
+          }
+        }
+      ]
+    },
+    "decorators": [],
+    "foliage_placer": {
+      "type": "minecraft:blob_foliage_placer",
+      "height": 2,
+      "offset": 0,
+      "radius": 1
+    },
+    "foliage_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "dwm:petrified_log",
+        "Properties": {
+          "axis": "y"
+        }
+      }
+    },
+    "ignore_vines": true,
+    "minimum_size": {
+      "type": "minecraft:two_layers_feature_size",
+      "limit": 0,
+      "min_clipped_height": 4,
+      "upper_size": 0
+    },
+    "trunk_placer": {
+      "type": "minecraft:fancy_trunk_placer",
+      "base_height": 3,
+      "height_rand_a": 11,
+      "height_rand_b": 0
+    },
+    "trunk_provider": {
+      "type": "minecraft:simple_state_provider",
+      "state": {
+        "Name": "dwm:petrified_log",
+        "Properties": {
+          "axis": "y"
+        }
+      }
+    }
+  }
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/placed_feature/fallen_petrified_jungle_trees.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/placed_feature/fallen_petrified_jungle_trees.json
@@ -1,0 +1,19 @@
+{
+  "feature": "dwm:fallen_petrified_tree",
+  "placement": [
+    {
+      "type": "minecraft:rarity_filter",
+      "chance": 6
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "OCEAN_FLOOR"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/placed_feature/petrified_jungle_snags.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/placed_feature/petrified_jungle_snags.json
@@ -1,0 +1,35 @@
+{
+  "feature": "dwm:petrified_snag",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": {
+        "type": "minecraft:weighted_list",
+        "distribution": [
+          {
+            "data": 8,
+            "weight": 9
+          },
+          {
+            "data": 9,
+            "weight": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:surface_water_depth_filter",
+      "max_water_depth": 0
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "OCEAN_FLOOR"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/dwm/src/main/generated/data/dwm/worldgen/placed_feature/petrified_jungle_trees.json
+++ b/dwm/src/main/generated/data/dwm/worldgen/placed_feature/petrified_jungle_trees.json
@@ -1,0 +1,35 @@
+{
+  "feature": "dwm:petrified_tree",
+  "placement": [
+    {
+      "type": "minecraft:count",
+      "count": {
+        "type": "minecraft:weighted_list",
+        "distribution": [
+          {
+            "data": 12,
+            "weight": 9
+          },
+          {
+            "data": 13,
+            "weight": 1
+          }
+        ]
+      }
+    },
+    {
+      "type": "minecraft:in_square"
+    },
+    {
+      "type": "minecraft:surface_water_depth_filter",
+      "max_water_depth": 0
+    },
+    {
+      "type": "minecraft:heightmap",
+      "heightmap": "OCEAN_FLOOR"
+    },
+    {
+      "type": "minecraft:biome"
+    }
+  ]
+}

--- a/dwm/src/main/java/com/adamkali/dwm/gametest/PetrifiedTreeGameTests.java
+++ b/dwm/src/main/java/com/adamkali/dwm/gametest/PetrifiedTreeGameTests.java
@@ -1,0 +1,93 @@
+package com.adamkali.dwm.gametest;
+
+import com.adamkali.dwm.block.DWMBlocks;
+import com.adamkali.dwm.world.DWMConfiguredFeatures;
+import net.fabricmc.fabric.api.gametest.v1.GameTest;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.gametest.framework.GameTestHelper;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.tags.BlockTags;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.LeavesBlock;
+import net.minecraft.world.level.block.SaplingBlock;
+import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
+
+public class PetrifiedTreeGameTests {
+    @GameTest(structure = "fabric-gametest-api-v1:empty")
+    public void petrifiedSnagPlacesLogWithoutLeavesOrSaplings(GameTestHelper context) {
+        BlockPos dirtRel = new BlockPos(3, 0, 3);
+        BlockPos trunkOriginRel = dirtRel.above();
+        context.setBlock(dirtRel, Blocks.PODZOL.defaultBlockState());
+        for (int y = 1; y < 8; y++) {
+            context.setBlock(dirtRel.above(y), Blocks.AIR.defaultBlockState());
+        }
+
+        ServerLevel world = context.getLevel();
+        BlockPos trunkOriginAbs = context.absolutePos(trunkOriginRel);
+        ConfiguredFeature<?, ?> snag = world.registryAccess()
+                .lookupOrThrow(Registries.CONFIGURED_FEATURE)
+                .get(DWMConfiguredFeatures.PETRIFIED_SNAG)
+                .orElseThrow(() -> new AssertionError("Expected configured feature dwm:petrified_snag"))
+                .value();
+
+        boolean placed = false;
+        for (long seed : new long[] {1L, 2L, 3L, 7L, 13L, 42L, 99L}) {
+            clearColumn(context, dirtRel);
+            context.setBlock(dirtRel, Blocks.PODZOL.defaultBlockState());
+            if (snag.place(world, world.getChunkSource().getGenerator(), RandomSource.create(seed), trunkOriginAbs)
+                    && containsBlockInBox(context, DWMBlocks.PETRIFIED_LOG)) {
+                placed = true;
+                break;
+            }
+        }
+
+        if (!placed) {
+            throw new AssertionError("Expected petrified snag to place petrified_log on podzol");
+        }
+        if (containsLivingWoodInBox(context)) {
+            throw new AssertionError("Petrified snag must not place leaves or saplings");
+        }
+
+        context.succeed();
+    }
+
+    private static void clearColumn(GameTestHelper context, BlockPos dirtRel) {
+        for (int y = 0; y < 8; y++) {
+            context.setBlock(dirtRel.above(y), Blocks.AIR.defaultBlockState());
+        }
+    }
+
+    private static boolean containsBlockInBox(GameTestHelper context, Block block) {
+        for (int x = 0; x < 8; x++) {
+            for (int y = 0; y < 8; y++) {
+                for (int z = 0; z < 8; z++) {
+                    if (context.getLevel().getBlockState(context.absolutePos(new BlockPos(x, y, z))).is(block)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean containsLivingWoodInBox(GameTestHelper context) {
+        for (int x = 0; x < 8; x++) {
+            for (int y = 0; y < 8; y++) {
+                for (int z = 0; z < 8; z++) {
+                    Block block = context.getLevel().getBlockState(context.absolutePos(new BlockPos(x, y, z))).getBlock();
+                    if (block instanceof LeavesBlock || block instanceof SaplingBlock || block.defaultBlockState().is(BlockTags.LEAVES)) {
+                        return true;
+                    }
+                    String path = block.builtInRegistryHolder().key().identifier().getPath();
+                    if (path.contains("leaves") || path.contains("sapling")) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatureBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatureBootstrap.java
@@ -8,21 +8,28 @@ import net.minecraft.resources.ResourceKey;
 import net.minecraft.util.random.WeightedList;
 import net.minecraft.util.valueproviders.BiasedToBottomInt;
 import net.minecraft.util.valueproviders.ConstantInt;
+import net.minecraft.util.valueproviders.UniformInt;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 import net.minecraft.world.level.levelgen.feature.Feature;
 import net.minecraft.world.level.levelgen.feature.configurations.BlockColumnConfiguration;
+import net.minecraft.world.level.levelgen.feature.configurations.FallenTreeConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.OreConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.SimpleBlockConfiguration;
 import net.minecraft.world.level.levelgen.feature.configurations.TreeConfiguration;
 import net.minecraft.world.level.levelgen.feature.featuresize.TwoLayersFeatureSize;
 import net.minecraft.world.level.levelgen.feature.foliageplacers.BlobFoliagePlacer;
+import net.minecraft.world.level.levelgen.feature.foliageplacers.FoliagePlacer;
 import net.minecraft.world.level.levelgen.feature.stateproviders.BlockStateProvider;
 import net.minecraft.world.level.levelgen.feature.stateproviders.WeightedStateProvider;
+import net.minecraft.world.level.levelgen.feature.trunkplacers.FancyTrunkPlacer;
 import net.minecraft.world.level.levelgen.feature.trunkplacers.StraightTrunkPlacer;
+import net.minecraft.world.level.levelgen.feature.trunkplacers.TrunkPlacer;
 import net.minecraft.world.level.levelgen.structure.templatesystem.TagMatchTest;
+
+import java.util.OptionalInt;
 
 public final class DWMConfiguredFeatureBootstrap {
     private DWMConfiguredFeatureBootstrap() {
@@ -88,6 +95,31 @@ public final class DWMConfiguredFeatureBootstrap {
         registerOre(registerable, DWMConfiguredFeatures.GALLIFREY_DIAMOND_ORE_MEDIUM, DWMBlocks.GALLIFREY_DIAMOND_ORE, 8, 0.5F);
         registerOre(registerable, DWMConfiguredFeatures.GALLIFREY_DIAMOND_ORE_LARGE, DWMBlocks.GALLIFREY_DIAMOND_ORE, 12, 0.7F);
         registerOre(registerable, DWMConfiguredFeatures.GALLIFREY_DIAMOND_ORE_BURIED, DWMBlocks.GALLIFREY_DIAMOND_ORE, 8, 1.0F);
+
+        registerPetrifiedTree(
+                registerable,
+                DWMConfiguredFeatures.PETRIFIED_TREE,
+                new FancyTrunkPlacer(3, 11, 0),
+                new BlobFoliagePlacer(ConstantInt.of(1), ConstantInt.of(0), 2),
+                new TwoLayersFeatureSize(0, 0, 0, OptionalInt.of(4))
+        );
+        registerPetrifiedTree(
+                registerable,
+                DWMConfiguredFeatures.PETRIFIED_SNAG,
+                new StraightTrunkPlacer(4, 2, 0),
+                new BlobFoliagePlacer(ConstantInt.of(0), ConstantInt.of(0), 1),
+                new TwoLayersFeatureSize(1, 0, 1)
+        );
+        registerable.register(
+                DWMConfiguredFeatures.FALLEN_PETRIFIED_TREE,
+                new ConfiguredFeature<>(
+                        Feature.FALLEN_TREE,
+                        new FallenTreeConfiguration.FallenTreeConfigurationBuilder(
+                                BlockStateProvider.simple(DWMBlocks.PETRIFIED_LOG),
+                                UniformInt.of(4, 11)
+                        ).build()
+                )
+        );
     }
 
     private static void registerOre(
@@ -140,6 +172,35 @@ public final class DWMConfiguredFeatureBootstrap {
                                 BlockStateProvider.simple(leaves),
                                 new BlobFoliagePlacer(ConstantInt.of(2), ConstantInt.of(0), 3),
                                 new TwoLayersFeatureSize(1, 0, 1),
+                                TreeConfiguration.defaultPlaceBelowTreeTrunkProvider(
+                                        registerable.lookup(Registries.BIOME)
+                                )
+                        ).ignoreVines().build()
+                )
+        );
+    }
+
+    /**
+     * Dead mineralized trunks: trunk and "foliage" are both petrified log (no leaves/saplings).
+     */
+    private static void registerPetrifiedTree(
+            BootstrapContext<ConfiguredFeature<?, ?>> registerable,
+            ResourceKey<ConfiguredFeature<?, ?>> key,
+            TrunkPlacer trunkPlacer,
+            FoliagePlacer foliagePlacer,
+            TwoLayersFeatureSize minimumSize
+    ) {
+        BlockState log = DWMBlocks.PETRIFIED_LOG.defaultBlockState();
+        registerable.register(
+                key,
+                new ConfiguredFeature<>(
+                        Feature.TREE,
+                        new TreeConfiguration.TreeConfigurationBuilder(
+                                BlockStateProvider.simple(log),
+                                trunkPlacer,
+                                BlockStateProvider.simple(log),
+                                foliagePlacer,
+                                minimumSize,
                                 TreeConfiguration.defaultPlaceBelowTreeTrunkProvider(
                                         registerable.lookup(Registries.BIOME)
                                 )

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatures.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMConfiguredFeatures.java
@@ -27,6 +27,10 @@ public final class DWMConfiguredFeatures {
     public static final ResourceKey<ConfiguredFeature<?, ?>> GALLIFREY_DIAMOND_ORE_LARGE = key("gallifrey_diamond_ore_large");
     public static final ResourceKey<ConfiguredFeature<?, ?>> GALLIFREY_DIAMOND_ORE_BURIED = key("gallifrey_diamond_ore_buried");
 
+    public static final ResourceKey<ConfiguredFeature<?, ?>> PETRIFIED_TREE = key("petrified_tree");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> PETRIFIED_SNAG = key("petrified_snag");
+    public static final ResourceKey<ConfiguredFeature<?, ?>> FALLEN_PETRIFIED_TREE = key("fallen_petrified_tree");
+
     private static ResourceKey<ConfiguredFeature<?, ?>> key(String path) {
         return ResourceKey.create(
                 Registries.CONFIGURED_FEATURE,

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatureBootstrap.java
@@ -200,6 +200,28 @@ public final class DWMPlacedFeatureBootstrap {
                 HeightRangePlacement.triangle(VerticalAnchor.aboveBottom(-80), VerticalAnchor.aboveBottom(80)),
                 BiomeFilter.biome()
         );
+
+        registerSaplingFreeTree(
+                registerable,
+                DWMPlacedFeatures.PETRIFIED_JUNGLE_TREES,
+                configured.getOrThrow(DWMConfiguredFeatures.PETRIFIED_TREE),
+                PlacementUtils.countExtra(12, 0.1F, 1)
+        );
+        registerSaplingFreeTree(
+                registerable,
+                DWMPlacedFeatures.PETRIFIED_JUNGLE_SNAGS,
+                configured.getOrThrow(DWMConfiguredFeatures.PETRIFIED_SNAG),
+                PlacementUtils.countExtra(8, 0.1F, 1)
+        );
+        PlacementUtils.register(
+                registerable,
+                DWMPlacedFeatures.FALLEN_PETRIFIED_JUNGLE_TREES,
+                configured.getOrThrow(DWMConfiguredFeatures.FALLEN_PETRIFIED_TREE),
+                RarityFilter.onAverageOnceEvery(6),
+                InSquarePlacement.spread(),
+                PlacementUtils.HEIGHTMAP_OCEAN_FLOOR,
+                BiomeFilter.biome()
+        );
     }
 
     private static void registerTree(
@@ -214,6 +236,21 @@ public final class DWMPlacedFeatureBootstrap {
                 key,
                 feature,
                 VegetationPlacements.treePlacement(countModifier, sapling)
+        );
+    }
+
+    /** Tree placement without a sapling would-survive check (petrified wood has no saplings). */
+    private static void registerSaplingFreeTree(
+            BootstrapContext<PlacedFeature> registerable,
+            ResourceKey<PlacedFeature> key,
+            Holder<ConfiguredFeature<?, ?>> feature,
+            PlacementModifier countModifier
+    ) {
+        PlacementUtils.register(
+                registerable,
+                key,
+                feature,
+                VegetationPlacements.treePlacement(countModifier)
         );
     }
 

--- a/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/DWMPlacedFeatures.java
@@ -31,6 +31,10 @@ public final class DWMPlacedFeatures {
     public static final ResourceKey<PlacedFeature> GALLIFREY_DIAMOND_ORE_LARGE = key("gallifrey_diamond_ore_large");
     public static final ResourceKey<PlacedFeature> GALLIFREY_DIAMOND_ORE_BURIED = key("gallifrey_diamond_ore_buried");
 
+    public static final ResourceKey<PlacedFeature> PETRIFIED_JUNGLE_TREES = key("petrified_jungle_trees");
+    public static final ResourceKey<PlacedFeature> PETRIFIED_JUNGLE_SNAGS = key("petrified_jungle_snags");
+    public static final ResourceKey<PlacedFeature> FALLEN_PETRIFIED_JUNGLE_TREES = key("fallen_petrified_jungle_trees");
+
     private static ResourceKey<PlacedFeature> key(String path) {
         return ResourceKey.create(Registries.PLACED_FEATURE, Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path));
     }

--- a/dwm/src/main/java/com/adamkali/dwm/world/SkaroBiomeBootstrap.java
+++ b/dwm/src/main/java/com/adamkali/dwm/world/SkaroBiomeBootstrap.java
@@ -9,6 +9,7 @@ import net.minecraft.world.level.biome.Biome;
 import net.minecraft.world.level.biome.BiomeGenerationSettings;
 import net.minecraft.world.level.biome.BiomeSpecialEffects;
 import net.minecraft.world.level.biome.MobSpawnSettings;
+import net.minecraft.world.level.levelgen.GenerationStep;
 import net.minecraft.world.level.levelgen.carver.ConfiguredWorldCarver;
 import net.minecraft.world.level.levelgen.placement.PlacedFeature;
 
@@ -54,12 +55,16 @@ public final class SkaroBiomeBootstrap {
             HolderGetter<PlacedFeature> features,
             HolderGetter<ConfiguredWorldCarver<?>> carvers
     ) {
+        BiomeGenerationSettings.Builder generation = basicGeneration(features, carvers);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.PETRIFIED_JUNGLE_TREES);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.PETRIFIED_JUNGLE_SNAGS);
+        generation.addFeature(GenerationStep.Decoration.VEGETAL_DECORATION, DWMPlacedFeatures.FALLEN_PETRIFIED_JUNGLE_TREES);
         return buildBiome(
                 true,
                 0.9F,
                 0.8F,
                 emptySpawns(),
-                basicGeneration(features, carvers),
+                generation,
                 0x5A5040,
                 0x4A4030,
                 0x6E5E4E,

--- a/dwm/src/main/resources/fabric.mod.json
+++ b/dwm/src/main/resources/fabric.mod.json
@@ -37,6 +37,7 @@
       "com.adamkali.dwm.gametest.AzbantiumGameTests",
       "com.adamkali.dwm.gametest.GallifreyVanillaOresGameTests",
       "com.adamkali.dwm.gametest.SkaroDimensionGameTests",
+      "com.adamkali.dwm.gametest.PetrifiedTreeGameTests",
       "com.adamkali.dwm.gametest.ZeitonGameTests",
       "com.adamkali.dwm.gametest.SonicInteractionGameTests",
       "com.adamkali.dwm.gametest.SonicTardisGameTests",

--- a/dwm/src/test/java/com/adamkali/dwm/ResourceValidationTests.java
+++ b/dwm/src/test/java/com/adamkali/dwm/ResourceValidationTests.java
@@ -962,7 +962,30 @@ public class ResourceValidationTests {
                         biomeFile + " must not include Gallifrey-only generated content: " + forbidden
                 );
             }
+            if ("skaro_petrified_jungle.json".equals(biomeFile)) {
+                assertTrue(
+                        blob.contains("dwm:petrified_jungle_trees"),
+                        biomeFile + " must include petrified jungle trees"
+                );
+                assertTrue(
+                        blob.contains("dwm:petrified_jungle_snags"),
+                        biomeFile + " must include petrified jungle snags"
+                );
+                assertTrue(
+                        blob.contains("dwm:fallen_petrified_jungle_trees"),
+                        biomeFile + " must include fallen petrified jungle trees"
+                );
+            } else {
+                assertFalse(
+                        blob.contains("dwm:petrified_jungle_trees")
+                                || blob.contains("dwm:petrified_jungle_snags")
+                                || blob.contains("dwm:fallen_petrified_jungle_trees"),
+                        biomeFile + " must not include petrified jungle vegetation"
+                );
+            }
         }
+
+        assertPetrifiedTreeConfiguredFeaturesAreLogOnly();
 
         Path noise = Path.of("src/main/generated/data/dwm/worldgen/noise_settings/skaro.json");
         assertTrue(Files.isRegularFile(noise) && Files.size(noise) > 0, "Missing generated Skaro noise settings: " + noise);
@@ -974,6 +997,23 @@ public class ResourceValidationTests {
                 Files.isRegularFile(Path.of("src/main/resources/data/dwm/dimension_type/skaro.json")),
                 "Missing hand-maintained dimension_type/skaro.json"
         );
+    }
+
+    private static void assertPetrifiedTreeConfiguredFeaturesAreLogOnly() throws Exception {
+        Path configuredDir = Path.of("src/main/generated/data/dwm/worldgen/configured_feature");
+        String[] petrifiedFeatures = {
+                "petrified_tree.json",
+                "petrified_snag.json",
+                "fallen_petrified_tree.json"
+        };
+        for (String featureFile : petrifiedFeatures) {
+            Path path = configuredDir.resolve(featureFile);
+            assertTrue(Files.isRegularFile(path), "Missing generated configured feature: " + path);
+            String blob = Files.readString(path);
+            assertTrue(blob.contains("dwm:petrified_log"), featureFile + " must use petrified_log");
+            assertFalse(blob.contains("leaves"), featureFile + " must not reference leaves");
+            assertFalse(blob.contains("sapling"), featureFile + " must not reference saplings");
+        }
     }
 
     private static boolean biomeHasCreatureSpawn(String biomeFile, String entityId) throws Exception {

--- a/dwm/src/test/java/com/adamkali/dwm/world/PetrifiedTreeWorldgenTest.java
+++ b/dwm/src/test/java/com/adamkali/dwm/world/PetrifiedTreeWorldgenTest.java
@@ -1,0 +1,27 @@
+package com.adamkali.dwm.world;
+
+import com.adamkali.dwm.DWMReference;
+import net.minecraft.resources.Identifier;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class PetrifiedTreeWorldgenTest {
+    @Test
+    void configuredFeatureKeys_matchExpectedIds() {
+        assertEquals(id("petrified_tree"), DWMConfiguredFeatures.PETRIFIED_TREE.identifier());
+        assertEquals(id("petrified_snag"), DWMConfiguredFeatures.PETRIFIED_SNAG.identifier());
+        assertEquals(id("fallen_petrified_tree"), DWMConfiguredFeatures.FALLEN_PETRIFIED_TREE.identifier());
+    }
+
+    @Test
+    void placedFeatureKeys_matchExpectedIds() {
+        assertEquals(id("petrified_jungle_trees"), DWMPlacedFeatures.PETRIFIED_JUNGLE_TREES.identifier());
+        assertEquals(id("petrified_jungle_snags"), DWMPlacedFeatures.PETRIFIED_JUNGLE_SNAGS.identifier());
+        assertEquals(id("fallen_petrified_jungle_trees"), DWMPlacedFeatures.FALLEN_PETRIFIED_JUNGLE_TREES.identifier());
+    }
+
+    private static Identifier id(String path) {
+        return Identifier.fromNamespaceAndPath(DWMReference.MOD_ID, path);
+    }
+}


### PR DESCRIPTION
## Why this matters

- Petrified Jungle previously had surface and atmosphere only; without dead trunks it did not read as Skaro’s mineralized forest.
- This is the petrified-tree slice of DWM-068 so players can find and harvest `petrified_log` in the wild.

## Proposed Implementation

- Add configured features `petrified_tree`, `petrified_snag`, and `fallen_petrified_tree` (trunk + “foliage” are both `petrified_log`; no saplings/leaves).
- Place them only in `skaro_petrified_jungle` via `PETRIFIED_JUNGLE_TREES` / `SNAGS` / `FALLEN_PETRIFIED_JUNGLE_TREES`.
- Cover with JUnit key checks, resource validation, and a GameTest that places a snag on podzol.
- Document the shipped flora slice; remaining DWM-068 plants stay planned.

## Problems Encountered / Decisions Made

- Snag height uses `StraightTrunkPlacer(4, 2, 0)` so GameTest placement fits the empty template while still reading as a dead trunk.
- Variants are separate biome placed features (Gallifrey forest style) instead of a `RANDOM_SELECTOR`, avoiding extra intermediate placed-feature holders.
- Stacked on `cursor/skaro-dimension-9810` (Skaro dimension + empty spawn tables).


Made with [Cursor](https://cursor.com)